### PR TITLE
fix: UIG-2419 - vl-toggle-button - kan nu ook error status tonen zonder actief te zijn

### DIFF
--- a/libs/components/src/lib/toggle-button/stories/vl-toggle-button.stories-arg.ts
+++ b/libs/components/src/lib/toggle-button/stories/vl-toggle-button.stories-arg.ts
@@ -153,7 +153,6 @@ export const toggleButtonArgTypes = {
     ...sharedButtonArgTypes,
     error: {
         ...sharedButtonArgTypes.error,
-        description:
-            'Used to emphasize the importance or consequences of an action when the toggle button is in an active state.',
+        description: 'Used to emphasize the importance or consequences of an action.',
     },
 };

--- a/libs/components/src/lib/toggle-button/vl-toggle-button.component.ts
+++ b/libs/components/src/lib/toggle-button/vl-toggle-button.component.ts
@@ -151,7 +151,7 @@ export class VlToggleButtonComponent extends LitElement {
                 is="vl-button"
                 aria-label="toggle-button"
                 part="button template"
-                ?data-vl-error=${this._active && this.error}
+                ?data-vl-error=${this.error}
                 ?data-vl-block=${this.block}
                 ?data-vl-large=${this.large}
                 ?data-vl-wide=${this.wide}


### PR DESCRIPTION
op zich breaking change maar ik denk niet dat dit problematisch zal zijn

https://www.milieuinfo.be/jira/browse/UIG-2419
