### PR TITLE
fix: UIG-2538 - vl-document - ontbrekende styling voor title toegevoegd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/document/vl-document.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/document/vl-document.stories.cy.ts
@@ -3,14 +3,14 @@ const documentUrl = 'http://localhost:8080/iframe.html?id=components-document--d
 describe('story vl-document', () => {
     it('should contain a document type and icon', () => {
         cy.visit(`${documentUrl}`);
-        cy.getDataCy('document')
+        cy.get('vl-document')
             .shadow()
             .find('.vl-document__type')
             .find('i')
             .should('have.class', 'vl-vi')
             .should('have.class', 'vl-vi-document');
 
-        cy.getDataCy('document')
+        cy.get('vl-document')
             .shadow()
             .find('.vl-document__type')
             .find('span')
@@ -19,11 +19,16 @@ describe('story vl-document', () => {
 
     it('should contain a document title', () => {
         cy.visit(`${documentUrl}`);
-        cy.getDataCy('document').find('span[slot="title"]').contains('Hubert en Jan van Eyck, Vlaamse Primitieven');
+        cy.get('vl-document').find('span[slot="title"]').contains('Hubert en Jan van Eyck, Vlaamse Primitieven');
     });
 
     it('should contain a document metadata', () => {
         cy.visit(`${documentUrl}`);
-        cy.getDataCy('document').find('span[slot="metadata"]').contains('PDF - 580 kB');
+        cy.get('vl-document').find('span[slot="metadata"]').contains('PDF - 580 kB');
+    });
+
+    it('should contain a document metadata', () => {
+        cy.visit(`${documentUrl}`);
+        cy.get('vl-document').find('span[slot="title"]').shouldHaveStyle('color', 'rgb(0, 85, 204)');
     });
 });

--- a/libs/components/src/lib/document/stories/vl-document.stories-arg.ts
+++ b/libs/components/src/lib/document/stories/vl-document.stories-arg.ts
@@ -1,10 +1,11 @@
 import { ArgTypes } from '@storybook/web-components';
+import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
 
 export const documentArgs = {
     href: '#',
-    type: 'PDF',
-    title: 'Hubert en Jan van Eyck, Vlaamse Primitieven',
-    metadata: 'PDF - 580 kB',
+    type: '',
+    title: '',
+    metadata: '',
 };
 
 export const documentArgTypes: ArgTypes<typeof documentArgs> = {
@@ -12,11 +13,33 @@ export const documentArgTypes: ArgTypes<typeof documentArgs> = {
         name: 'data-vl-href',
         description: 'Attribuut wordt gebruikt om de download link te bepalen.',
         table: {
-            type: { summary: 'string' },
-            defaultValue: { summary: '#' },
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: documentArgs.href },
         },
     },
-    type: { name: 'type (slot)' },
-    title: { name: 'title (slot)' },
-    metadata: { name: 'metadata (slot)' },
+    type: {
+        name: 'type',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: documentArgs.type },
+        },
+    },
+    title: {
+        name: 'title',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: documentArgs.title },
+        },
+    },
+    metadata: {
+        name: 'metadata',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: documentArgs.metadata },
+        },
+    },
 };

--- a/libs/components/src/lib/document/stories/vl-document.stories-doc.mdx
+++ b/libs/components/src/lib/document/stories/vl-document.stories-doc.mdx
@@ -1,0 +1,35 @@
+import { ArgsTable, DocsStory, PRIMARY_STORY } from '@storybook/addon-docs';
+
+# Document
+
+Gebruik het document component om een link naar een bestand toe te voegen dat de gebruiker in de browser kan bekijken of downloaden.
+
+## Voorbeeld
+
+```js
+import { VlDocumentComponent } from '@domg-wc/components';
+```
+
+```html
+<vl-document></vl-document>
+```
+
+<DocsStory id="components-document--document-default" />
+
+## Configuratie
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+**Documentatie Digitaal Vlaanderen:** https://overheid.vlaanderen.be/webuniversum/v3/documentation/components/vl-ui-document
+
+### Legacy Documentatie
+
+**Legacy Storybook:** https://webcomponenten.omgeving.vlaanderen.be/storybook/?path=/docs/custom-elements-vl-document--default
+
+**Legacy Documentatie:** https://webcomponenten.omgeving.vlaanderen.be/doc/VlDocument.html
+
+**Legacy Demo:** https://webcomponenten.omgeving.vlaanderen.be/demo/vl-document.html

--- a/libs/components/src/lib/document/stories/vl-document.stories.ts
+++ b/libs/components/src/lib/document/stories/vl-document.stories.ts
@@ -1,22 +1,36 @@
 import { html } from 'lit-html';
 import '../vl-document.component';
 import { documentArgs, documentArgTypes } from './vl-document.stories-arg';
-import { storyArgs, storyArgTypes } from '@domg-wc/common-storybook';
+import { story, storyArgs, storyArgTypes } from '@domg-wc/common-storybook';
 import { Meta } from '@storybook/web-components';
+import documentDoc from './vl-document.stories-doc.mdx';
 
 export default {
     title: 'Components/document',
     args: storyArgs(documentArgs),
     argTypes: storyArgTypes(documentArgTypes),
+    parameters: {
+        docs: {
+            page: documentDoc,
+        },
+    },
 } as Meta<typeof documentArgs>;
 
-export const documentDefault = ({ href, type, title, metadata }: typeof documentArgs) => html` <div is="vl-grid">
-    <div is="vl-column" data-vl-size="3" data-vl-medium-size="6">
-        <vl-document data-vl-href=${href} data-cy="document">
-            <span slot="type">${type}</span>
-            <span slot="title">${title}</span>
-            <span slot="metadata">${metadata}</span>
-        </vl-document>
-    </div>
-</div>`;
-documentDefault.storyName = 'vl-document - default';
+export const DocumentDefault = story(
+    documentArgs,
+    ({ href, type, title, metadata }) => html` <div is="vl-grid">
+        <div is="vl-column" data-vl-size="3" data-vl-medium-size="6">
+            <vl-document data-vl-href=${href}>
+                <span slot="type">${type}</span>
+                <span slot="title">${title}</span>
+                <span slot="metadata">${metadata}</span>
+            </vl-document>
+        </div>
+    </div>`
+);
+DocumentDefault.storyName = 'vl-document - default';
+DocumentDefault.args = {
+    type: 'PDF',
+    title: 'Hubert en Jan van Eyck, Vlaamse Primitieven',
+    metadata: 'PDF - 580 kB',
+};

--- a/libs/components/src/lib/document/vl-document.component.ts
+++ b/libs/components/src/lib/document/vl-document.component.ts
@@ -1,6 +1,6 @@
 import { BaseElementOfType, webComponent } from '@domg-wc/common-utilities';
 import { documentStyle, iconStyle } from '@domg/govflanders-style/component';
-import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
+import { baseStyle, elementStyle, resetStyle } from '@domg/govflanders-style/common';
 
 /**
  * VlDocument
@@ -23,6 +23,7 @@ export class VlDocumentComponent extends BaseElementOfType(HTMLElement) {
       <style>
         ${resetStyle}
         ${baseStyle}
+        ${elementStyle}
         ${documentStyle}
         ${iconStyle}
       </style>


### PR DESCRIPTION
bamboo: https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC89
jira: https://www.milieuinfo.be/jira/browse/UIG-2538

``` fix: UIG-2538 - vl-document - ontbrekende styling voor title toegevoegd

Storybook verbeterd & cypress tests uitgebreid.
```

heb kleine test toegevoegd die verzekert dat title in de juiste kleur gerenderd wordt