### PR TITLE
feat: UIG-2187 - vl-cookie-consent - uitgebreid met externe configuratie voor matomo

### DIFF
--- a/apps/storybook-e2e/src/e2e/sections/cookie-consent/vl-cookie-consent.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/sections/cookie-consent/vl-cookie-consent.stories.cy.ts
@@ -1,17 +1,26 @@
 const cookieConsentUrl =
-    'http://localhost:8080/iframe.html?args=&id=sections-cookie-consent--cookie-consent-default&viewMode=story';
+    'http://localhost:8080/iframe.html?id=sections-cookie-consent--cookie-consent-default&viewMode=story';
 
 describe('story vl-cookie-consent', () => {
     it('should contain the `Cookie-toestemming`', () => {
         cy.visit(`${cookieConsentUrl}`);
-        cy.getDataCy('button-open-cookie-consent').click();
-        cy.getDataCy('cookie-consent').shadow().find('vl-modal').shadow().find('h2').contains('Cookie-toestemming');
-        cy.getDataCy('cookie-consent')
+        cy.get('button#button-open-cookie-consent').click();
+        cy.get('vl-cookie-consent').shadow().find('vl-modal').shadow().find('h2').contains('Cookie-toestemming');
+        cy.get('vl-cookie-consent')
             .shadow()
             .find('vl-modal')
             .find('.vl-button')
             .scrollIntoView()
             .contains('Ik begrijp het')
             .click();
+    });
+
+    it('should contain the given matomo id & matomo url', () => {
+        const matomoId = 12345;
+        const matomoUrl = 'fake-matomo-url';
+        cy.visit(`${cookieConsentUrl}&args=matomoId:${matomoId};matomoUrl:${matomoUrl}`);
+        cy.get('script#vl-cookie-consent-matomo-script')
+            .should('contain.text', `_paq.push(['setSiteId', ${matomoId}]);`)
+            .should('contain.text', `var u='${matomoUrl}'`);
     });
 });

--- a/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-arg.ts
+++ b/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-arg.ts
@@ -5,6 +5,8 @@ export const cookieConsentArgs = {
     autoOptInFunctionalDisabled: false,
     owner: '',
     link: '',
+    matomoId: '',
+    matomoUrl: '',
 };
 
 export const cookieConsentArgTypes = {
@@ -54,6 +56,26 @@ export const cookieConsentArgTypes = {
         table: {
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: '' },
+        },
+    },
+    matomoId: {
+        name: 'data-vl-matomo-id',
+        type: { summary: TYPES.NUMBER },
+        description:
+            'Bepaald matomo id. Dit moet in combinatie met `matomo-url` gebruikt worden. Wanneer deze 2 properties ingesteld zijn, wordt niet meer `window.location.host` gekeken om de matomo id & url te bepalen.',
+        table: {
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: cookieConsentArgs.matomoId },
+        },
+    },
+    matomoUrl: {
+        name: 'data-vl-matomo-url',
+        type: { summary: TYPES.STRING },
+        description:
+            'Bepaald matomo url. Dit moet in combinatie met `matomo-id` gebruikt worden. Wanneer deze 2 properties ingesteld zijn, wordt niet meer `window.location.host` gekeken om de matomo id & url te bepalen.',
+        table: {
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: cookieConsentArgs.matomoUrl },
         },
     },
 };

--- a/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-doc.mdx
+++ b/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-doc.mdx
@@ -1,0 +1,32 @@
+import { ArgsTable, DocsStory, PRIMARY_STORY } from '@storybook/addon-docs';
+
+# Cookie Consent
+
+De cookie consent kan gebruikt worden om de gebruiker te informeren over al de cookies die gebruikt worden.
+Daarnaast kunnen er mits toestemming van de gebruiker analytics worden toegepast.
+
+## Voorbeeld
+
+```js
+import { VlCookieConsent } from '@domg-lib/sections';
+```
+
+```html
+<vl-cookie-consent></vl-cookie-consent>
+```
+
+<DocsStory id="sections-cookie-consent--cookie-consent-default" />
+
+## Configuratie
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Referenties
+
+### Legacy Documentatie
+
+**Legacy Storybook:** https://uig-webcomponents.omgeving.vlaanderen.be/?path=/story/legacy-vl-cookie-consent--default
+
+**Legacy Documentatie:** https://webcomponenten.omgeving.vlaanderen.be/doc/VlCookieConsent.html
+
+**Legacy Demo:** https://webcomponenten.omgeving.vlaanderen.be/demo/vl-cookie-consent.html

