### PR TITLE
feat: UIG-2393 - vl-textarea - stylen van de inhoud in rich-text mode

### DIFF
--- a/apps/playground/src/app/app.element.ts
+++ b/apps/playground/src/app/app.element.ts
@@ -1,5 +1,4 @@
 import { vlElementsStyle } from '@domg-wc/elements';
-import { baseStyle, typographyStyle } from '@domg/govflanders-style/common';
 import appStyle from './app.element.css';
 
 export class AppElement extends HTMLElement {
@@ -7,12 +6,7 @@ export class AppElement extends HTMLElement {
 
     constructor() {
         super();
-        document.adoptedStyleSheets = [
-            typographyStyle.styleSheet,
-            baseStyle.styleSheet,
-            ...vlElementsStyle.map((style) => style.styleSheet),
-            appStyle.styleSheet,
-        ];
+        document.adoptedStyleSheets = [...vlElementsStyle.map((style) => style.styleSheet), appStyle.styleSheet];
     }
 
     connectedCallback() {

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,15 +1,8 @@
 import { formatHTML } from '@domg-wc/common-utilities';
-import { CSSResult } from 'lit';
 import './docs-styling.css';
-import { resetStyle, baseStyle, typographyStyle } from '@domg/govflanders-style/common';
-import elementsStyle from '../../../libs/elements/src/lib/vl-elements.uig-css';
+import vlElementsStyle from '../../../libs/elements/src/lib/vl-elements.uig-css';
 
-document.adoptedStyleSheets = [
-    resetStyle.styleSheet,
-    typographyStyle.styleSheet,
-    baseStyle.styleSheet,
-    ...elementsStyle.map((style) => style.styleSheet),
-];
+document.adoptedStyleSheets = [...vlElementsStyle.map((style) => style.styleSheet)];
 
 export const parameters = {
     actions: { argTypesRegex: '^on[A-Z].*' },

--- a/libs/components/src/lib/textarea/vl-textarea.element.ts
+++ b/libs/components/src/lib/textarea/vl-textarea.element.ts
@@ -57,7 +57,7 @@ export class VlTextarea extends vlFormValidationElement(BaseElementOfType(HTMLTe
             branding: false,
             powerpaste_word_import: 'clean',
             powerpaste_html_import: 'clean',
-            // content_css: hier zou CDN link moeten komen voor de styling die zich in .style/vl-textarea.scss bevindt,
+            content_css: 'https://cdn.omgeving.vlaanderen.be/domg/govflanders-style/14.0.1/custom/tinymce.css',
             verify_html: false,
             forced_root_block: 'p',
             body_class: 'vl-typography',

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "typescript": "4.9.5"
     },
     "dependencies": {
-        "@domg/govflanders-style": "14.0.0",
+        "@domg/govflanders-style": "14.0.1",
         "@govflanders/vl-ui-accordion": "14.0.2",
         "@govflanders/vl-ui-code-preview": "14.0.2",
         "@govflanders/vl-ui-core": "15.0.2",


### PR DESCRIPTION
- technisch wordt er nu verwezen naar de specifiek hiervoor gepubliceerde css op de CDN
- daarnaast een kleine opkuis in de css van playground en storybook: de vlElementsStyle uit @domg-wc/elements bevat alle styling die nodig is op root niveau