### PR TITLE
fix: UIG-2557 hasAttribute gebruiken ipv get..

### DIFF
--- a/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
@@ -6,6 +6,8 @@ export const mapWmtsLayerArgs = {
     ...mapLayerArgs,
     layer: '',
     url: '',
+    matrixSet: 'BPL72VL',
+    matrixPrefix: false
 };
 
 export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
@@ -30,4 +32,23 @@ export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
             defaultValue: { summary: mapWmtsLayerArgs.url },
         },
     },
+    matrixSet: {
+        name: 'data-vl-matrix-set',
+        description: 'De matrix set van de WMTS.<br>Dit attribuut is niet reactief.',
+        type: { name: TYPES.STRING, required: false },
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWmtsLayerArgs.matrixSet }
+        }
+    },
+    matrixPrefix: {
+        name: 'data-vl-matrix-prefix',
+        description: 'Definieert of de matrix moet geprefixt worden met de matrix set.<br/>Dit attribuut is niet reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWmtsLayerArgs.matrixPrefix },
+        },
+    }
 };

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -82,8 +82,12 @@ export class VlMapWmtsLayer extends VlMapLayer {
         return 'image/png';
     }
 
-    get __grbMatrixSet() {
-        return 'BPL72VL';
+    get __grbMatrixSet(): string {
+        return this.getAttribute('matrix-set') || 'BPL72VL';
+    }
+
+    get __prefixMatrix(): boolean {
+        return this.getAttribute('matrix-prefix') !== undefined;
     }
 
     get __grbTileLimits() {
@@ -92,7 +96,9 @@ export class VlMapWmtsLayer extends VlMapLayer {
         const matrixIds = new Array(16);
         for (let z = 0; z < 16; ++z) {
             resolutions[z] = size / Math.pow(2, z);
-            matrixIds[z] = z;
+            matrixIds[z] = this.__prefixMatrix
+                ? this.__grbMatrixSet +':'+ z
+                : z;
         }
         return { matrixIds, resolutions };
     }

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -87,7 +87,7 @@ export class VlMapWmtsLayer extends VlMapLayer {
     }
 
     get __prefixMatrix(): boolean {
-        return this.getAttribute('matrix-prefix') !== undefined;
+        return this.hasAttribute('matrix-prefix');
     }
 
     get __grbTileLimits() {

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
@@ -18,6 +18,22 @@ const wmtsLayerFixture = async () =>
         </vl-map>
     `);
 
+const wmtsLayerWithDifferentMatrixSetFixture = async () =>
+    fixture(html`
+        <vl-map>
+            <vl-map-wmts-layer
+                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-layer="grb_sel"
+                data-vl-name="GRB Wegenkaart"
+                data-vl-min-resolution="2"
+                data-vl-max-resolution="4"
+                data-vl-matrix-set="MOCKMATRIX"
+                data-vl-matrix-prefix
+            >
+            </vl-map-wmts-layer>
+        </vl-map>
+    `);
+
 const wmtsLayerHiddenFixture = async () =>
     fixture(html`
         <vl-map>
@@ -71,6 +87,48 @@ describe('vl-map-wmts-layer', () => {
         );
         assert.deepEqual(tileGrid.getMatrixIds(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     });
+
+    it('de matrix configuratie wordt gerespecteerd', async() => {
+        const map: any = await wmtsLayerWithDifferentMatrixSetFixture();
+        await map.ready;
+        const layers = map.map.getOverlayLayers();
+        assert.lengthOf(layers, 1);
+        const layer = layers[0];
+        const source = layer.getSource();
+        assert.isTrue(source instanceof OlWMTSSource);
+        assert.equal(source.getMatrixSet(), 'MOCKMATRIX');
+    });
+
+    it('de matrixset wordt geprefixed indien meegegeven' , async () => {
+        const map: any = await wmtsLayerWithDifferentMatrixSetFixture();
+        await map.ready;
+
+        const layers = map.map.getOverlayLayers();
+        assert.lengthOf(layers, 1);
+        const layer = layers[0];
+
+        const source = layer.getSource();
+        const tileGrid = source.getTileGrid();
+        assert.deepEqual(tileGrid.getMatrixIds(), [
+            'MOCKMATRIX:0',
+            'MOCKMATRIX:1',
+            'MOCKMATRIX:2',
+            'MOCKMATRIX:3',
+            'MOCKMATRIX:4',
+            'MOCKMATRIX:5',
+            'MOCKMATRIX:6',
+            'MOCKMATRIX:7',
+            'MOCKMATRIX:8',
+            'MOCKMATRIX:9',
+            'MOCKMATRIX:10',
+            'MOCKMATRIX:11',
+            'MOCKMATRIX:12',
+            'MOCKMATRIX:13',
+            'MOCKMATRIX:14',
+            'MOCKMATRIX:15'
+        ]);
+    });
+
 
     it('de kaartlaag zal pas angemaakt worden na constructie zodat op moment van constructie nog niet al de attributen gekend moeten zijn', async () => {
         const map: any = await mapFixture();


### PR DESCRIPTION
@Goldflow @kspeltix bij deze... simpele fix, lit was hier dus de culprit.

Als je gewoon het attribuut plaatst zonder waarde geeft lit een lege string.. en dus `!== undefined` tofjes! 

Test lukt nu ook netjes. https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC68-1