### PR TITLE
fix: UIG-2297 - fix webComponent decorator voor VlPropertiesComponent

### DIFF
--- a/libs/elements/src/lib/properties/vl-properties.element.ts
+++ b/libs/elements/src/lib/properties/vl-properties.element.ts
@@ -10,8 +10,8 @@ import { BaseElementOfType, webComponent } from '@domg-wc/common-utilities';
  *
  * @property {boolean} data-vl-full-width - Attribuut wordt gebruikt om de maximale breedte van het label te benutten.
  */
-@webComponent('vl-properties', { extends: 'div' })
-export class VlPropertiesComponent extends BaseElementOfType(HTMLDivElement) {
+@webComponent('vl-properties')
+export class VlPropertiesComponent extends BaseElementOfType(HTMLElement) {
     static get _observedClassAttributes() {
         return ['full-width'];
     }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
         "storybook:ci-test-parallel-3": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e -- --spec **/src/e2e/elements/[a-i]*/**/*'",
         "storybook:ci-test-parallel-4": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e -- --spec **/src/e2e/elements/[j-z]*/**/*'",
         "storybook:ci-test-parallel-5": "start-server-and-test 'npx nx storybook storybook' http://localhost:8080 'npx nx e2e storybook-e2e -- --spec **/src/e2e/sections/**/*'",
+        "killstart:storybook": "npx kill-port 8080 && npx nx storybook storybook",
+        "killstart:playground": "npx kill-port 4200 && npx nx serve playground",
         "build:common-utilities": "npx nx build common-utilities",
         "build:elements": "npx nx build elements",
         "build:components": "npx nx build components",


### PR DESCRIPTION
`vl-properties`: lag aan het decorator gebeuren

is eigenlijk een `component` die bij de `elements` staat... en dus zijn interne klasse niet kreeg toegewezen; en de media query css waarop de child elementen berusten schiet pas in actie als de parent de juiste klasse krijgt (namelijk: `vl-properties`)

---

heb ook van eerste keer bij de rest van de `elements` gekeken, maar dit was dus de enige uitzondering
