### PR TITLE
fix: UIG-2551 - vl-modal - werking open attribuut veranderd zodat het interne open methode gebruikt

### DIFF
--- a/libs/components/src/lib/modal/vl-modal.component.ts
+++ b/libs/components/src/lib/modal/vl-modal.component.ts
@@ -75,8 +75,8 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
         this.dress();
     }
 
-    get _dialogElement() {
-        return this._element.querySelector('dialog');
+    get _dialogElement(): HTMLDialogElement {
+        return this._element?.querySelector('dialog');
     }
 
     get _titleElement() {
@@ -116,6 +116,7 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
         if (!this._dialogElement.hasAttribute('open')) {
             awaitUntil(() => this._dialogElement.isConnected).then(() => {
                 vl.modal.toggle(this._dialogElement);
+                this._dialogElement?.focus();
             });
         }
     }
@@ -134,8 +135,8 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
      * @param {String} event
      * @param {Function} callback
      */
-    on(event: Event, callback: any) {
-        this._dialogElement.addEventListener(event, callback);
+    on(event: string, callback: any) {
+        this._dialogElement?.addEventListener(event, callback);
     }
 
     _getCloseButtonTemplate() {
@@ -184,7 +185,7 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
     }
 
     _openChangedCallback(oldValue: string, newValue: string) {
-        this._dialogElement.setAttribute('open', newValue);
+        this.open();
     }
 
     _closableChangedCallback(oldValue: string, newValue: string) {


### PR DESCRIPTION
bamboo: https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC81
jira: https://www.milieuinfo.be/jira/browse/UIG-2551
---
Vroeger werd het open attribuut direct toegepast en dan werd "lastClickedToggle" niet correct ingesteld gezien de initialisatie dan nog niet is gebeurd. Nu wordt de bestaande "open()" methode gebruikt, die ook wacht tot die initialisatie is gebeurd en die ook meteen "data-vl-modal-open" plaatst op het component.
Escape functionaliteit gefixt door dialog focus te geven bij het openen.