### PR TITLE
fix: UIG-2550 - vl-form-validation - dot in name attribute

### DIFF
--- a/apps/storybook-e2e/src/e2e/elements/form/vl-form-validation.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/form/vl-form-validation.stories.cy.ts
@@ -2,15 +2,17 @@ const formValidationDefaultUrl =
     'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&viewMode=story&id=elements-form--form-validation';
 const formValidationOptionalUrl =
     'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&id=elements-form--form-validation-optional&viewMode=story';
+const formValidationEscapeFieldNamesUrl =
+    'http://localhost:8080/iframe.html?globals=backgrounds.value:!hex(F8F8F8)&viewMode=story&id=elements-form--form-validation-escape-field-names';
 
-describe('story vl-form - with validation', () => {
+describe('story vl-form - validation', () => {
     it('should be accessible', () => {
-        cy.visitWithA11y(`${formValidationDefaultUrl}`);
+        cy.visitWithA11y(formValidationDefaultUrl);
         cy.checkA11y('[is="vl-form"]');
     });
 
     it('should by default, not have native HTML validation', () => {
-        cy.visit(`${formValidationDefaultUrl}`);
+        cy.visit(formValidationDefaultUrl);
         cy.get('[is="vl-form"]').should('have.attr', 'novalidate');
     });
 
@@ -20,14 +22,14 @@ describe('story vl-form - with validation', () => {
     });
 });
 
-describe('story vl-form-validation - optional validation', () => {
+describe('story vl-form - validation optional', () => {
     it('should be accessible', () => {
-        cy.visitWithA11y(`${formValidationOptionalUrl}`);
+        cy.visitWithA11y(formValidationOptionalUrl);
         cy.checkA11y('[is="vl-form"]');
     });
 
     it('should have an error placeholder for every input-field', () => {
-        cy.visit(`${formValidationOptionalUrl}`);
+        cy.visit(formValidationOptionalUrl);
         cy.get('[is="vl-form"]')
             .find('[is="vl-input-field"]')
             .each((inputFieldResult) => {
@@ -37,8 +39,8 @@ describe('story vl-form-validation - optional validation', () => {
             });
     });
 
-    it('should be only validate required inputs', () => {
-        cy.visit(`${formValidationOptionalUrl}`);
+    it('should only validate required inputs', () => {
+        cy.visit(formValidationOptionalUrl);
 
         cy.get('[is="vl-form"]')
             .find('[is="vl-input-field"]')
@@ -58,11 +60,83 @@ describe('story vl-form-validation - optional validation', () => {
             .each((inputFieldResult) => {
                 const inputField = inputFieldResult[0];
                 const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
-                const isRequired = inputField.getAttribute('data-vl-required');
+                const isRequired = inputField.hasAttribute('data-vl-required');
                 if (isRequired) {
-                    cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`)
-                        .should('have.attr', 'error')
-                        .and('not.have.attr.hidden');
+                    cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`).should(
+                        'not.have.attr',
+                        'hidden'
+                    );
+                }
+            });
+    });
+});
+
+describe('story vl-form - validation escape field names', () => {
+    it('should be accessible', () => {
+        cy.visitWithA11y(formValidationEscapeFieldNamesUrl);
+        cy.checkA11y('[is="vl-form"]');
+    });
+
+    it('should have an error placeholder for every input-field', () => {
+        cy.visit(formValidationEscapeFieldNamesUrl);
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`);
+            });
+    });
+
+    it('should validate inputs', () => {
+        cy.visit(formValidationEscapeFieldNamesUrl);
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`).should(
+                    'have.attr',
+                    'hidden'
+                );
+            });
+
+        cy.get('[is="vl-form"]').submit();
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                const isRequired = inputField.hasAttribute('data-vl-required');
+                if (isRequired) {
+                    cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`).should(
+                        'not.have.attr',
+                        'hidden'
+                    );
+                }
+            });
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                cy.wrap(inputFieldResult).type('test');
+            });
+
+        cy.get('[is="vl-form"]').submit();
+
+        cy.get('[is="vl-form"]')
+            .find('[is="vl-input-field"]')
+            .each((inputFieldResult) => {
+                const inputField = inputFieldResult[0];
+                const errorPlaceholderId = inputField.getAttribute('data-vl-error-placeholder');
+                const isRequired = inputField.hasAttribute('data-vl-required');
+                if (isRequired) {
+                    cy.get(`[is="vl-form-validation-message"][data-vl-error-id="${errorPlaceholderId}"]`).should(
+                        'have.attr',
+                        'hidden'
+                    );
                 }
             });
     });

--- a/libs/common/utilities/src/lib/models/vl.model.ts
+++ b/libs/common/utilities/src/lib/models/vl.model.ts
@@ -24,7 +24,7 @@ interface Datepicker {
 }
 
 interface FormValidation {
-    dress(form: any): void;
+    dress(form: any, escapeFieldNames: boolean): void;
     undress(form: any): void;
     dressAll(): void;
     reset(form: any): void;

--- a/libs/elements/src/lib/form-validation/vl-form-validation.element.ts
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.element.ts
@@ -80,10 +80,12 @@ export const vlFormValidationElement = (SuperClass: Class): Class => {
 
         _dressFormValidation(): void {
             if (this.form && this.form.hasAttribute('data-vl-validate')) {
+                const escapeFieldNames = this.form.hasAttribute('data-vl-escape-field-names');
+
                 this._setClassAttributes();
                 this._observer = this._observeFormValidationClasses();
                 Object.assign(this, vlFormValidation);
-                this.dress(this.form);
+                this.dress(this.form, escapeFieldNames);
                 this.addEventListener('focus', () => this.focus());
             }
         }

--- a/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
@@ -6747,6 +6747,7 @@
      * @param       {[object]}   config [description]
      */
 
+    // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
     var _prepareFormvalidationConfig = function _prepareFormvalidationConfig(field, config) {
         var fieldObj = {},
             randomName,
@@ -6775,6 +6776,8 @@
             field.setAttribute('id', randomId);
             fieldObj.id = randomId;
         }
+
+        if (config.escapeFieldNames) fieldObj.name = fieldObj.name.replace(/\./g, '\\\\\\\\\\.');
 
         config.constraints[fieldObj.name] = _buildFormvalidationConfig(field, fieldObj);
     };
@@ -6889,15 +6892,17 @@
      * @param       {[object]}    errors [errors]
      */
 
-    var _showErrors = function _showErrors(form, errors) {
+    // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
+    var _showErrors = function _showErrors(form, errors, config) {
         vl.util.each(form.querySelectorAll('input, textarea, select, [data-vl-error-placeholder]'), function (input) {
             if (
                 input.hasAttribute(fvErrorPlchAtt) &&
                 input.name.length &&
                 form.querySelector('['.concat(fvErrorIDAtt, '="').concat(input.getAttribute(fvErrorPlchAtt), '"]'))
             ) {
+                const name = config.escapeFieldNames ? input.name.replace(/\./g, '\\\\\\\\\\.') : input.name;
                 _showSuccessForInput(input, errors);
-                _showErrorsForInput(input, errors && errors[input.name]);
+                _showErrorsForInput(input, errors && errors[name]);
             }
         });
     };
@@ -6959,13 +6964,14 @@
      * @param       {Boolean}     isCollection [if true, an entire form gets validated]
      */
 
-    var _handleErrors = function _handleErrors(el, errors, isCollection) {
+    // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
+    var _handleErrors = function _handleErrors(el, errors, isCollection, config) {
         if (isCollection) {
             _resetAllError(el);
 
             _showSuccess(el, errors);
 
-            _showErrors(el, errors);
+            _showErrors(el, errors, config);
         } else {
             _resetInput(el);
 
@@ -6981,12 +6987,13 @@
      * @param       {[object]}      config [the config file to validate against]
      */
 
+    // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
     var _validateForm = function _validateForm(form, config) {
         var errors,
             constraints = config.constraints;
         errors = validate(form, constraints, fvValidatorOptions);
 
-        _handleErrors(form, errors || {}, true);
+        _handleErrors(form, errors || {}, true, config);
 
         if (!errors) {
             _formSubmit(form);
@@ -6999,15 +7006,17 @@
      * @param       {[object]}       config [the config file to validate against]
      */
 
+    // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
     var _validateField = function _validateField(el, config) {
+        const name = config.escapeFieldNames ? el.name.replace(/\./g, '\\\\\\\\\\.') : el.name;
         var errors,
             constraints = config.constraints,
             fieldConstraints;
         fieldConstraints = {};
-        fieldConstraints[el.name] = constraints[el.name];
+        fieldConstraints[name] = constraints[name];
         errors = validate(el.form, fieldConstraints, fvValidatorOptions) || {};
 
-        _handleErrors(el, errors[el.name], false);
+        _handleErrors(el, errors[name], false);
     };
 
     var FormValidation = /*#__PURE__*/ (function () {
@@ -7018,12 +7027,14 @@
         _createClass(FormValidation, [
             {
                 key: 'dress',
-                value: function dress(form) {
+                // feat: UIG-2550 - vl-form - validatie voor input fields met een dot (.) in het name attribuut
+                value: function dress(form, escapeFieldNames) {
                     var fields,
                         validationConfig = {},
                         validationFormType = form.getAttribute(fvFormValidationType),
                         eventTargetSelect;
                     validationConfig.constraints = {};
+                    validationConfig.escapeFieldNames = escapeFieldNames;
                     form.setAttribute(fvDressedAtt, true); // if the form does not have an ID, create one in JS
 
                     if (!form.id) {

--- a/libs/elements/src/lib/form-validation/vl-form-validation.ts
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.ts
@@ -1,4 +1,4 @@
-import { awaitUntil } from '@domg-wc/common-utilities';
+import { VL, awaitUntil } from '@domg-wc/common-utilities';
 import '@govflanders/vl-ui-util/dist/js/util.js';
 import '@govflanders/vl-ui-core/dist/js/core.js';
 import './vl-form-validation.lib.js';
@@ -7,7 +7,7 @@ import './vl-form-validation.lib.js';
 //  - er een vlFormValidation en een vlFormValidationElement is -> vooral of vlFormValidation dan wel een goede naam is ?
 //  - waarom VlFormValidation en vlFormValidation bestaat
 
-declare const vl: any;
+declare const vl: VL;
 declare const window: any;
 
 /**
@@ -41,13 +41,13 @@ export const vlFormValidation = {
      *
      * @param {HTMLElement} element
      */
-    dress(element: any) {
+    dress(element: any, escapeFieldNames: boolean) {
         if (
             element &&
             element.hasAttribute('data-vl-validate') &&
             !element.hasAttribute('data-vl-formvalidation-dressed')
         ) {
-            vl.formValidation.dress(element);
+            vl.formValidation.dress(element, escapeFieldNames);
         }
     },
 

--- a/libs/elements/src/lib/form/stories/vl-form-group.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form-group.stories.ts
@@ -22,9 +22,14 @@ export default {
 
 export const formGroup = story(
     formArgs,
-    ({ validate, nativeValidation }) => html`
+    ({ validate, nativeValidation, escapeFieldNames }) => html`
         <div style="max-width: 800px">
-            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+            <form
+                is="vl-form"
+                ?data-vl-validate=${validate}
+                ?data-vl-native-validation=${nativeValidation}
+                ?data-vl-escape-field-names=${escapeFieldNames}
+            >
                 <div is="vl-form-group" data-cy="form-group">
                     <div is="vl-form-grid" data-vl-is-stacked>
                         <div is="vl-form-column" data-vl-size="3">

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
@@ -21,6 +21,7 @@ import { VlFormValidation, VlFormElement } from '@domg-wc/elements';
 <ArgsTable story={PRIMARY_STORY} />
 
 ## Info
+
 > `vl-form-validation` element gebruikt achterliggend `validate.js` 0.12 ([http://validatejs.org/](http://validatejs.org/)).
 
 Het attribuut `[data-validate-form]` is vereist voor het formulierelement.
@@ -49,6 +50,13 @@ Je vindt een voorbeeld hieronder; naam is verplicht en voornaam is niet verplich
 
 <DocsStory id="elements-form--form-validation-optional" />
 
+### Escape naam attributen
+
+Indien er een `.` in het naam attribuut van een input veld staat en de validatie niet correct werkt moet dit naam attribuut ge-escaped worden.<br/>
+Zet hiervoor het attribuut `data-vl-escape-field-names` op true op het form element.
+
+<DocsStory id="elements-form--form-validation" />
+
 ### Group
 
 Met `vl-form-group` wordt styling toegevoegd om makkelijker te onderscheiden tussen verschillende form controls.
@@ -56,7 +64,6 @@ Met `vl-form-group` wordt styling toegevoegd om makkelijker te onderscheiden tus
 Zie voorbeeld hieronder:
 
 <DocsStory id="elements-form--form-group" />
-
 
 ## Referenties
 

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories.ts
@@ -20,9 +20,14 @@ export default {
 
 export const formValidation = story(
     formArgs,
-    ({ validate, nativeValidation }) => html`
+    ({ validate, nativeValidation, escapeFieldNames }) => html`
         <div style="max-width: 800px">
-            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+            <form
+                is="vl-form"
+                ?data-vl-validate=${validate}
+                ?data-vl-native-validation=${nativeValidation}
+                ?data-vl-escape-field-names=${escapeFieldNames}
+            >
                 <div is="vl-form-grid" data-vl-is-stacked>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="name" data-vl-block>
@@ -78,16 +83,21 @@ export const formValidation = story(
         </div>
     `
 );
-formValidation.storyName = 'vl-form - with validation';
+formValidation.storyName = 'vl-form - validation';
 formValidation.args = {
     validate: true,
 };
 
 export const formValidationOptional = story(
     formArgs,
-    ({ validate, nativeValidation }) => html`
+    ({ validate, nativeValidation, escapeFieldNames }) => html`
         <div style="max-width: 800px">
-            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+            <form
+                is="vl-form"
+                ?data-vl-validate=${validate}
+                ?data-vl-native-validation=${nativeValidation}
+                ?data-vl-escape-field-names=${escapeFieldNames}
+            >
                 <div is="vl-form-grid" data-vl-is-stacked>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="name" data-vl-block>
@@ -139,7 +149,78 @@ export const formValidationOptional = story(
         </div>
     `
 );
-formValidationOptional.storyName = 'vl-form - with validation optional';
+formValidationOptional.storyName = 'vl-form - validation optional';
 formValidationOptional.args = {
     validate: true,
+};
+
+export const formValidationEscapeFieldNames = story(
+    formArgs,
+    ({ validate, nativeValidation, escapeFieldNames }) => html`
+        <div style="max-width: 800px">
+            <form
+                is="vl-form"
+                ?data-vl-validate=${validate}
+                ?data-vl-native-validation=${nativeValidation}
+                ?data-vl-escape-field-names=${escapeFieldNames}
+            >
+                <div is="vl-form-grid" data-vl-is-stacked>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="foo.bar" data-vl-block>
+                            Naam
+                            <span is="vl-form-annotation-span">(verplicht)</span>
+                        </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input
+                            id="foo.bar"
+                            name="foo.bar"
+                            autocomplete="name"
+                            is="vl-input-field"
+                            data-vl-block
+                            data-vl-required
+                            data-vl-error-message="Geef een naam in."
+                            data-vl-error-placeholder="foo.bar-error"
+                        />
+                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="foo.bar-error"></p>
+                    </div>
+
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="foo.bar.baz" data-vl-block>
+                            Voornaam
+                            <span is="vl-form-annotation-span">(verplicht)</span>
+                        </label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input
+                            id="foo.bar.baz"
+                            name="foo.bar.baz"
+                            autocomplete="given-name"
+                            is="vl-input-field"
+                            data-vl-block
+                            data-vl-required
+                            data-vl-error-message="Geef een voornaam in."
+                            data-vl-error-placeholder="foo.bar.baz-error"
+                        />
+                        <p is="vl-form-validation-message" data-vl-error data-vl-error-id="foo.bar.baz-error"></p>
+                    </div>
+
+                    <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                        <div is="vl-action-group">
+                            <button is="vl-button" type="submit">Versturen</button>
+                            <a is="vl-link" href="#">
+                                <span is="vl-icon" data-vl-icon="cross" data-vl-before></span>
+                                Annuleren
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    `
+);
+formValidationEscapeFieldNames.storyName = 'vl-form - validation escape field names';
+formValidationEscapeFieldNames.args = {
+    validate: true,
+    escapeFieldNames: true,
 };

--- a/libs/elements/src/lib/form/stories/vl-form.stories-arg.ts
+++ b/libs/elements/src/lib/form/stories/vl-form.stories-arg.ts
@@ -2,23 +2,33 @@ import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
 import { ArgTypes } from '@storybook/web-components';
 
 export const formArgs = {
-    validate: false,
+    escapeFieldNames: false,
     nativeValidation: false,
+    validate: false,
 };
 
 export const formArgTypes: ArgTypes<typeof formArgs> = {
-    validate: {
-        name: 'data-vl-validate',
-        description: 'Validatie van invoervelden inschakelen.',
+    escapeFieldNames: {
+        name: 'data-vl-escape-field-names',
+        description: `Geeft aan dat het name attribuut van de input velden ge-escaped moet worden.<br/>Kan gebruikt worden als er een '.' in het name attribuut staat en de validatie niet correct werkt.`,
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: formArgs.escapeFieldNames },
+        },
+    },
+    nativeValidation: {
+        name: 'data-vl-native-validation',
+        description: 'Stelt native validation in.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: formArgs.validate },
         },
     },
-    nativeValidation: {
-        name: 'data-vl-native-validation',
-        description: 'Stelt native validation in.',
+    validate: {
+        name: 'data-vl-validate',
+        description: 'Validatie van invoervelden inschakelen.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/elements/src/lib/form/stories/vl-form.stories.ts
+++ b/libs/elements/src/lib/form/stories/vl-form.stories.ts
@@ -19,9 +19,14 @@ export default {
 
 export const formDefault = story(
     formArgs,
-    ({ validate, nativeValidation }) => html`
+    ({ validate, nativeValidation, escapeFieldNames }) => html`
         <div style="max-width: 800px">
-            <form is="vl-form" ?data-vl-validate=${validate} ?data-vl-native-validation=${nativeValidation}>
+            <form
+                is="vl-form"
+                ?data-vl-validate=${validate}
+                ?data-vl-native-validation=${nativeValidation}
+                ?data-vl-escape-field-names=${escapeFieldNames}
+            >
                 <div is="vl-form-grid" data-vl-is-stacked>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="name" data-vl-block> Naam </label>

--- a/libs/elements/src/lib/form/vl-form.element.ts
+++ b/libs/elements/src/lib/form/vl-form.element.ts
@@ -11,6 +11,7 @@ declare const vl: VL;
  * @extends HTMLElement
  *
  * @property {boolean} data-vl-validate - Attribuut wordt gebruikt om aan te geven dat de input velden validatie geactiveerd moet worden.
+ * @property {boolean} data-vl-escape-field-names - Geeft aan dat het name attribuut van de input velden ge-escaped moet worden. Kan gebruikt worden als er een '.' in het name attribuut staat en de validatie niet correct werkt.
  */
 @webComponent('vl-form', { extends: 'form' })
 export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
@@ -61,6 +62,8 @@ export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
         const node = this as unknown as Node;
         const vlFormElement = node as unknown as VlFormElement;
         const observer = new MutationObserver((mutations) => {
+            const escapeFieldNames = this.form.hasAttribute('data-vl-escape-field-names');
+
             for (const mutation of mutations) {
                 const { addedNodes } = mutation;
                 for (const node of addedNodes) {
@@ -73,7 +76,7 @@ export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
                         // in case a new formElement was added, we need to undress the form to avoid duplicate event listeners
                         vl.formValidation.undress(vlFormElement);
                         // then dress the form again
-                        vl.formValidation.dress(vlFormElement);
+                        vl.formValidation.dress(vlFormElement, escapeFieldNames);
                     }
                 }
             }


### PR DESCRIPTION
Het issue kwam doordat er een '.' in het naam attribuut stond.

Validate.js gaat achterliggend een naam attribuut met een '.' in interpreteren als een genest object, en in het form op zoek gaan naar de values op een geneste manier. Ik heb het probleem opgelost door de naam attributen in het stuk code van DV in vl-form-validation.lib.js te escapen, ik heb de code van Validate.js niet aangeraakt zodat deze later als dependency geīnstalleerd kan worden zonder dat hier aanpassingen aan gedaan moeten worden.

Je kan de bovenstaande werking van Validate.js terugvinden in de methodes getDeepObjectValue() en forEachKeyInKeypath() in vl-form-validation.lib.js.

Ik heb een attribuut 'data-vl-escape-field-names' toegevoegd aan de vl-form voor backwards compatibility moest er toch een afnemer zijn die berust op bovenstaand gedrag.

Het lijkt alsof ik te veel escape characters heb toegevoegd, dit was nodig om de code van Validate.js te laten werken.

Er is een Storybook story toegevoegd voor dit scenario, en de nodige Cypress testen zijn er ook.

[Jira ticket](https://www.milieuinfo.be/jira/browse/UIG-2550)
[Bamboo build](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC88)