### PR TITLE
fix: UIG-2503, feat: UIG-2505, feat: 2504

### DIFF
--- a/apps/storybook-e2e/src/e2e/elements/form-grid/vl-form-column.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form-grid/vl-form-column.stories.cy.ts
@@ -1,13 +1,13 @@
-const formDefaultUrl = 'http://localhost:8080/iframe.html?id=elements-form-grid--form-grid-column&viewMode=story';
+const formGridDefaultUrl = 'http://localhost:8080/iframe.html?id=elements-form-grid--form-grid-column&viewMode=story';
 
 describe('story vl-form-column', () => {
     it('should contain form with a 8/12 form column in it', () => {
-        cy.visit(`${formDefaultUrl}`);
+        cy.visit(`${formGridDefaultUrl}`);
         cy.getDataCy('form').getDataCy('form-column').should('have.class', 'vl-form-col--8-12');
     });
 
     it("should contain form with a 8/12 form column in it that's pushed 2/12 columns", () => {
-        cy.visit(`${formDefaultUrl}&args=push:2`);
+        cy.visit(`${formGridDefaultUrl}&args=push:2`);
         cy.getDataCy('form')
             .getDataCy('form-column')
             .should('have.class', 'vl-form-col--8-12')

--- a/apps/storybook-e2e/src/e2e/elements/form-validation/vl-form-validation.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form-validation/vl-form-validation.stories.cy.ts
@@ -1,0 +1,59 @@
+const formValidationDefaultUrl =
+    'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&viewMode=story&id=elements-form--form-validation';
+const formValidationOptionalUrl =
+    'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&args=&id=elements-form--form-validation-optional&viewMode=story';
+
+describe('story vl-form-validation - default', () => {
+    it('should be accessible', () => {
+        cy.visitWithA11y(`${formValidationDefaultUrl}`);
+        cy.checkA11y('[is="vl-form"]');
+    });
+});
+
+describe('story vl-form-validation - optional validation', () => {
+    it('should be accessible', () => {
+        cy.visitWithA11y(`${formValidationOptionalUrl}`);
+        cy.checkA11y('[is="vl-form"]');
+    });
+
+    it('should have an error placeholder for every input-field', () => {
+        cy.visit(`${formValidationOptionalUrl}`);
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`);
+            });
+    });
+
+    it('should be only validate required inputs', () => {
+        cy.visit(`${formValidationOptionalUrl}`);
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`).should(
+                    'have.attr',
+                    'hidden'
+                );
+            });
+
+        cy.get('[is="vl-form"]').submit();
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                const isRequired = inputField.getAttribute('data-vl-required');
+                if (isRequired) {
+                    cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`)
+                        .should('have.attr', 'error')
+                        .and('not.have.attr.hidden');
+                }
+            });
+    });
+});

--- a/apps/storybook-e2e/src/e2e/elements/form/vl-form-group.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form/vl-form-group.stories.cy.ts
@@ -1,7 +1,12 @@
+const formGroupUrl = 'http://localhost:8080/iframe.html?id=elements-form--form-group&viewMode=story';
 describe('story vl-form-group', () => {
-    beforeEach(() => cy.visit('http://localhost:8080/iframe.html?id=elements-form--form-group&viewMode=story'));
-
     it('should contain form with a form group in it', () => {
-        cy.getDataCy('form-group').should('have.class', 'vl-form__group');
+        cy.visit(formGroupUrl);
+        cy.get('[is="vl-form-group"]').should('have.class', 'vl-form__group');
+    });
+
+    it('should be accessible', () => {
+        cy.visitWithA11y(`${formGroupUrl}`);
+        cy.checkA11y('[is="vl-form"]');
     });
 });

--- a/apps/storybook-e2e/src/e2e/elements/form/vl-form-validation.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form/vl-form-validation.stories.cy.ts
@@ -1,12 +1,22 @@
 const formValidationDefaultUrl =
     'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&viewMode=story&id=elements-form--form-validation';
 const formValidationOptionalUrl =
-    'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&args=&id=elements-form--form-validation-optional&viewMode=story';
+    'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&id=elements-form--form-validation-optional&viewMode=story';
 
-describe('story vl-form-validation - default', () => {
+describe('story vl-form - with validation', () => {
     it('should be accessible', () => {
         cy.visitWithA11y(`${formValidationDefaultUrl}`);
         cy.checkA11y('[is="vl-form"]');
+    });
+
+    it('should by default, not have native HTML validation', () => {
+        cy.visit(`${formValidationDefaultUrl}`);
+        cy.get('[is="vl-form"]').should('have.attr', 'novalidate');
+    });
+
+    it('should have native HTML validation', () => {
+        cy.visit(`${formValidationDefaultUrl}&args=nativeValidation:true`);
+        cy.get('[is="vl-form"]').should('not.have.attr', 'novalidate');
     });
 });
 

--- a/apps/storybook-e2e/src/e2e/elements/form/vl-form.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form/vl-form.stories.cy.ts
@@ -1,7 +1,12 @@
+const formDefaultUrl = 'http://localhost:8080/iframe.html?id=elements-form--form-default&viewMode=story';
 describe('story vl-form', () => {
-    beforeEach(() => cy.visit('http://localhost:8080/iframe.html?id=elements-form--form-default&viewMode=story'));
-
     it('should contain a form', () => {
-        cy.getDataCy('form-default').should('have.class', 'vl-form');
+        cy.visit(formDefaultUrl);
+        cy.get('[is="vl-form"]').should('have.class', 'vl-form');
+    });
+
+    it('should be accessible', () => {
+        cy.visitWithA11y(formDefaultUrl);
+        cy.checkA11y('[is="vl-form"]');
     });
 });

--- a/libs/common/utilities/src/lib/models/vl.model.ts
+++ b/libs/common/utilities/src/lib/models/vl.model.ts
@@ -78,8 +78,8 @@ interface Upload {
     dress(element: any): void;
     dressAll(): void;
     undress(): void;
-    enable(element: HTMLElement): void;
-    disable(element: HTMLElement): void;
+    enable(element: HTMLElement | undefined): void;
+    disable(element: HTMLElement | undefined): void;
     dropzoneInstances: any[];
     disabledMutationObserver: MutationObserver;
 }

--- a/libs/common/utilities/src/lib/models/vl.model.ts
+++ b/libs/common/utilities/src/lib/models/vl.model.ts
@@ -2,6 +2,8 @@
 // Voor JavaScript componenten, gebruikt Digitaal Vlaanderen een `vl`-object dat ze creëren op Window
 // typisch worden de sub-objecten van `vl` gebruikt binnen die JavaScript componenten
 
+import { VlFormElement } from '@domg-wc/elements';
+
 interface Accordion {
     dress(element: any): void;
     dressAll(): void;
@@ -24,9 +26,10 @@ interface Datepicker {
 }
 
 interface FormValidation {
-    dress(form: HTMLFormElement): void;
+    dress(form: VlFormElement): void;
+    undress(form: VlFormElement): void;
     dressAll(): void;
-    reset(): void;
+    reset(form: VlFormElement): void;
     _resetInput(el: HTMLElement): void;
 }
 

--- a/libs/elements/src/lib/form-validation/vl-form-validation.element.ts
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.element.ts
@@ -32,6 +32,7 @@ export const vlFormValidationElement = (SuperClass: Class): Class => {
 
         /**
          * Sets a custom validity message for the element.
+         * used in vl-form-validation.lib.js
          *
          * @param {string} message
          */
@@ -84,6 +85,9 @@ export const vlFormValidationElement = (SuperClass: Class): Class => {
             }
         }
 
+        /**
+         * hier worden data-vl-error & data-vl-succes ingesteld
+         */
         _observeFormValidationClasses() {
             const node = this as unknown as Node;
             const observer = new MutationObserver((mutations) => {

--- a/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
@@ -6690,7 +6690,9 @@
         var errorMessage = {
             message: obj.errorMessage,
         };
-        obj.validationConstraints.presence = errorMessage;
+
+        // enkel required instellen wanneer required uitdrukkelijk is ingesteld op het component
+        obj.validationConstraints.presence = obj && obj.required ? errorMessage : null;
 
         switch (obj.validationType) {
             case 'email':

--- a/libs/elements/src/lib/form/stories/vl-form-group.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form-group.stories.ts
@@ -5,68 +5,125 @@ import '../../form-grid/vl-form-grid.element';
 import '../../input-field/vl-input-field.element';
 import '../../form-message/vl-form-validation-message.element';
 import { formArgs, formArgTypes } from './vl-form.stories-arg';
+import { Meta, StoryFn } from '@storybook/web-components';
+import { setDefaultArgsToNothing } from '@domg-wc/common-utilities';
+import formValidationDoc from './vl-form-validation.stories-doc.mdx';
 
 export default {
     title: 'Elements/form',
     args: formArgs,
     argTypes: formArgTypes,
-};
+    parameters: {
+        docs: { page: formValidationDoc },
+    },
+} as Meta<typeof formArgs>;
 
-export const formGroup = ({ validate }: typeof formArgs) => html`
-    <div style="max-width: 800px">
-        <form is="vl-form" ?data-vl-validate=${validate}>
-            <div is="vl-form-group" data-cy="form-group">
-                <div is="vl-form-grid" data-vl-is-stacked>
-                    <div is="vl-form-column" data-vl-size="3">
-                        <label is="vl-form-label" for="name" data-vl-block>
-                            Naam
-                            <span is="vl-form-annotation-span">(verplicht)</span>
-                        </label>
-                    </div>
-                    <div is="vl-form-column" data-vl-size="9">
-                        <input
-                            name="name"
-                            autocomplete="name"
-                            is="vl-input-field"
-                            data-vl-block
-                            data-vl-required
-                            data-vl-error-message="Geef een naam in."
-                            data-vl-error-placeholder="name-error"
-                        />
-                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="name-error"></p>
-                    </div>
+export const formGroup: StoryFn<typeof formArgs> = (formParameters) => {
+    const { validate, nativeValidation } = setDefaultArgsToNothing(formParameters, formArgs);
+    return html`
+        <div style="max-width: 800px">
+            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+                <div is="vl-form-group" data-cy="form-group">
+                    <div is="vl-form-grid" data-vl-is-stacked>
+                        <div is="vl-form-column" data-vl-size="3">
+                            <label is="vl-form-label" for="name" data-vl-block>
+                                Naam
+                                <span is="vl-form-annotation-span">(verplicht)</span>
+                            </label>
+                        </div>
+                        <div is="vl-form-column" data-vl-size="9">
+                            <input
+                                id="name"
+                                name="name"
+                                autocomplete="name"
+                                is="vl-input-field"
+                                data-vl-block
+                                data-vl-required
+                                data-vl-error-message="Geef een naam in."
+                                data-vl-error-placeholder="name-error"
+                            />
+                            <p is="vl-form-validation-message" data-vl-error data-vl-error-id="name-error"></p>
+                        </div>
 
-                    <div is="vl-form-column" data-vl-size="3">
-                        <label is="vl-form-label" for="firstname" data-vl-block>
-                            Voornaam
-                            <span is="vl-form-annotation-span">(verplicht)</span>
-                        </label>
-                    </div>
-                    <div is="vl-form-column" data-vl-size="9">
-                        <input
-                            name="firstname"
-                            autocomplete="firstname"
-                            is="vl-input-field"
-                            data-vl-block
-                            data-vl-required
-                            data-vl-error-message="Geef een voornaam in."
-                            data-vl-error-placeholder="firstname-error"
-                        />
-                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="firstname-error"></p>
-                    </div>
-
-                    <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                        <div is="vl-action-group">
-                            <button is="vl-button" type="submit">Versturen</button>
-                            <a is="vl-link" href="#">
-                                <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
-                                Annuleren
-                            </a>
+                        <div is="vl-form-column" data-vl-size="3">
+                            <label is="vl-form-label" for="firstname" data-vl-block>
+                                Voornaam
+                                <span is="vl-form-annotation-span">(verplicht)</span>
+                            </label>
+                        </div>
+                        <div is="vl-form-column" data-vl-size="9">
+                            <input
+                                id="firstname"
+                                name="firstname"
+                                autocomplete="given-name"
+                                is="vl-input-field"
+                                data-vl-block
+                                data-vl-required
+                                data-vl-error-message="Geef een voornaam in."
+                                data-vl-error-placeholder="firstname-error"
+                            />
+                            <p is="vl-form-validation-message" data-vl-error data-vl-error-id="firstname-error"></p>
                         </div>
                     </div>
                 </div>
-            </div>
-        </form>
-    </div>
-`;
+                <div is="vl-form-group" data-cy="form-group">
+                    <div is="vl-form-grid" data-vl-is-stacked>
+                        <div is="vl-form-column" data-vl-size="3">
+                            <label is="vl-form-label" for="street" data-vl-block>
+                                Straat
+                                <span is="vl-form-annotation-span">(verplicht)</span>
+                            </label>
+                        </div>
+                        <div is="vl-form-column" data-vl-size="9">
+                            <input
+                                id="street"
+                                name="street"
+                                autocomplete="address-line1"
+                                is="vl-input-field"
+                                data-vl-block
+                                data-vl-required
+                                data-vl-error-message="Geef een straat in."
+                                data-vl-error-placeholder="street-error"
+                            />
+                            <p is="vl-form-validation-message" data-vl-error data-vl-error-id="street-error"></p>
+                        </div>
+
+                        <div is="vl-form-column" data-vl-size="3">
+                            <label is="vl-form-label" for="city" data-vl-block>
+                                Stad
+                                <span is="vl-form-annotation-span">(verplicht)</span>
+                            </label>
+                        </div>
+                        <div is="vl-form-column" data-vl-size="9">
+                            <input
+                                id="city"
+                                name="city"
+                                autocomplete="address-level2"
+                                is="vl-input-field"
+                                data-vl-block
+                                data-vl-required
+                                data-vl-error-message="Geef een stad in."
+                                data-vl-error-placeholder="city-error"
+                            />
+                            <p is="vl-form-validation-message" data-vl-error data-vl-error-id="city-error"></p>
+                        </div>
+
+                        <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                            <div is="vl-action-group">
+                                <button is="vl-button" type="submit">Versturen</button>
+                                <a is="vl-link" href="#">
+                                    <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
+                                    Annuleren
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    `;
+};
 formGroup.storyName = 'vl-form - group';
+formGroup.args = {
+    validate: true,
+};

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
@@ -14,7 +14,7 @@ import { VlFormValidation, VlFormElement } from '@domg-wc/elements';
 <form is="vl-form"></form>
 ```
 
-<DocsStory id="elements-form--form-validation" />
+<DocsStory id="elements-form--form-default" />
 
 ## Configuratie
 
@@ -23,9 +23,15 @@ import { VlFormValidation, VlFormElement } from '@domg-wc/elements';
 ## Info
 > `vl-form-validation` element gebruikt achterliggend `validate.js` 0.12 ([http://validatejs.org/](http://validatejs.org/)).
 
-Het kenmerk `[data-validate-form]` is vereist voor het formulierelement.
+Het attribuut `[data-validate-form]` is vereist voor het formulierelement.
 
-Standaard zal de HTML5-validatie van de browser deactiveren.
+<DocsStory id="elements-form--form-validation" />
+
+### Native validation
+
+Standaard zal de HTML5-validatie van de browser gedeactiveerd worden en word `novalidate` attribuut toegevoegd. [Zie hier voor meer info op MDN.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#novalidate)
+
+Als je toch native HTML validation wil toelaten, moet je het attribuut `data-vl-native-validation` toevoegen.
 
 ### Reset
 
@@ -38,6 +44,14 @@ Om de `form-validation` te laten werken voor een control moet je uitdrukkelijk `
 Je vindt een voorbeeld hieronder; naam is verplicht en voornaam is niet verplicht.
 
 <DocsStory id="elements-form--form-validation-optional" />
+
+### Group
+
+Met `vl-form-group` wordt styling toegevoegd om makkelijker te onderscheiden tussen verschillende form controls.
+
+Zie voorbeeld hieronder:
+
+<DocsStory id="elements-form--form-group" />
 
 
 ## Referenties

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
@@ -21,15 +21,24 @@ import { VlFormValidation, VlFormElement } from '@domg-wc/elements';
 <ArgsTable story={PRIMARY_STORY} />
 
 ## Info
-Info and options
+> `vl-form-validation` element gebruikt achterliggend `validate.js` 0.12 ([http://validatejs.org/](http://validatejs.org/)).
 
 Het kenmerk `[data-validate-form]` is vereist voor het formulierelement.
 
-Als het formulier geen validatie vereist, stel dan het `[novalidate]` attribuut in. Dit voorkomt dat de standaard HTML5-validatie van de browser wordt geactiveerd.
+Standaard zal de HTML5-validatie van de browser deactiveren.
 
-Als u een formulier opnieuw instelt, worden validatiefouten automatisch gereset. Als u validaties expliciet opnieuw wilt instellen (bijvoorbeeld na het verzenden aan de clientzijde), kunt u `vl.formValidation.reset(formEl)` aanroepen
+### Reset
 
-`vl-form-validation` element gebruikt achterliggend `validate.js` 0.12 ([http://validatejs.org/](http://validatejs.org/)).
+Als u een formulier opnieuw instelt, worden validatiefouten automatisch gereset. Als u validaties uitdrukkelijk opnieuw wilt instellen (bijvoorbeeld na het verzenden aan de clientzijde), kunt u `vl.formValidation.reset(formEl)` aanroepen
+
+### Required
+
+Om de `form-validation` te laten werken voor een control moet je uitdrukkelijk `data-vl-required` op het te valideren element zetten. Anders wordt het element als een optioneel invoerveld gezien.
+
+Je vindt een voorbeeld hieronder; naam is verplicht en voornaam is niet verplicht.
+
+<DocsStory id="elements-form--form-validation-optional" />
+
 
 ## Referenties
 

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
@@ -13,8 +13,8 @@ export default {
     args: formArgs,
     argTypes: formArgTypes,
     parameters: {
-        docs: { page: formValidationDoc }
-    }
+        docs: { page: formValidationDoc },
+    },
 } as Meta<typeof formArgs>;
 
 export const formValidation: StoryFn<typeof formArgs> = ({ validate }: typeof formArgs) => html`
@@ -29,6 +29,7 @@ export const formValidation: StoryFn<typeof formArgs> = ({ validate }: typeof fo
                 </div>
                 <div is="vl-form-column" data-vl-size="9">
                     <input
+                        id="name"
                         name="name"
                         autocomplete="name"
                         is="vl-input-field"
@@ -48,8 +49,9 @@ export const formValidation: StoryFn<typeof formArgs> = ({ validate }: typeof fo
                 </div>
                 <div is="vl-form-column" data-vl-size="9">
                     <input
+                        id="firstname"
                         name="firstname"
-                        autocomplete="firstname"
+                        autocomplete="given-name"
                         is="vl-input-field"
                         data-vl-block
                         data-vl-required
@@ -73,3 +75,61 @@ export const formValidation: StoryFn<typeof formArgs> = ({ validate }: typeof fo
     </div>
 `;
 formValidation.storyName = 'vl-form - with validation';
+
+export const formValidationOptional: StoryFn<typeof formArgs> = ({ validate }: typeof formArgs) => html`
+    <div style="max-width: 800px">
+        <form is="vl-form" ?data-vl-validate=${validate}>
+            <div is="vl-form-grid" data-vl-is-stacked>
+                <div is="vl-form-column" data-vl-size="3">
+                    <label is="vl-form-label" for="name" data-vl-block>
+                        Naam
+                        <span is="vl-form-annotation-span">(verplicht)</span>
+                    </label>
+                </div>
+                <div is="vl-form-column" data-vl-size="9">
+                    <input
+                        id="name"
+                        name="name"
+                        autocomplete="name"
+                        is="vl-input-field"
+                        data-vl-block
+                        data-vl-required
+                        data-vl-error-message="Geef een naam in."
+                        data-vl-error-placeholder="name-error"
+                    />
+                    <p is="vl-form-validation-message" data-vl-error data-vl-error-id="name-error"></p>
+                </div>
+
+                <div is="vl-form-column" data-vl-size="3">
+                    <label is="vl-form-label" for="firstname" data-vl-block>
+                        Voornaam
+                        <span is="vl-form-annotation-span">(verplicht)</span>
+                    </label>
+                </div>
+                <div is="vl-form-column" data-vl-size="9">
+                    <input
+                        id="firstname"
+                        name="firstname"
+                        autocomplete="given-name"
+                        is="vl-input-field"
+                        data-vl-block
+                        data-vl-error-message="Geef een voornaam in."
+                        data-vl-error-placeholder="firstname-error"
+                    />
+                    <p is="vl-form-validation-message" data-vl-error data-vl-error-id="firstname-error"></p>
+                </div>
+
+                <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                    <div is="vl-action-group">
+                        <button is="vl-button" type="submit">Versturen</button>
+                        <a is="vl-link" href="#">
+                            <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
+                            Annuleren
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+`;
+formValidationOptional.storyName = 'vl-form - with validation optional';

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
@@ -7,6 +7,7 @@ import '../../form-message/vl-form-validation-message.element';
 import { formArgs, formArgTypes } from './vl-form.stories-arg';
 import formValidationDoc from './vl-form-validation.stories-doc.mdx';
 import { Meta, StoryFn } from '@storybook/web-components';
+import { setDefaultArgsToNothing } from '@domg-wc/common-utilities';
 
 export default {
     title: 'Elements/form',
@@ -17,68 +18,74 @@ export default {
     },
 } as Meta<typeof formArgs>;
 
-export const formValidation: StoryFn<typeof formArgs> = ({ validate }: typeof formArgs) => html`
-    <div style="max-width: 800px">
-        <form is="vl-form" ?data-vl-validate=${validate}>
-            <div is="vl-form-grid" data-vl-is-stacked>
-                <div is="vl-form-column" data-vl-size="3">
-                    <label is="vl-form-label" for="name" data-vl-block>
-                        Naam
-                        <span is="vl-form-annotation-span">(verplicht)</span>
-                    </label>
-                </div>
-                <div is="vl-form-column" data-vl-size="9">
-                    <input
-                        id="name"
-                        name="name"
-                        autocomplete="name"
-                        is="vl-input-field"
-                        data-vl-block
-                        data-vl-required
-                        data-vl-error-message="Geef een naam in."
-                        data-vl-error-placeholder="name-error"
-                    />
-                    <p is="vl-form-validation-message" data-vl-error data-vl-error-id="name-error"></p>
-                </div>
+export const formValidation: StoryFn<typeof formArgs> = (formParameters: typeof formArgs) => {
+    const { validate, nativeValidation } = setDefaultArgsToNothing(formParameters, formArgs);
+    return html`
+        <div style="max-width: 800px">
+            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+                <div is="vl-form-grid" data-vl-is-stacked>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="name" data-vl-block>
+                            Naam
+                            <span is="vl-form-annotation-span">(verplicht)</span>
+                        </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input
+                            id="name"
+                            name="name"
+                            autocomplete="name"
+                            is="vl-input-field"
+                            data-vl-block
+                            data-vl-required
+                            data-vl-error-message="Geef een naam in."
+                            data-vl-error-placeholder="name-error"
+                        />
+                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="name-error"></p>
+                    </div>
 
-                <div is="vl-form-column" data-vl-size="3">
-                    <label is="vl-form-label" for="firstname" data-vl-block>
-                        Voornaam
-                        <span is="vl-form-annotation-span">(verplicht)</span>
-                    </label>
-                </div>
-                <div is="vl-form-column" data-vl-size="9">
-                    <input
-                        id="firstname"
-                        name="firstname"
-                        autocomplete="given-name"
-                        is="vl-input-field"
-                        data-vl-block
-                        data-vl-required
-                        data-vl-error-message="Geef een voornaam in."
-                        data-vl-error-placeholder="firstname-error"
-                    />
-                    <p is="vl-form-validation-message" data-vl-error data-vl-error-id="firstname-error"></p>
-                </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="firstname" data-vl-block>
+                            Voornaam
+                            <span is="vl-form-annotation-span">(verplicht)</span>
+                        </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input
+                            id="firstname"
+                            name="firstname"
+                            autocomplete="given-name"
+                            is="vl-input-field"
+                            data-vl-block
+                            data-vl-required
+                            data-vl-error-message="Geef een voornaam in."
+                            data-vl-error-placeholder="firstname-error"
+                        />
+                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="firstname-error"></p>
+                    </div>
 
-                <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                    <div is="vl-action-group">
-                        <button is="vl-button" type="submit">Versturen</button>
-                        <a is="vl-link" href="#">
-                            <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
-                            Annuleren
-                        </a>
+                    <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                        <div is="vl-action-group">
+                            <button is="vl-button" type="submit">Versturen</button>
+                            <a is="vl-link" href="#">
+                                <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
+                                Annuleren
+                            </a>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </form>
-    </div>
-`;
+            </form>
+        </div>
+    `;
+};
 formValidation.storyName = 'vl-form - with validation';
+formValidation.args = {
+    validate: true,
+};
 
-export const formValidationOptional: StoryFn<typeof formArgs> = ({ validate }: typeof formArgs) => html`
+export const formValidationOptional: StoryFn<typeof formArgs> = ({ validate, nativeValidation }) => html`
     <div style="max-width: 800px">
-        <form is="vl-form" ?data-vl-validate=${validate}>
+        <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
             <div is="vl-form-grid" data-vl-is-stacked>
                 <div is="vl-form-column" data-vl-size="3">
                     <label is="vl-form-label" for="name" data-vl-block>
@@ -101,10 +108,7 @@ export const formValidationOptional: StoryFn<typeof formArgs> = ({ validate }: t
                 </div>
 
                 <div is="vl-form-column" data-vl-size="3">
-                    <label is="vl-form-label" for="firstname" data-vl-block>
-                        Voornaam
-                        <span is="vl-form-annotation-span">(verplicht)</span>
-                    </label>
+                    <label is="vl-form-label" for="firstname" data-vl-block> Voornaam </label>
                 </div>
                 <div is="vl-form-column" data-vl-size="9">
                     <input
@@ -133,3 +137,6 @@ export const formValidationOptional: StoryFn<typeof formArgs> = ({ validate }: t
     </div>
 `;
 formValidationOptional.storyName = 'vl-form - with validation optional';
+formValidationOptional.args = {
+    validate: true,
+};

--- a/libs/elements/src/lib/form/stories/vl-form.stories-arg.ts
+++ b/libs/elements/src/lib/form/stories/vl-form.stories-arg.ts
@@ -1,18 +1,28 @@
 import { CATEGORIES, TYPES } from '@domg-wc/common-utilities';
-import { Args, ArgTypes } from '@storybook/web-components';
+import { ArgTypes } from '@storybook/web-components';
 
-export const formArgs: Args = {
-    validate: true,
+export const formArgs = {
+    validate: false,
+    nativeValidation: false,
 };
 
-export const formArgTypes: ArgTypes = {
+export const formArgTypes: ArgTypes<typeof formArgs> = {
     validate: {
         name: 'data-vl-validate',
-        description: 'Attribute is used to indicate that the input fields validation should be enabled.',
+        description: 'Validatie van invoervelden inschakelen.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: 'false' },
+            defaultValue: { summary: formArgs.validate },
+        },
+    },
+    nativeValidation: {
+        name: 'data-vl-native-validation',
+        description: 'Stelt native validation in.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: formArgs.validate },
         },
     },
 };

--- a/libs/elements/src/lib/form/stories/vl-form.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form.stories.ts
@@ -4,49 +4,58 @@ import '../../button/vl-button.element';
 import '../../form-grid/vl-form-grid.element';
 import '../../form-message/vl-form-annotation.element';
 import { formArgs, formArgTypes } from './vl-form.stories-arg';
+import { Meta, StoryFn } from '@storybook/web-components';
+import { setDefaultArgsToNothing } from '@domg-wc/common-utilities';
+import formValidationDoc from './vl-form-validation.stories-doc.mdx';
 
 export default {
     title: 'Elements/form',
     args: formArgs,
     argTypes: formArgTypes,
-};
+    parameters: {
+        docs: { page: formValidationDoc },
+    },
+} as Meta<typeof formArgs>;
 
-export const formDefault = ({ validate }: typeof formArgs) => html`
-    <div style="max-width: 800px">
-        <form is="vl-form" data-cy="form-default" ?data-vl-validate=${validate}>
-            <div is="vl-form-grid" data-vl-is-stacked>
-                <div is="vl-form-column" data-vl-size="3">
-                    <label is="vl-form-label" for="name" data-vl-block>
-                        Naam
-                        <span is="vl-form-annotation-span">(verplicht)</span>
-                    </label>
-                </div>
-                <div is="vl-form-column" data-vl-size="9">
-                    <input name="name" autocomplete="name" is="vl-input-field" data-vl-block />
-                </div>
+export const formDefault: StoryFn<typeof formArgs> = (formParameters: typeof formArgs) => {
+    const { validate, nativeValidation } = setDefaultArgsToNothing(formParameters, formArgs);
+    return html`
+        <div style="max-width: 800px">
+            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+                <div is="vl-form-grid" data-vl-is-stacked>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="name" data-vl-block> Naam </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="name" name="name" autocomplete="name" is="vl-input-field" data-vl-block />
+                    </div>
 
-                <div is="vl-form-column" data-vl-size="3">
-                    <label is="vl-form-label" for="firstname" data-vl-block>
-                        Voornaam
-                        <span is="vl-form-annotation-span">(verplicht)</span>
-                    </label>
-                </div>
-                <div is="vl-form-column" data-vl-size="9">
-                    <input name="firstname" autocomplete="firstname" is="vl-input-field" data-vl-block />
-                </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="firstname" data-vl-block> Voornaam </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input
+                            id="firstname"
+                            name="firstname"
+                            autocomplete="given-name"
+                            is="vl-input-field"
+                            data-vl-block
+                        />
+                    </div>
 
-                <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                    <div is="vl-action-group">
-                        <button is="vl-button" type="submit">Versturen</button>
-                        <a is="vl-link" href="#">
-                            <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
-                            Annuleren
-                        </a>
+                    <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                        <div is="vl-action-group">
+                            <button is="vl-button" type="submit">Versturen</button>
+                            <a is="vl-link" href="#">
+                                <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
+                                Annuleren
+                            </a>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </form>
-    </div>
-`;
+            </form>
+        </div>
+    `;
+};
 formDefault.storyName = 'vl-form - default';
 formDefault.args = { validate: false };

--- a/libs/elements/src/lib/form/vl-form.element.ts
+++ b/libs/elements/src/lib/form/vl-form.element.ts
@@ -13,7 +13,7 @@ import './vl-form-group.element';
 @webComponent('vl-form', { extends: 'form' })
 export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
     static get _observedAttributes() {
-        return ['target', 'action', 'validate'];
+        return ['target', 'action', 'validate', 'native-validation'];
     }
 
     static get _targetElementName() {
@@ -76,7 +76,10 @@ export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
     }
 
     _disableNativeValidation() {
-        this.setAttribute('novalidate', '');
+        const nativeValidationEnabled = this.getAttribute('data-vl-native-validation') !== null;
+        if (!nativeValidationEnabled) {
+            this.setAttribute('novalidate', '');
+        }
     }
 
     _addClasses() {


### PR DESCRIPTION
- Vroeger werd elke form element ingesteld als required, met of zonder het required attribuut. Dit werkt nu zoals gedocumenteerd.
- Standaard wordt native validation uitgezet. Met nieuwe native-validation attribuut kan dit ook terug aangezet worden.
- Vroeger konden achteraf toegevoegde form elementen niet meer gevalideerd worden. Nu wordt er geluisterd naar nieuwe elementen en worden de validatie daarvoor opgezet.
- Storybook verbeterd & cypress testen toegevoegd.