### PR TITLE
fix: UIG-2569 - vl-map-layer-switcher - nu worden enkel nodes van type Element beschouwd om vlMapLayers te bepalen

### DIFF
--- a/libs/map/src/lib/components/layer-switcher/vl-map-layer-switcher.ts
+++ b/libs/map/src/lib/components/layer-switcher/vl-map-layer-switcher.ts
@@ -123,13 +123,13 @@ export class VlMapLayerSwitcher extends LitElement {
         this.layerObserver = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
                 mutation.addedNodes.forEach((node) => {
-                    if ((node as HTMLElement).hasAttribute('data-vl-is-layer')) {
+                    if (node instanceof HTMLElement && node.hasAttribute('data-vl-is-layer')) {
                         this.vlMapLayers = [...this.vlMapLayers, node as unknown as VlMapLayer];
                     }
                 });
 
                 mutation.removedNodes.forEach((node) => {
-                    if ((node as HTMLElement).hasAttribute('data-vl-is-layer')) {
+                    if (node instanceof HTMLElement && node.hasAttribute('data-vl-is-layer')) {
                         this.vlMapLayers = this.vlMapLayers.filter(
                             (layer) => (node as unknown as VlMapLayer) !== layer
                         );


### PR DESCRIPTION
fix: UIG-2569 - vl-map-layer-switcher - beschouw enkel HTMLElement nodes om vlMapLayers te bepalen

Voorheen werd er geen verschil gemaakt in afhandeling tussen node types. Wanneer de node van type text is, is hasAttribute('data-vl-is-layer') echter niet aanroepbaar.

Dit is nu gefixt door enkel hasAttribute('data-vl-is-layer') aan te roepen als de node van type HTMLElement is.

