### PR TITLE
refactor: KBOMG-27 typering verbeteren bij map

### DIFF
--- a/web-components/libs/map/src/lib/actions/map/custom-map.spec.ts
+++ b/web-components/libs/map/src/lib/actions/map/custom-map.spec.ts
@@ -1,4 +1,4 @@
-import { VlCustomMap } from './custom-map';
+import {VlCustomMap, VLCustomMapOptions} from './custom-map';
 import {Vector, Tile, Group} from 'ol/layer';
 import {Vector as VectorSource} from 'ol/source';
 import Projection from 'ol/proj/Projection';
@@ -29,8 +29,12 @@ describe('custom map', () => {
     };
 
     const createMap = (options = {}) => {
-        const defaultOptions = {
-            actions: [],
+        const defaultOptions:VLCustomMapOptions = {
+            defaultZoom: false,
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false,
             customLayers: {
                 baseLayerGroup: new Group({
                     layers: layers,
@@ -43,7 +47,7 @@ describe('custom map', () => {
             projection: new Projection({
                 code: 'EPSG:31370',
                 extent: [9928.000000, 66928.000000, 272072.000000, 329072.000000],
-            }),
+            })
         };
 
         if (options) {
@@ -59,8 +63,12 @@ describe('custom map', () => {
     };
 
     const createMapZonderLayers = () => {
-        const defaultOptions = {
-            actions: [],
+        const defaultOptions: VLCustomMapOptions = {
+            defaultZoom: false,
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false,
             customLayers: {
                 baseLayerGroup: new Group({
                     layers: [],
@@ -73,7 +81,7 @@ describe('custom map', () => {
             projection: new Projection({
                 code: 'EPSG:31370',
                 extent: [9928.000000, 66928.000000, 272072.000000, 329072.000000],
-            }),
+            })
         };
 
         const map = new VlCustomMap(defaultOptions);

--- a/web-components/libs/map/src/lib/actions/map/map-with-actions.spec.ts
+++ b/web-components/libs/map/src/lib/actions/map/map-with-actions.spec.ts
@@ -22,8 +22,6 @@ function sleep() {
 
 describe('map with actions', () => {
     let map;
-    let action1;
-    let action2;
 
     class VlTestMapWithActions extends VlMapWithActions {
         getDefaultActiveAction() {
@@ -39,40 +37,32 @@ describe('map with actions', () => {
         }
     }
 
-    beforeEach(() => {
-        action1 = new VlBaseMapAction([new Interaction(), new Interaction()]);
-        action2 = new VlBaseMapAction([new Interaction(), new Interaction(), new Interaction()]);
-    });
-
-    it('adds the interactions of all actions to the map', () => {
-        map = new VlTestMapWithActions({
-            actions: [action1, action2],
-        });
-
-        expect(map.getInteractions().getLength()).toBe(14); // 9 standaard + 5
-    });
 
     it('can add a new action to the map', async () => {
         map = new VlTestMapWithActions({
-            actions: [action1, action2],
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false
         });
 
-        expect(map.actions.length).toBe(2);
-        expect(map.getInteractions().getLength()).toBe(14);
+        expect(map.actions.length).toBe(0);
 
         const newAction = new VlBaseMapAction([new Interaction(), new Interaction()]);
 
         map.addAction(newAction);
         await sleep();
 
-        expect(map.actions.length).toBe(3);
-        expect(map.actions[2]).toBe(newAction);
-        expect(map.getInteractions().getLength()).toBe(16);
+        expect(map.actions.length).toBe(1);
+        expect(map.getInteractions().getLength()).toBe(11); // 9 by default from OL + 2 in the action
     });
 
     it('can remove an action from the map', async () => {
         map = new VlTestMapWithActions({
-            actions: [action1, action2],
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false
         });
 
         const newAction = new VlBaseMapAction([new Interaction(), new Interaction()]);
@@ -85,14 +75,16 @@ describe('map with actions', () => {
 
         map.removeAction(newAction);
 
-        expect(map.actions.length).toBe(2);
+        expect(map.actions.length).toBe(0);
         expect(map.actions.indexOf(newAction)).toBe(-1);
-        expect(map.getInteractions().getLength()).toBe(14);
     });
 
     it('if the action to be removed is the current action, the default is activated', async () => {
         map = new VlTestMapWithActions({
-            actions: [action1, action2],
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false
         });
 
         const activateDefaultActionSpy = jest.spyOn(map, 'activateDefaultAction').mockClear();
@@ -112,71 +104,13 @@ describe('map with actions', () => {
         expect(activateDefaultActionSpy).toHaveBeenCalled();
     });
 
-    it('there are 9 predefined interactions', () => {
-        const map = new VlTestMapWithActions({
-            actions: [],
-        });
-
-        expect(map.getInteractions().getLength()).toBe(9); // There are 9 standard interactions
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof DragRotate).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof DoubleClickZoom).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof KeyboardPan).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof KeyboardZoom).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof MouseWheelZoom).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof PinchZoom).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof PinchRotate).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof DragPan).length,
-        ).toBe(1);
-        expect(
-            map
-                .getInteractions()
-                .getArray()
-                .filter((interaction) => interaction instanceof DragZoom).length,
-        ).toBe(1);
-    });
 
     it('when creating a map with actions, standard functionality is added to the map that on escape the first map action gets activated when no action is active', () => {
         map = new VlTestMapWithActions({
-            actions: [],
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false
         });
 
         jest.spyOn(map, 'activateDefaultAction');
@@ -187,18 +121,21 @@ describe('map with actions', () => {
         expect(map.activateDefaultAction).toHaveBeenCalled();
     });
 
-    it('when creating a map with actions, standard functionality is added to the map that on escape the current active action gets stopped when an action is active', async () => {
+    it('when creating a map, and adding an action, standard functionality is added to the map that on escape the current active action gets stopped when an action is active', async () => {
         const source = new VectorSource({});
 
         const layer = {
             getSource: () => source,
         };
+        map = new VlTestMapWithActions({
+            disableEscapeKey: false,
+            disableKeyboard: false,
+            disableMouseWheelZoom: false,
+            disableRotation: false
+        });
 
         const drawLineAction = new VlDrawLineAction(layer, () => {}, {});
-
-        map = new VlTestMapWithActions({
-            actions: [drawLineAction],
-        });
+        map.addAction(drawLineAction);
 
         jest.spyOn(drawLineAction, 'stop');
 
@@ -215,10 +152,10 @@ describe('map with actions', () => {
         currentActiveActionStub.mockReset();
     });
 
-    it('if desired, the standard escape functionality can be disabled when creating a map with actions', () => {
+    it('if desired, the standard escape functionality can be disabled', () => {
         const map = new VlTestMapWithActions({
-            actions: [],
-            disableEscapeKey: true,
+            disableKeyboard: false, disableMouseWheelZoom: false, disableRotation: false,
+            disableEscapeKey: true
         });
 
         const activateDefaultActionStub = jest.spyOn(map, 'activateDefaultAction').mockImplementation();
@@ -232,10 +169,10 @@ describe('map with actions', () => {
         activateDefaultActionStub.mockReset();
     });
 
-    it('if desired, the standard rotation functionality can be disabled when creating a map with actions', () => {
+    it('if desired, the standard rotation functionality can be disabled', () => {
         const map = new VlTestMapWithActions({
-            actions: [],
-            disableRotation: true,
+            disableEscapeKey: false, disableKeyboard: false, disableMouseWheelZoom: false,
+            disableRotation: true
         });
 
         expect(map.getInteractions().getLength()).toBe(7); // 9-2=7
@@ -297,9 +234,9 @@ describe('map with actions', () => {
 
     it('if desired, extra interactions can be added when creating a map with actions', () => {
         const map = new VlTestMapWithActions({
-            actions: [],
+            disableEscapeKey: false, disableKeyboard: false, disableMouseWheelZoom: false,
             interactions: new Collection([new PinchZoom(), new PinchRotate()]),
-            disableRotation: true,
+            disableRotation: true
         });
 
         expect(map.getInteractions().getLength()).toBe(9); // 9-2+2=9
@@ -307,8 +244,8 @@ describe('map with actions', () => {
 
     it('if desired, zooming with the mouse wheel can be turned off', () => {
         const map = new VlTestMapWithActions({
-            actions: [],
-            disableMouseWheelZoom: true,
+            disableEscapeKey: false, disableKeyboard: false, disableRotation: false,
+            disableMouseWheelZoom: true
         });
 
         expect(map.getInteractions().getLength()).toBe(8);

--- a/web-components/libs/map/src/lib/actions/map/map-with-actions.ts
+++ b/web-components/libs/map/src/lib/actions/map/map-with-actions.ts
@@ -1,15 +1,15 @@
-import { defaults } from 'ol/interaction';
+import {defaults} from 'ol/interaction';
 import Map from 'ol/Map';
-import { CONTROL_TYPE } from '../../vl-map.model';
+import {CONTROL_TYPE} from '../../vl-map.model';
+import {MapOptions} from "ol/PluggableMap";
 
-export interface VlMapActionOptions {
-    disableEscapeKey?: Boolean;
-    actions?: any;
-    interactions?: any;
-    disableKeyboard?: Boolean;
-    disableRotation?: Boolean;
-    disableMouseWheelZoom?: Boolean;
+export interface VlMapWithActionsOptions extends MapOptions {
+    disableEscapeKey: boolean;
+    disableKeyboard: boolean;
+    disableRotation: boolean;
+    disableMouseWheelZoom: boolean;
 }
+
 
 /**
  * Deze map bevat enkel de functionaliteit om de acties te behandelen. Aan het eerste argument van de constructor kan het gebruikelijke object map opties worden weergegeven die ook op de ol.Map worden gezet, samen met een extra parameter 'acties' in dat object. Deze array bevat MapActions.
@@ -17,33 +17,30 @@ export interface VlMapActionOptions {
  *
  * Deze kaart regelt dat er maar één actie actief kan staan. Bij het activeren van een andere actie wordt namelijk de huidige actie gedeactiveerd.
  */
+
 export class VlMapWithActions extends Map {
-    private actions: any[];
+    private _actions: any[] = [];
     private timeout: any;
     static get CLICK_COUNT_TIMEOUT() {
         return 300;
     }
+    get actions(): any[] {
+        return this._actions;
+    }
 
-    constructor(options: VlMapActionOptions = <VlMapActionOptions>{}) {
-        const { disableRotation, disableMouseWheelZoom, disableKeyboard } = options;
-        const enableRotation = !disableRotation;
-        const enableMouseWheelZoom = !disableMouseWheelZoom;
+    constructor(options: VlMapWithActionsOptions) {
+
         const interactions = defaults({
-            altShiftDragRotate: enableRotation,
-            pinchRotate: enableRotation,
-            mouseWheelZoom: enableMouseWheelZoom,
-            keyboard: !disableKeyboard,
+            altShiftDragRotate: !options.disableRotation,
+            pinchRotate: !options.disableRotation,
+            mouseWheelZoom: !options.disableMouseWheelZoom,
+            keyboard: !options.disableKeyboard,
         });
         if (options && options.interactions) {
             options.interactions.forEach((interaction) => interactions.push(interaction));
         }
         options.interactions = interactions;
         super(options);
-        this.actions = [];
-
-        options.actions.forEach((action) => {
-            this.addAction(action);
-        });
 
         // TODO: check if timeout and activating default is still needed here (old bugfix)
         setTimeout(() => {
@@ -70,15 +67,15 @@ export class VlMapWithActions extends Map {
     }
 
     getDefaultActiveAction() {
-        return this.actions && this.actions.find((action) => action.element._defaultActive);
+        return this._actions && this._actions.find((action) => action.element._defaultActive);
     }
 
     getCurrentActiveAction() {
-        return this.actions && this.actions.find((action) => action.element._active);
+        return this._actions && this._actions.find((action) => action.element._active);
     }
 
     getActionWithIdentifier(identifier) {
-        return this.actions && this.actions.find((action) => action.element.identifier === identifier);
+        return this._actions && this._actions.find((action) => action.element.identifier === identifier);
     }
 
     getControlsOfType(type) {
@@ -99,7 +96,7 @@ export class VlMapWithActions extends Map {
     }
 
     getLayerActions(layer) {
-        return this.actions && this.actions.filter((action) => action.layer === layer);
+        return this._actions && this._actions.filter((action) => action.layer === layer);
     }
 
     activateAction(action) {
@@ -144,7 +141,7 @@ export class VlMapWithActions extends Map {
 
         action.element.reset();
 
-        this.actions.splice(this.actions.indexOf(action), 1);
+        this._actions.splice(this._actions.indexOf(action), 1);
     }
 
     activateDefaultAction() {

--- a/web-components/libs/map/src/lib/vl-map.ts
+++ b/web-components/libs/map/src/lib/vl-map.ts
@@ -7,9 +7,12 @@ import proj4 from 'proj4';
 import { VlCustomMap } from './actions';
 import { EVENT } from './vl-map.model';
 import styles from './vl-map.scss';
+import Control from "ol/control/Control";
+import Collection from "ol/Collection";
 
 @webComponent('vl-map')
 export class VlMap extends BaseElementOfType(HTMLElement) {
+
     constructor() {
         super(`
       <style>
@@ -43,16 +46,16 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
      *
      * @return {VlCustomMap}
      */
-    get map() {
+    get map(): VlCustomMap {
         return this._map;
     }
 
     /**
      * Returns the OpenLayers map resolution.
      *
-     * @return {Object}
+     * @return {number}
      */
-    get resolution() {
+    get resolution(): number {
         return this.map.getView().getResolution();
     }
 
@@ -65,19 +68,19 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
         return [...this.querySelectorAll(':scope > [data-vl-is-layer]')];
     }
 
-    get disableEscapeKey() {
+    get disableEscapeKey():boolean {
         return this.getAttribute('disable-escape-key') != undefined;
     }
 
-    get disableRotation() {
+    get disableRotation():boolean {
         return this.getAttribute('disable-rotation') != undefined;
     }
 
-    get disableMouseWheelZoom() {
+    get disableMouseWheelZoom():boolean {
         return this.getAttribute('disable-mouse-wheel-zoom') != undefined;
     }
 
-    get disableKeyboard() {
+    get disableKeyboard():boolean {
         return this.getAttribute('disable-keyboard') != undefined;
     }
 
@@ -101,14 +104,15 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
         return this._shadow.querySelector('#map');
     }
 
-    get _controls() {
+    get _controls(): Collection<Control> {
+        const collection = new Collection<Control>();
         if (this.dataset.vlAllowFullscreen != undefined) {
-            return [new OlFullScreenControl()];
+            collection.push(new OlFullScreenControl());
         }
-        return [];
+        return collection;
     }
 
-    get _projection() {
+    get _projection(): OlProjection {
         return new OlProjection({
             code: 'EPSG:31370',
             extent: this._extent,
@@ -124,7 +128,6 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
         this.__initializeCoordinateSystem();
 
         this._map = new VlCustomMap({
-            actions: [],
             disableEscapeKey: this.disableEscapeKey,
             disableRotation: this.disableRotation,
             disableMouseWheelZoom: this.disableMouseWheelZoom,
@@ -140,14 +143,13 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
             defaultZoom: false,
         });
 
-        this._map.initializeView();
         this.__updateMapSizeOnLoad();
         this.__updateOverviewMapSizeOnLoad();
 
-        this._map.addControl(this.__createZoomControl());
+        this.map.addControl(this.__createZoomControl());
     }
 
-    __createZoomControl() {
+    __createZoomControl(): Zoom {
         const zoomOptions: { zoomInTipLabel?; zoomOutTipLabel? } = {};
         if (this.zoomInTipLabel) {
             zoomOptions.zoomInTipLabel = this.zoomInTipLabel;
@@ -166,6 +168,7 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
         return this.getAttribute('data-vl-zoomOutTooltip');
     }
 
+    // wordt in code aangesproken via bv: this.mapElement.addLayer(this._layer);
     addLayer(layer) {
         this.map.getOverlayLayers().push(layer);
     }
@@ -325,7 +328,7 @@ export class VlMap extends BaseElementOfType(HTMLElement) {
         VlMap.__callOnceOnLoad(this.__updateMapSize.bind(this));
     }
 
-    __createLayerGroup(title, layers) {
+    __createLayerGroup(title, layers): OlLayerGroup {
         // title is not a valid option property, also can not find it in html DOM when setting it
         // ref.: https://openlayers.org/en/v6.15.1/apidoc/module-ol_layer_Group-LayerGroup.html
         return new OlLayerGroup(<any>{

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -13,6 +13,7 @@
         "test:wctonly": "npx nx wct map",
         "test:wctdetail": "npm run build:all  && npx nx wctdetail map",
         "test:wctdetailonly": "npx nx wctdetail map",
+        "storybook": "npx nx storybook storybook http://localhost:8080",
         "storybook:ci-test": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e'",
         "storybook:ci-test-parallel-1": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e -- --spec **/src/e2e/components/[a-m]*/**/*'",
         "storybook:ci-test-parallel-2": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e -- --spec **/src/e2e/components/[n-z]*/**/*'",


### PR DESCRIPTION
Typering verbeteren bij map.

Ik merk op dat aan VlMapWithActions 'actions' in de constructor konden worden doorgegeven. Echter is VlMap (via VlCustomMap) de enige aanspreker van die klasse. En daar worden die actions niet doorgegeven.

Enkel in de testklasse van VlMapWithActions worden actions gezet. Ik heb die daar verwijderd. Wel even verifieren dat er geen manier is om toch actions door te geven bij het instantieren van een VlMap.