### PR TITLE
feat: UIG-2520 - vl-upload - uitgebreid met duplicaat detectie op basis van bestandsinhoud

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/upload/vl-upload.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/upload/vl-upload.stories.cy.ts
@@ -150,6 +150,15 @@ describe('story vl-upload - default', () => {
         cy.get('vl-upload').shadow().find('.dz-error-message').should('contain', errorMessage, '');
     });
 
+    it('when adding duplicate files, only one will be added & duplicateRemoved event will be thrown', () => {
+        cy.visit(uploadUrl.concat(`&args=maxFiles:2;disallowDuplicates:true`));
+
+        shouldAddPdfFiles(2);
+        shouldHaveUploadFiles(1);
+        cy.createStubForEvent('vl-upload', 'duplicateRemoved');
+        cy.get('@duplicateRemoved').should('have.been.called');
+    });
+
     it('when adding a file that is bigger than allowed, it will generate an error', () => {
         const errorMessage = 'Dit bestand heeft de maximale bestandsgrootte overschreden';
         cy.visit(

--- a/libs/components/src/lib/upload/stories/vl-upload.stories-args.ts
+++ b/libs/components/src/lib/upload/stories/vl-upload.stories-args.ts
@@ -20,6 +20,7 @@ export const uploadArgs: Args = {
     title: '',
     url: 'http://httpbin.org/post',
     onChange: action('change'),
+    onDuplicateRemoved: action('duplicateRemoved'),
 };
 
 export const uploadArgTypes: ArgTypes = {
@@ -60,7 +61,8 @@ export const uploadArgTypes: ArgTypes = {
     },
     disallowDuplicates: {
         name: 'data-vl-disallow-duplicates',
-        description: 'Als dit op `true` staat, is het niet toegelaten om dezelfde bijlage meerdere keren te uploaden.',
+        description:
+            'Bepaalt dat het niet is toegelaten om dezelfde bijlage meerdere keren te uploaden. Niet reactief.',
         table: {
             type: {
                 summary: TYPES.BOOLEAN,
@@ -220,6 +222,15 @@ export const uploadArgTypes: ArgTypes = {
         description: 'Afgevuurd na het toevoegen of verwijderen van een bestand of een succesvolle upload',
         table: {
             type: { summary: 'change' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onDuplicateRemoved: {
+        name: 'duplicateRemoved',
+        description:
+            'Afgevuurd nadat een file is verwijderd die dezelfde content had als een file die reeds geselecteerd was.',
+        table: {
+            type: { summary: 'duplicateRemoved' },
             category: CATEGORIES.EVENTS,
         },
     },

--- a/libs/components/src/lib/upload/stories/vl-upload.stories-doc.mdx
+++ b/libs/components/src/lib/upload/stories/vl-upload.stories-doc.mdx
@@ -1,4 +1,5 @@
-import { ArgsTable, DocsStory, PRIMARY_STORY } from '@storybook/addon-docs';
+import { ArgsTable, DocsStory, PRIMARY_STORY, Source } from '@storybook/addon-docs';
+import addDuplicateWarning from '!raw-loader!./vl-upload.stories-util';
 
 # Upload
 
@@ -48,6 +49,22 @@ In bepaalde instanties is het gewenst dat de `vl-upload` validatie gereset wordt
 Dit gaat de validatie resetten van de `vl-form` tot de welke deze `vl-upload` behoort.
 
 <DocsStory id="components-upload--upload-in-form" />
+
+### Duplicaat detectie
+
+Het is mogelijk om duplicaten van eenzelfde bestand te vermijden met het `disallow-duplicates`-attribuut. Achterliggend wordt er gecontroleerd op ofwel bestandsnaam & aantal bytes, of word een hex string vergeleken met eerder toegevoegde bestanden.
+In dat geval worden de duplicaten verwijderd.
+
+Wanneer een duplicaat wordt verwijderd kan je luisteren naar `duplicateRemoved` event om de gebruiker te informeren dat bestanden werden verwijderd wegens duplicaat detectie.
+
+Onderstaand voorbeeld is ook geïntegreerd in de 2 stories die hierboven vermeld staan.
+
+<details>
+    <summary>code voorbeeld voor een waarschuwing te tonen bij duplicaat detectie </summary>
+    <Source code={addDuplicateWarning} language="ts" dark={true} format={true} />
+</details>
+
+## Referenties
 
 ### Digitaal Vlaanderen
 

--- a/libs/components/src/lib/upload/stories/vl-upload.stories-util.ts
+++ b/libs/components/src/lib/upload/stories/vl-upload.stories-util.ts
@@ -1,0 +1,19 @@
+const addDuplicateWarning = () => {
+    const vlUpload = document.querySelector('#vl-upload');
+    const vlWarningDuplicate = document.querySelector('#warning-duplicate');
+    if (!vlWarningDuplicate) {
+        vlUpload?.insertAdjacentHTML(
+            'afterend',
+            `<vl-alert
+                    id="warning-duplicate"
+                    data-vl-type="warning"
+                    data-vl-icon="warning"
+                    data-vl-title="Waarschuwing"
+                    data-vl-closable="">
+                    <p>Er werden 1 of meer kopieën van hetzelfde bestand gedetecteerd. De kopieën werden verwijderd.</p>
+                  </vl-alert>`
+        );
+    }
+};
+
+export default addDuplicateWarning;

--- a/libs/components/src/lib/upload/stories/vl-upload.stories.ts
+++ b/libs/components/src/lib/upload/stories/vl-upload.stories.ts
@@ -4,6 +4,7 @@ import { uploadArgs, uploadArgTypes } from './vl-upload.stories-args';
 import uploadDoc from './vl-upload.stories-doc.mdx';
 import { nothing } from 'lit';
 import { Meta, StoryFn } from '@storybook/web-components';
+import addDuplicateWarning from './vl-upload.stories-util';
 
 export default {
     title: 'Components/upload',
@@ -34,7 +35,8 @@ export const UploadDefault: StoryFn<typeof uploadArgs> = ({
     url,
     resetFormOnClear,
     onChange,
-}: typeof uploadArgs) => {
+    onDuplicateRemoved,
+}) => {
     return html`
         <vl-upload
             data-vl-url=${url}
@@ -55,6 +57,10 @@ export const UploadDefault: StoryFn<typeof uploadArgs> = ({
             ?data-vl-success=${success}
             ?data-vl-reset-form-on-clear=${resetFormOnClear}
             @change=${(event: CustomEvent) => onChange(event.detail)}
+            @duplicateRemoved=${(event: CustomEvent) => {
+                addDuplicateWarning();
+                onDuplicateRemoved(event.detail);
+            }}
             id="vl-upload"
         ></vl-upload>
     `;
@@ -80,6 +86,7 @@ export const UploadInForm: StoryFn<typeof uploadArgs> = ({
     url,
     resetFormOnClear,
     onChange,
+    onDuplicateRemoved,
 }: typeof uploadArgs) => {
     return html`
         <form is="vl-form" data-vl-validate data-validate-form>
@@ -107,6 +114,10 @@ export const UploadInForm: StoryFn<typeof uploadArgs> = ({
                             ?data-vl-success=${success}
                             ?data-vl-reset-form-on-clear=${resetFormOnClear}
                             @change=${(event: CustomEvent) => onChange(event.detail)}
+                            @duplicateRemoved=${(event: CustomEvent) => {
+                                addDuplicateWarning();
+                                onDuplicateRemoved(event.detail);
+                            }}
                             id="vl-upload"
                         ></vl-upload>
                         <p

--- a/libs/components/src/lib/upload/vl-upload.component.ts
+++ b/libs/components/src/lib/upload/vl-upload.component.ts
@@ -237,28 +237,35 @@ export class VlUploadComponent extends vlFormValidationElement(BaseHTMLElement) 
         if (!this._dressed) {
             vl.upload.dress(this._upload);
             this._dressFormValidation();
-            this._dropzone.on('addedfile', () => this.__triggerChange());
-            this._dropzone.on('removedfile', () => {
+            this._dropzone.on('addedfile', (file: File) => this.__triggerChange(file));
+            this._dropzone.on('removedfile', (file: File) => {
                 const customAction = () => {
                     if (this.hasAttribute('reset-form-on-clear')) {
                         this.form.reset();
                     }
                 };
-                this.__triggerChange(customAction);
+                this.__triggerChange(file, customAction);
             });
             this._dropzone.on('success', (file: any, response: any) => {
                 file.responseBody = response;
-                this.__triggerChange();
+                this.__triggerChange(file);
             });
+            this._dropzone.on('duplicateRemoved', (file: File) => this.__duplicateRemoved(file));
             this._dropzone.timeout = 0; // 0 value will disable the connection timeout
         }
     }
 
     // TODO meer specifieke events te definiëren, eenmaal we breaking changes kunnen introduceren
-    __triggerChange(customAction?: () => void): void {
+    __triggerChange(data: unknown, customAction?: () => void): void {
         setTimeout(() => {
-            this.dispatchEvent(new Event('change'));
+            this.dispatchEvent(new CustomEvent('change', { detail: { data } }));
             if (customAction) customAction();
+        });
+    }
+
+    __duplicateRemoved(file: File): void {
+        setTimeout(() => {
+            this.dispatchEvent(new CustomEvent('duplicateRemoved', { detail: { data: file } }));
         });
     }
 


### PR DESCRIPTION
Afnemer wou mogelijkheid gebruiker op de hoogte te stellen wanneer bestanden werden verwijderd en ook dat de bestandsinhoud zou gecontroleerd worden reeds in de browser.

---

- Vroeger gebeurde duplicaat detectie enkel op basis van filename & aantal kilobytes. Hierdoor kan het zijn dat identieke bestanden met verschillende bestandsnaam toch niet eruit gefilterd werden. Duplicaat detectie is nu uitgebreid met vergelijking van hashes op basis van bestandsinhoud
- Vroeger werd bij duplicaat detectie enkel het laatst toegevoegde bestand behouden, nu wordt die verwijderd en het origineel behouden.
- `data-vl-disallow-duplicates`-attribuut moet nu enkel aanwezig zijn ipv expliciet op `true` te staan
- Storybook verbeteren & cypress testen toevoegen
- Uitgebreid met event om te melden wanneer een bestand verwijderd werd bij het detecteren van duplicaten
- DV-broncode geannoteerd

---

Gebruik hier de native SubtleCrypto API om hashes te maken, zie: [https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto#hashing_a_file](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto#hashing_a_file)

ter info, voor de `digest()` method van de SubtleCrypto API lijkt alles ok voor alle moderne browsers, ook op mobile