### PR TITLE
fix: UIG-2510 - vl-map - wacht tussen clicks in vl-map-draw-line-action.tester en vl-map-draw-polygon-action.tester

### DIFF
--- a/libs/support/test-support/src/lib/map/components/action/draw-action/vl-map-draw-line-action.tester.js
+++ b/libs/support/test-support/src/lib/map/components/action/draw-action/vl-map-draw-line-action.tester.js
@@ -9,8 +9,10 @@ export class VlMapDrawLineActionTester extends VlMapDrawActionTester {
             await map.driver
                 .actions()
                 .move({ origin: map, x: pixel1.x, y: pixel1.y })
+                .pause(1000)  // wacht bij een move/klik aangezien te snel klikken problematisch is
                 .click()
                 .move({ origin: map, x: pixel2.x, y: pixel2.y })
+                .pause(1000)  // wacht bij een move/klik aangezien te snel klikken problematisch is
                 .doubleClick()
                 .perform();
         });

--- a/libs/support/test-support/src/lib/map/components/action/draw-action/vl-map-draw-polygon-action.tester.js
+++ b/libs/support/test-support/src/lib/map/components/action/draw-action/vl-map-draw-polygon-action.tester.js
@@ -17,12 +17,14 @@ export class VlMapDrawPolygonActionTester extends VlMapDrawActionTester {
             for (let i = 0; i < coordinates.length; i++) {
                 const coordinate = coordinates[i];
                 const pixel = await map.getPixelFromCoordinate([coordinate.x, coordinate.y]);
+                await actions.move({origin: map, x: pixel.x, y: pixel.y}).pause(1000); // wacht bij een move/klik aangezien te snel klikken problematisch is
                 if (i + 1 < coordinates.length) {
-                    await actions.move({origin: map, x: pixel.x, y: pixel.y}).click();
+                    await actions.click();
                 } else {
-                    await actions.move({origin: map, x: pixel.x, y: pixel.y}).doubleClick().perform();
+                    await actions.doubleClick();
                 }
             }
+            await actions.perform();
         });
     }
 }


### PR DESCRIPTION
OpenLayers wacht 250ms na een click om te bepalen of het een double click is of een single click.
In de testers, bij het tekenen, hielden we hier geen rekening mee. Soms werd dat dan aanzien als double click met als gevolg dat er niet getekend wordt wat we verwachten.

Daarom introduceer ik nu tussen clicks een pauze van 1s tussen clicks (lager dan dit bleef problemen geven).