### PR TITLE
fix: UIG-2610 - vl-textarea - pas disabled instellen wanneer opzet klaar is

### DIFF
--- a/libs/components/src/lib/textarea/vl-textarea.element.ts
+++ b/libs/components/src/lib/textarea/vl-textarea.element.ts
@@ -18,6 +18,7 @@ export class VlTextarea extends vlFormValidationElement(BaseElementOfType(HTMLTe
         return ['disabled', 'block', 'error', 'success', 'focus', 'rich', 'readonly'];
     }
 
+    private initialised = false;
     _editor: Editor | undefined;
 
     connectedCallback() {
@@ -93,6 +94,7 @@ export class VlTextarea extends vlFormValidationElement(BaseElementOfType(HTMLTe
                     this.__disableActiveEditor(this.isDisabled);
                     this.__toggleEditorToolbar(this.isReadonly);
                     this.__toggleEditorReadonly(this.isReadonly || this.isDisabled);
+                    this.initialised = true;
                 });
             },
         };
@@ -165,7 +167,7 @@ export class VlTextarea extends vlFormValidationElement(BaseElementOfType(HTMLTe
 
     _disabledChangedCallback(oldValue: string, newValue: string) {
         const disabled = newValue !== null;
-        if (this.isRich) {
+        if (this.isRich && this.initialised) {
             this.__toggleEditorReadonly(disabled);
             this.__disableActiveEditor(disabled);
         }


### PR DESCRIPTION
bamboo: https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC79
jira: https://www.milieuinfo.be/jira/browse/UIG-2610
---

## Werking:

disabled wordt op true/false gezet afhankelijk van flag `data-vl-disabled`

- `disabled` gaat achterliggend:
  -  DV's "disabled"-styling toepassen
  - textarea in readonly modus zetten (niet aanpasbare modus van tinymce)
- `disabled` wordt ingesteld in een `init` functie
- daarnaast kan `disabled` ook reactief veranderd worden

## Probleem

in Chrome vormt dit geen probleem, in Safari gaat `_disabledChangedCallback` afvuren vooraleer initalisatie is gebeurd; dit zorgt blijkbaar voor abnormale werking.

## Oplossing

`initialised` variabele geintroduceerd en pas `_disabledChangedCallback` changes toelaten nadat initalisatie is gebeurd

## Reproductie

om het in Safari te reproduceren default textarea openen, en dan switchen naar rich text modus, dan zie je dat de opties disabled staan, ook al staat disabled op false (standaard)

---

@kspeltix best voordat we hotfix maken, eerst beta package laten afnemen om te zien dat de fix effectief werkt

