### PR TITLE
fix: vl-side-navigation-reference voegt extra blanco pagina's toe tijdens printen in Chrome

### DIFF
--- a/web-components/libs/elements/src/lib/side-navigation/style/_vl-side-navigation.scss
+++ b/web-components/libs/elements/src/lib/side-navigation/style/_vl-side-navigation.scss
@@ -1,0 +1,8 @@
+[is="vl-side-navigation-reference"] {
+    @media print {
+        // Fix voor UIG-2288: er worden in Chrome veel extra blanco pagina's toegevoegd tijdens het printen
+        .resize-sensor {
+            display: none !important;
+        }
+    }
+}

--- a/web-components/libs/elements/src/lib/vl-elements.scss
+++ b/web-components/libs/elements/src/lib/vl-elements.scss
@@ -12,3 +12,4 @@
 @import './link/style/vl-link';
 @import './multiselect/style/vl-multiselect';
 @import './select/style/vl-select';
+@import './side-navigation/style/vl-side-navigation';


### PR DESCRIPTION
UIG-2288