### PR TITLE
feat: UIG-2540 - vl-functional-header - breadcrumb

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/breadcrumb/vl-breadcrumb.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/breadcrumb/vl-breadcrumb.stories.cy.ts
@@ -11,7 +11,7 @@ describe('story vl-breadcrumb', () => {
             .should('have.attr', 'aria-label', 'U bent hier: ');
     });
 
-    it('should contain 4 items', () => {
+    it('should contain 4 breadcrumb items', () => {
         cy.visit(breadcrumbUrl);
 
         cy.get('vl-breadcrumb')
@@ -21,7 +21,7 @@ describe('story vl-breadcrumb', () => {
             .should('have.length', 4);
     });
 
-    it('should contain valid items', () => {
+    it('should contain correct breadcrumb items', () => {
         cy.visit(breadcrumbUrl);
 
         cy.get('vl-breadcrumb')
@@ -36,7 +36,7 @@ describe('story vl-breadcrumb', () => {
             .contains('Componenten');
     });
 
-    it('should set correct links', () => {
+    it('should set correct links for breadcrumb items', () => {
         cy.visit(`${breadcrumbUrl}&args=href1:1;href2:2;href3:3`);
 
         cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(0).shadow().find('a').should('have.attr', 'href', '1');

--- a/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
@@ -4,6 +4,8 @@ const functionalHeaderActionsUrl =
     'http://localhost:8080/iframe.html?id=components-functional-header--functional-header-actions&viewMode=story';
 const functionalHeaderTabsUrl =
     'http://localhost:8080/iframe.html?id=components-functional-header--functional-header-tabs&viewMode=story';
+const functionalHeaderBreadcrumbUrl =
+    'http://localhost:8080/iframe.html?id=components-functional-header--functional-header-breadcrumb&viewMode=story';
 const functionalHeaderSlotsUrl =
     'http://localhost:8080/iframe.html?id=components-functional-header--functional-header-slots&viewMode=story';
 
@@ -226,6 +228,54 @@ describe('story vl-functional-header tabs', () => {
         cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'true');
         cy.get('vl-tabs').shadow().find('a#trein').click();
         cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
+    });
+});
+
+describe('story vl-functional-header breadcrumb', () => {
+    it('should set title link', () => {
+        cy.visit(`${functionalHeaderBreadcrumbUrl}&args=link:test`);
+
+        shouldSetTitleLink();
+    });
+
+    it('should set title text', () => {
+        cy.visit(`${functionalHeaderBreadcrumbUrl}&args=title:School+en+studietoelagen`);
+
+        shouldSetTitleText();
+    });
+
+    it('should contain 4 breadcrumb items', () => {
+        cy.visit(functionalHeaderBreadcrumbUrl);
+
+        cy.get('vl-breadcrumb')
+            .shadow()
+            .find('.vl-breadcrumb__list')
+            .children('.vl-breadcrumb__list__item')
+            .should('have.length', 4);
+    });
+
+    it('should contain correct breadcrumb items', () => {
+        cy.visit(functionalHeaderBreadcrumbUrl);
+
+        cy.get('vl-breadcrumb')
+            .find('vl-breadcrumb-item')
+            .first()
+            .contains('Vlaanderen Intern')
+            .next()
+            .contains('Regelgeving')
+            .next()
+            .contains('Webuniversum')
+            .next()
+            .contains('Componenten');
+    });
+
+    it('should set correct links for breadcrumb items', () => {
+        cy.visit(functionalHeaderBreadcrumbUrl);
+
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(0).shadow().find('a').should('have.attr', 'href', '1');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(1).shadow().find('a').should('have.attr', 'href', '2');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(2).shadow().find('a').should('have.attr', 'href', '3');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(3).shadow().find('span');
     });
 });
 

--- a/libs/components/src/lib/functional-header/stories/vl-functional-header.stories-arg.ts
+++ b/libs/components/src/lib/functional-header/stories/vl-functional-header.stories-arg.ts
@@ -8,6 +8,7 @@ export const functionalHeaderArgs = {
     backLink: 'document.referrer',
     disableBackLink: false,
     fullWidth: false,
+    hideBackLink: false,
     link: '',
     marginBottom: 'large',
     subTitle: '',
@@ -58,6 +59,15 @@ export const functionalHeaderArgTypes: ArgTypes<typeof functionalHeaderArgs> = {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: functionalHeaderArgs.fullWidth },
+        },
+    },
+    hideBackLink: {
+        name: 'data-vl-hide-back-link',
+        description: 'Verbergt de terug link.<br>Dit attribuut is niet reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: functionalHeaderArgs.hideBackLink },
         },
     },
     link: {

--- a/libs/components/src/lib/functional-header/stories/vl-functional-header.stories-doc.mdx
+++ b/libs/components/src/lib/functional-header/stories/vl-functional-header.stories-doc.mdx
@@ -32,9 +32,16 @@ import { VlFunctionalHeaderComponent } from '@domg-lib/components';
 
 ### Met tabs
 
-Gebruik het [vl-tabs](/docs/components-tabs--tabs-default) component in het sub-header slot om tabs af te beelden binnen de `functional-header`.
+Gebruik het [vl-tabs](/docs/components-tabs--tabs-default) component in het `sub-header` slot om tabs af te beelden binnen de `functional-header`.
 
 <DocsStory id="components-functional-header--functional-header-tabs" />
+
+### Met breadcrumb
+
+Gebruik het [vl-breadcrumb](/docs/components-breadcrumb--breadcrumb-default) component in het `sub-title` slot om een breadcrumb af te beelden binnen de `functional-header`.<br/>
+Plaats het `data-vl-hide-back-link` attribuut om de terug-link te verbergen.
+
+<DocsStory id="components-functional-header--functional-header-breadcrumb" />
 
 ## Referenties
 

--- a/libs/components/src/lib/functional-header/stories/vl-functional-header.stories.ts
+++ b/libs/components/src/lib/functional-header/stories/vl-functional-header.stories.ts
@@ -25,6 +25,7 @@ const Template = story(
         backLink,
         disableBackLink,
         fullWidth,
+        hideBackLink,
         link,
         marginBottom,
         subTitle,
@@ -44,6 +45,7 @@ const Template = story(
             data-vl-back-link=${backLink}
             ?data-vl-disable-back-link=${disableBackLink}
             ?data-vl-full-width=${fullWidth}
+            ?data-vl-hide-back-link=${hideBackLink}
             data-vl-link=${link}
             data-vl-margin-bottom=${marginBottom}
             data-vl-sub-title=${subTitle}
@@ -111,5 +113,29 @@ export const FunctionalHeaderTabs = story(
 );
 FunctionalHeaderTabs.storyName = 'vl-functional-header - tabs';
 FunctionalHeaderTabs.args = {
+    title: 'School- en studietoelagen',
+};
+
+export const FunctionalHeaderBreadcrumb = story(
+    functionalHeaderArgs,
+    ({ fullWidth, marginBottom, title, link }) => html`
+        <vl-functional-header
+            ?data-vl-full-width=${fullWidth}
+            data-vl-link=${link}
+            data-vl-margin-bottom=${marginBottom}
+            data-vl-title=${title}
+            data-vl-hide-back-link
+        >
+            <vl-breadcrumb slot="sub-title">
+                <vl-breadcrumb-item data-vl-href=${'1'}>Vlaanderen Intern</vl-breadcrumb-item>
+                <vl-breadcrumb-item data-vl-href=${'2'}>Regelgeving</vl-breadcrumb-item>
+                <vl-breadcrumb-item data-vl-href=${'3'}>Webuniversum</vl-breadcrumb-item>
+                <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+            </vl-breadcrumb>
+        </vl-functional-header>
+    `
+);
+FunctionalHeaderBreadcrumb.storyName = 'vl-functional-header - breadcrumb';
+FunctionalHeaderBreadcrumb.args = {
     title: 'School- en studietoelagen',
 };

--- a/libs/components/src/lib/functional-header/vl-functional-header.component.ts
+++ b/libs/components/src/lib/functional-header/vl-functional-header.component.ts
@@ -21,7 +21,16 @@ import { baseStyle, elementStyle, layoutStyle, resetStyle } from '@domg/govfland
 @webComponent('vl-functional-header')
 export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) {
     static get _observedAttributes() {
-        return ['back', 'back-link', 'disable-back-link', 'link', 'margin-bottom', 'sub-title', 'title'];
+        return [
+            'back',
+            'back-link',
+            'disable-back-link',
+            'hide-back-link',
+            'link',
+            'margin-bottom',
+            'sub-title',
+            'title',
+        ];
     }
 
     static get _observedClassAttributes() {
@@ -67,7 +76,7 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
           <div class="vl-functional-header__sub" id="sub-header">
             <slot name="sub-header">
               <ul class="vl-functional-header__sub__actions">
-                  <li class="vl-functional-header__sub__action">
+                  <li id="back-link-container" class="vl-functional-header__sub__action">
                       <slot name="back-link">
                           <a id="back-link" is="vl-link" tabindex="0" href="${document.referrer}">
                               <span is="vl-icon" data-vl-icon="arrow-left-fat" data-vl-before></span>
@@ -91,7 +100,10 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
 
         this._observer = this.__observeSlotElements(() => this.__processSlotElements());
         this.__processSlotElements();
-        this._backLinkElement.onclick = (event: Event) => this._handleClickBackLink(event);
+
+        if (this._backLinkElement) {
+            this._backLinkElement.onclick = (event: Event) => this._handleClickBackLink(event);
+        }
     }
 
     disconnectedCallback() {
@@ -104,6 +116,10 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
 
     get _subTitleElement() {
         return this._shadow.querySelector('#sub-title');
+    }
+
+    get _backLinkContainer() {
+        return this._shadow.querySelector('#back-link-container');
     }
 
     get _backLinkElement() {
@@ -182,6 +198,12 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
             header.style.marginBottom = margin;
         } else {
             header.style.removeProperty('margin-bottom');
+        }
+    }
+
+    _hideBackLinkChangedCallback(oldValue: string, newValue: string) {
+        if (newValue != undefined) {
+            this._backLinkContainer?.remove();
         }
     }
 


### PR DESCRIPTION
Gebruik van vl-breadcrumb in de vl-functional-header 
Storybook uitgebreid & Cypress tests toegevoegd

[Bamboo build](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC77)
[Jira ticket](https://www.milieuinfo.be/jira/browse/UIG-2540)