--- a/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories.ts
+++ b/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories.ts
@@ -1,33 +1,37 @@
-import { ifDefinedString } from '@domg-wc/common-utilities';
 import { html } from 'lit-html';
+import { StoryFn } from '@storybook/web-components';
+import { setDefaultArgsToNothing } from '@domg-wc/common-utilities';
 import '../vl-cookie-consent.section';
 import { cookieConsentArgs, cookieConsentArgTypes } from './vl-cookie-consent.stories-arg';
+import cookieConsentDoc from './vl-cookie-consent.stories-doc.mdx';
 
 export default {
     title: 'sections/cookie-consent',
     args: cookieConsentArgs,
     argTypes: cookieConsentArgTypes,
     parameters: {
-        controls: { hideNoControlsWarning: true },
+        layout: 'fullscreen',
+        docs: { page: cookieConsentDoc },
     },
 };
 
-export const cookieConsentDefault = ({
-    analytics,
-    autoOptInFunctionalDisabled,
-    owner,
-    link,
-}: typeof cookieConsentArgs) => {
+export const cookieConsentDefault: StoryFn<typeof cookieConsentArgs> = (args: typeof cookieConsentArgs) => {
+    const { analytics, autoOptInFunctionalDisabled, owner, link, matomoId, matomoUrl } = setDefaultArgsToNothing(
+        args,
+        cookieConsentArgs
+    );
     return html`
         <div>
             <vl-cookie-consent
                 data-cy="cookie-consent"
                 id="cookie-consent"
-                ?data-vl-analytics=${analytics}
+                data-vl-analytics=${analytics}
+                data-vl-matomo-id=${matomoId}
+                data-vl-matomo-url=${matomoUrl}
                 data-vl-auto-open-disabled=""
                 ?data-vl-auto-opt-in-functional-disabled=${autoOptInFunctionalDisabled}
-                data-vl-owner=${ifDefinedString(owner)}
-                data-vl-link=${ifDefinedString(link)}
+                data-vl-owner=${owner}
+                data-vl-link=${link}
             ></vl-cookie-consent>
             <button
                 data-cy="button-open-cookie-consent"

--- a/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
+++ b/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
@@ -1,9 +1,10 @@
 class AnalyticsUtil {
-    private _matomoScriptId;
-    private _matomoPiwikScriptId;
-    private _matomoOntwikkelUrl;
-    private _matomoOefenUrl;
-    private _matomoProdUrl;
+    private _matomoScriptId: string;
+    private _matomoPiwikScriptId: string;
+    private _matomoOntwikkelUrl: string;
+    private _matomoOefenUrl: string;
+    private _matomoProdUrl: string;
+    private matomoParameters: { matomoId: number; matomoUrl: string } | undefined;
 
     constructor() {
         this._matomoScriptId = 'vl-cookie-consent-matomo-script';
@@ -13,11 +14,11 @@ class AnalyticsUtil {
         this._matomoProdUrl = '//stats.milieuinfo.be/';
     }
 
-    get scriptId() {
+    get scriptId(): string {
         return this._matomoScriptId;
     }
 
-    get id() {
+    getUrlIdMatch(): { id: number; url: string } | undefined {
         let match = {
             'stats-ontwikkel.milieuinfo.be': {
                 id: 1,
@@ -239,7 +240,27 @@ class AnalyticsUtil {
         return match;
     }
 
-    get script() {
+    /**
+     * matomo config manueel instellen ipv te rekenen op the interne config
+     * @param matomoId
+     * @param matomoUrl
+     */
+    setMatomoConfig(matomoId: number, matomoUrl: string): void {
+        this.matomoParameters = { matomoId, matomoUrl };
+    }
+
+    get id(): { id: number; url: string } | undefined {
+        let urlIdResult = this.getUrlIdMatch();
+        if (this.matomoParameters) {
+            const { matomoId, matomoUrl } = this.matomoParameters;
+            if (matomoId && matomoUrl) {
+                urlIdResult = { id: matomoId, url: matomoUrl };
+            }
+        }
+        return urlIdResult;
+    }
+
+    get script(): HTMLScriptElement {
         const matomo = analytics.id;
         const element = document.createElement('script');
         element.setAttribute('id', this._matomoScriptId);


### PR DESCRIPTION

- vroeger werd er op basis van `window.location.host` bepaald welke id & url te gebruiken voor matomo; nu kan deze ingesteld worden als attributen
- storybook verbeterd & cypress test toegevoegd