### PR TITLE
fix: UIG-2543 vl-cookie-consent en Matomo compatibility

### DIFF
--- a/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
+++ b/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
@@ -292,7 +292,7 @@ class AnalyticsUtil {
                     "_paq.push(['setCustomUrl', currentUrl]);" +
                     "_paq.push(['setDocumentTitle', document.title]);" +
                     "_paq.push(['deleteCustomVariables', 'page']);" +
-                    "_paq.push(['setGenerationTimeMs', 0]);" +
+                    "_paq.push(['setPagePerformanceTiming', 0]);" +
                     "_paq.push(['trackPageView']);" +
                     "var content = document.getElementById('content');" +
                     "_paq.push(['MediaAnalytics::scanForMedia', content]);" +


### PR DESCRIPTION
setGenerationTimeMs is niet langer ondersteund in Matomo 4. De vervanger is setPagePerformanceTiming.

- Jira: [UIG-2543](https://www.milieuinfo.be/jira/browse/UIG-2543)
- Bamboo: [build(s)](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC75)