### PR TITLE
fix: UIG-2560 - storybook - tests voor GRB lagen

### DIFF
--- a/apps/storybook-e2e/src/e2e/map/layer/wms-layer/tiled-wms-layer/vl-map-tiled-wms-layer.stories-dom.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/layer/wms-layer/tiled-wms-layer/vl-map-tiled-wms-layer.stories-dom.cy.ts
@@ -2,7 +2,7 @@ const mapTiledWmsLayerUrl =
     'http://localhost:8080/iframe.html?id=map-layer-wms-layer-tiled-wms-layer--map-tiled-wms-layer-default&viewMode=story';
 
 describe('story vl-map-tiled-wms-layer default', () => {
-    const wmsUrl = 'https://geoservices.informatievlaanderen.be/raadpleegdiensten/GRB/wms';
+    const wmsUrl = 'https://geo.api.vlaanderen.be/GRB/wms';
 
     it('should fetch WMS layer', () => {
         cy.visit(mapTiledWmsLayerUrl);

--- a/apps/storybook-e2e/src/e2e/map/layer/wms-layer/tiled-wms-layer/vl-map-tiled-wms-layer.stories-wc.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/layer/wms-layer/tiled-wms-layer/vl-map-tiled-wms-layer.stories-wc.cy.ts
@@ -5,7 +5,7 @@ const mapTiledWmsLayerUrl =
     'http://localhost:8080/iframe.html?id=map-layer-wms-layer-tiled-wms-layer--map-tiled-wms-layer-default&viewMode=story';
 
 describe('story vl-map-tiled-wms-layer default', () => {
-    const wmsUrl = 'https://geoservices.informatievlaanderen.be/raadpleegdiensten/GRB/wms';
+    const wmsUrl = 'https://geo.api.vlaanderen.be/GRB/wms';
 
     it('should fetch new WMS layer on change url attribute', () => {
         cy.visit(mapTiledWmsLayerUrl);

--- a/libs/map/src/lib/components/layer/vl-map-layer.wctest.ts
+++ b/libs/map/src/lib/components/layer/vl-map-layer.wctest.ts
@@ -73,7 +73,7 @@ const wmtsLayerFixture = async () =>
     fixture(html`
         <vl-map>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="http://dummy/wmts"
                 data-vl-layer="grb_sel"
                 data-vl-name="GRB Wegenkaart"
                 data-vl-min-resolution="2"
@@ -131,11 +131,11 @@ const wmtsLayersFixture = async () =>
     fixture(html`
         <vl-map>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="http://dummy/wmts"
                 data-vl-layer="grb_sel"
             ></vl-map-wmts-layer>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="http://dummy/wmts"
                 data-vl-layer="grb_sel"
             ></vl-map-wmts-layer>
         </vl-map>

--- a/libs/map/src/lib/components/layer/wms-layer/vl-map-tiled-wms-layer/stories/vl-map-tiled-wms-layer.stories.ts
+++ b/libs/map/src/lib/components/layer/wms-layer/vl-map-tiled-wms-layer/stories/vl-map-tiled-wms-layer.stories.ts
@@ -42,5 +42,5 @@ MapTiledWmsLayerDefault.storyName = 'vl-map-tiled-wms-layer - default';
 MapTiledWmsLayerDefault.args = {
     layers: 'GEM_GRENS',
     name: 'Gemeentegrenzen',
-    url: 'https://geoservices.informatievlaanderen.be/raadpleegdiensten/GRB/wms',
+    url: 'https://geo.api.vlaanderen.be/GRB/wms',
 };

--- a/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories.ts
@@ -41,5 +41,5 @@ MapWmtsLayerDefault.storyName = 'vl-map-wmts-layer - default';
 MapWmtsLayerDefault.args = {
     name: 'GRB Wegenkaart',
     layer: 'grb_sel',
-    url: 'https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts',
+    url: 'https://geo.api.vlaanderen.be/GRB/wmts',
 };

--- a/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
+++ b/libs/map/src/lib/components/layer/wmts-layer/vl-map-wmts-layer.wctest.ts
@@ -8,7 +8,7 @@ const wmtsLayerFixture = async () =>
     fixture(html`
         <vl-map>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="https://geo.api.vlaanderen.be/GRB/wmts"
                 data-vl-layer="grb_sel"
                 data-vl-name="GRB Wegenkaart"
                 data-vl-min-resolution="2"
@@ -22,7 +22,7 @@ const wmtsLayerWithDifferentMatrixSetFixture = async () =>
     fixture(html`
         <vl-map>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="https://geo.api.vlaanderen.be/GRB/wmts"
                 data-vl-layer="grb_sel"
                 data-vl-name="GRB Wegenkaart"
                 data-vl-min-resolution="2"
@@ -38,7 +38,7 @@ const wmtsLayerHiddenFixture = async () =>
     fixture(html`
         <vl-map>
             <vl-map-wmts-layer
-                data-vl-url="https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts"
+                data-vl-url="https://geo.api.vlaanderen.be/GRB/wmts"
                 data-vl-layer="grb_sel"
                 data-vl-name="GRB Wegenkaart"
                 data-vl-min-resolution="2"
@@ -71,7 +71,7 @@ describe('vl-map-wmts-layer', () => {
         assert.isTrue(source instanceof OlWMTSSource);
 
         assert.lengthOf(source.urls, 1);
-        assert.equal(source.urls[0], 'https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts');
+        assert.equal(source.urls[0], 'https://geo.api.vlaanderen.be/GRB/wmts');
         assert.equal(source.getLayer(), 'grb_sel');
         assert.equal(source.getMatrixSet(), 'BPL72VL');
         assert.equal(source.getFormat(), 'image/png');
@@ -133,7 +133,7 @@ describe('vl-map-wmts-layer', () => {
     it('de kaartlaag zal pas angemaakt worden na constructie zodat op moment van constructie nog niet al de attributen gekend moeten zijn', async () => {
         const map: any = await mapFixture();
         const layer = document.createElement('vl-map-wmts-layer');
-        layer.setAttribute('data-vl-url', 'https://tile.informatievlaanderen.be/ws/raadpleegdiensten/wmts');
+        layer.setAttribute('data-vl-url', 'https://geo.api.vlaanderen.be/GRB/wmts');
         layer.setAttribute('data-vl-layer', 'grb_sel');
         layer.setAttribute('data-vl-name', 'GRB Wegenkaart');
         layer.setAttribute('data-vl-min-resolution', '2');


### PR DESCRIPTION
## Issue
- Jira: [UIG-2560](https://www.milieuinfo.be/jira/browse/UIG-2560)
- Bamboo: [PR Builds](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC73)

## Omschrijving oplossing
URL's in de Storybook testen aangepast naar de nieuwe.
Heeft geen invloed op de component(en) zelf aangezien de URL als attribuut moet meegegeven worden.
Resultaat:
<img width="500" alt="Scherm­afbeelding 2023-07-23 om 12 09 48" src="https://github.com/milieuinfo/uigov-web-components/assets/436498/3eaca715-a6d0-40ea-9a13-17902a76ad3f">


## Finale commit boodschap
De oude URl voor grafische webdiensten van Digitaal Vlaanderen werd uitgefaseerd. Hierdoor zag je geen lagen meer in de Storybook. De URL werd aangepast naar de nieuwe waardoor deze weer resultaat geven.