### PR TITLE
OMGVN-9313: init vl-map-features-layer vanuit connectedCallback

### DIFF
--- a/libs/map/src/lib/components/layer/vector-layer/vl-map-features-layer.ts
+++ b/libs/map/src/lib/components/layer/vector-layer/vl-map-features-layer.ts
@@ -32,12 +32,16 @@ export class VlMapFeaturesLayer extends VlMapVectorLayer {
 
     constructor() {
         super();
+    }
+
+    init() {
         this._geoJSON = new OlGeoJSON();
         this._source = this.__createSource();
         this._layer = this._createLayer();
     }
 
     async connectedCallback() {
+        this.init();
         await super.connectedCallback();
         this._autoZoomToExtent();
     }


### PR DESCRIPTION
Het blijkt dat wanneer we de cluster en cluster-distance attributen zetten op de vl-map-features-layer bij gebruikt van de webcomponenten vanuit react, dat dan de cluster en cluster-distance attributes nog niet gezet zijn. Daardoor werkt clustering niet.
Als we de initialisatie van de vl-map-features-layer niet in de constructor doen, maar vanuit de connectedCallback(), dan werkt de clustering wel vanuit ons inzage loket.
Met deze nieuwe manier van initialisatie werden ook geen clustering issues gevonden in de map stories van de uig web componenten.