### PR TITLE
fix: UIG-2425 - vl-multiselect foutief icoon

### DIFF
--- a/libs/elements/src/lib/multiselect/style/_vl-multiselect.scss
+++ b/libs/elements/src/lib/multiselect/style/_vl-multiselect.scss
@@ -24,8 +24,8 @@
     text-transform: none
 }
 
-.js-vl-select[data-type*=multiple] .vl-pill__close::before {
-    content: ""
+.js-vl-select[data-type*=multiple] .vl-pill__close {
+    @include vi-cross;
 }
 
 .js-vl-select[data-type*=multiple] .vl-pill__close:hover,


### PR DESCRIPTION
Hardcoded content van icoon vervangen door de mixin die voorzien wordt door DV.