### PR TITLE
fix: UIG-2557 - WMTS request corrigeren

### DIFF
--- a/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
@@ -6,6 +6,8 @@ export const mapWmtsLayerArgs = {
     ...mapLayerArgs,
     layer: '',
     url: '',
+    matrixSet: 'BPL72VL',
+    matrixPrefix: false
 };
 
 export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
@@ -30,4 +32,23 @@ export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
             defaultValue: { summary: mapWmtsLayerArgs.url },
         },
     },
+    matrixSet: {
+        name: 'data-vl-matrix-set',
+        description: 'De matrix set van de WMTS.<br>Dit attribuut is niet reactief.',
+        type: { name: TYPES.STRING, required: false },
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWmtsLayerArgs.matrixSet }
+        }
+    },
+    matrixPrefix: {
+        name: 'data-vl-matrix-prefix',
+        description: 'Definieert of de matrix moet geprefixt worden met de matrix set.<br/>Dit attribuut is niet reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWmtsLayerArgs.matrixPrefix },
+        },
+    }
 };

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -87,7 +87,7 @@ export class VlMapWmtsLayer extends VlMapLayer {
     }
 
     get __prefixMatrix(): boolean {
-        return this.getAttribute('matrix-prefix') != undefined;
+        return this.getAttribute('matrix-prefix') !== undefined;
     }
 
     get __grbTileLimits() {

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -82,17 +82,24 @@ export class VlMapWmtsLayer extends VlMapLayer {
         return 'image/png';
     }
 
-    get __grbMatrixSet() {
-        return 'BPL72VL';
+    get __grbMatrixSet(): string {
+        return this.getAttribute('matrix-set') || "BPL72VL";
+    }
+
+    get __prefixMatrix(): boolean {
+        return this.getAttribute('matrix-prefix') != undefined;
     }
 
     get __grbTileLimits() {
         const size = OlExtent.getWidth(this._projection.getExtent()) / 256;
         const resolutions = new Array(16);
         const matrixIds = new Array(16);
+        console.log(this.__prefixMatrix);
         for (let z = 0; z < 16; ++z) {
             resolutions[z] = size / Math.pow(2, z);
-            matrixIds[z] = this.__grbMatrixSet +':'+ z;
+            matrixIds[z] = this.__prefixMatrix
+                ? this.__grbMatrixSet +':'+ z
+                : z;
         }
         return { matrixIds, resolutions };
     }

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -92,7 +92,7 @@ export class VlMapWmtsLayer extends VlMapLayer {
         const matrixIds = new Array(16);
         for (let z = 0; z < 16; ++z) {
             resolutions[z] = size / Math.pow(2, z);
-            matrixIds[z] = z;
+            matrixIds[z] = this.__grbMatrixSet +':'+ z;
         }
         return { matrixIds, resolutions };
     }

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -83,7 +83,7 @@ export class VlMapWmtsLayer extends VlMapLayer {
     }
 
     get __grbMatrixSet(): string {
-        return this.getAttribute('matrix-set') || "BPL72VL";
+        return this.getAttribute('matrix-set') || 'BPL72VL';
     }
 
     get __prefixMatrix(): boolean {
@@ -94,7 +94,6 @@ export class VlMapWmtsLayer extends VlMapLayer {
         const size = OlExtent.getWidth(this._projection.getExtent()) / 256;
         const resolutions = new Array(16);
         const matrixIds = new Array(16);
-        console.log(this.__prefixMatrix);
         for (let z = 0; z < 16; ++z) {
             resolutions[z] = size / Math.pow(2, z);
             matrixIds[z] = this.__prefixMatrix

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
@@ -18,6 +18,22 @@ const wmtsLayerFixture = async () =>
         </vl-map>
     `);
 
+const wmtsLayerWithDifferentMatrixSetFixture = async () =>
+    fixture(html`
+        <vl-map>
+            <vl-map-wmts-layer
+                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-layer="grb_sel"
+                data-vl-name="GRB Wegenkaart"
+                data-vl-min-resolution="2"
+                data-vl-max-resolution="4"
+                data-vl-matrix-set="MOCKMATRIX"
+                data-vl-matrix-prefix
+            >
+            </vl-map-wmts-layer>
+        </vl-map>
+    `);
+
 const wmtsLayerHiddenFixture = async () =>
     fixture(html`
         <vl-map>
@@ -69,25 +85,50 @@ describe('vl-map-wmts-layer', () => {
             tileGrid.getResolutions(),
             [1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625, 0.03125],
         );
+        assert.deepEqual(tileGrid.getMatrixIds(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    });
+
+    it('de matrix configuratie wordt gerespecteerd', async() => {
+        const map: any = await wmtsLayerWithDifferentMatrixSetFixture();
+        await map.ready;
+        const layers = map.map.getOverlayLayers();
+        assert.lengthOf(layers, 1);
+        const layer = layers[0];
+        const source = layer.getSource();
+        assert.isTrue(source instanceof OlWMTSSource);
+        assert.equal(source.getMatrixSet(), 'MOCKMATRIX');
+    });
+
+    it('de matrixset wordt geprefixed indien meegegeven' , async () => {
+        const map: any = await wmtsLayerWithDifferentMatrixSetFixture();
+        await map.ready;
+
+        const layers = map.map.getOverlayLayers();
+        assert.lengthOf(layers, 1);
+        const layer = layers[0];
+
+        const source = layer.getSource();
+        const tileGrid = source.getTileGrid();
         assert.deepEqual(tileGrid.getMatrixIds(), [
-            'BPL72VL:0',
-            'BPL72VL:1',
-            'BPL72VL:2',
-            'BPL72VL:3',
-            'BPL72VL:4',
-            'BPL72VL:5',
-            'BPL72VL:6',
-            'BPL72VL:7',
-            'BPL72VL:8',
-            'BPL72VL:9',
-            'BPL72VL:10',
-            'BPL72VL:11',
-            'BPL72VL:12',
-            'BPL72VL:13',
-            'BPL72VL:14',
-            'BPL72VL:15'
+            'MOCKMATRIX:0',
+            'MOCKMATRIX:1',
+            'MOCKMATRIX:2',
+            'MOCKMATRIX:3',
+            'MOCKMATRIX:4',
+            'MOCKMATRIX:5',
+            'MOCKMATRIX:6',
+            'MOCKMATRIX:7',
+            'MOCKMATRIX:8',
+            'MOCKMATRIX:9',
+            'MOCKMATRIX:10',
+            'MOCKMATRIX:11',
+            'MOCKMATRIX:12',
+            'MOCKMATRIX:13',
+            'MOCKMATRIX:14',
+            'MOCKMATRIX:15'
         ]);
     });
+
 
     it('de kaartlaag zal pas angemaakt worden na constructie zodat op moment van constructie nog niet al de attributen gekend moeten zijn', async () => {
         const map: any = await mapFixture();

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
@@ -69,7 +69,24 @@ describe('vl-map-wmts-layer', () => {
             tileGrid.getResolutions(),
             [1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625, 0.03125],
         );
-        assert.deepEqual(tileGrid.getMatrixIds(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert.deepEqual(tileGrid.getMatrixIds(), [
+            'BPL72VL:0',
+            'BPL72VL:1',
+            'BPL72VL:2',
+            'BPL72VL:3',
+            'BPL72VL:4',
+            'BPL72VL:5',
+            'BPL72VL:6',
+            'BPL72VL:7',
+            'BPL72VL:8',
+            'BPL72VL:9',
+            'BPL72VL:10',
+            'BPL72VL:11',
+            'BPL72VL:12',
+            'BPL72VL:13',
+            'BPL72VL:14',
+            'BPL72VL:15'
+        ]);
     });
 
     it('de kaartlaag zal pas angemaakt worden na constructie zodat op moment van constructie nog niet al de attributen gekend moeten zijn', async () => {


### PR DESCRIPTION
WMTS url corrigeren zodat deze voor alle type WMTS lagen werkt door te prefixen met de matrixSet

[Jira](https://www.milieuinfo.be/jira/browse/UIG-2557)
[Bamboo build](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC62)