### PR TITLE
feat: UIG-2502 - vl-map-layer - voorkom dubbele styling op VlMapLayer

### DIFF
--- a/libs/map/src/lib/components/layer/vl-map-layer.ts
+++ b/libs/map/src/lib/components/layer/vl-map-layer.ts
@@ -1,5 +1,6 @@
 import { BaseElementOfType } from '@domg-wc/common-utilities';
 import { VlMap } from '../../vl-map';
+import { VlMapLayerStyle } from '../layer-style/vl-map-layer-style';
 
 /**
  * VlMapLayer
@@ -23,6 +24,7 @@ export abstract class VlMapLayer extends BaseElementOfType(HTMLElement) {
     }
 
     __counter: number;
+    __styleCount: number;
     __ready: boolean;
     _layer: any;
     _source: any;
@@ -42,7 +44,21 @@ export abstract class VlMapLayer extends BaseElementOfType(HTMLElement) {
             await this.mapElement.ready;
             this.mapElement.addLayer(this._layer);
         }
+        // bereken hoeveel VlMapStyle elementen er actief zouden moeten zijn
+        this.__styleCount = this.getStyleCount();
         this.__markAsReady();
+    }
+
+    /**
+     * bereken op basis van direct child elements hoeveel er van het type VlMapLayerStyle zijn
+     */
+    getStyleCount(): number {
+        const childNodeList = (<any>this).querySelectorAll(':scope > *');
+        return Array.from(childNodeList)?.filter((child) => child instanceof VlMapLayerStyle).length;
+    }
+
+    disconnectedCallback() {
+        this._layer?.dispose();
     }
 
     static get _counter() {
@@ -154,6 +170,11 @@ export abstract class VlMapLayer extends BaseElementOfType(HTMLElement) {
     }
 
     get _styles() {
+        // als er meer styles zijn op het VlMapLayer, dan dat er VlMapLayerStyle elementen zijn
+        // dan verwijderen we de dubbels
+        if (this.__styles.length > this.__styleCount) {
+            this.__styles = Array.from(new Set(this.__styles));
+        }
         return this.__styles;
     }
 


### PR DESCRIPTION
gezien dat bij renderen van de `vl-map-layer` de aanwezige styles worden ingesteld, zullen die telkens opnieuw worden ingesteld als de `vl-map-layer` bv. naar een andere node in de DOM wordt verplaatst (waar deze use case omgaat)

in deze PR doe ik het volgende
- wanneer `vl-map-layer` disconnected wordt, roep ik `dispose()` aan om die op te ruimen
- bij het ophalen van de `styles` wordt gecontroleerd of er duplicates zijn en zoja, worden die eruit gefilterd
- idealiter voorkomen we dat de duplicates in de eerste plaats worden gezet, maar dit is een beetje problematisch gezien `vl-map-layer` eigenlijk een abstracte klasse is en bv. `vl-map-wms-layer`, `vl-map-vector-layer` hier van overerven en daarin de "styles" worden ingesteld (in functie `set style(style)`)