### PR TITLE
feature: UIG-2635 - vl-cookie-consent - analytics: naamswijziging KBOMG

### DIFF
--- a/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
+++ b/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
@@ -88,7 +88,7 @@ class AnalyticsUtil {
                 id: 38,
                 url: this._matomoOntwikkelUrl,
             },
-            'kruispuntbank-ontwikkel.omgeving.vlaanderen.be': {
+            'informatie-ontwikkel.omgeving.vlaanderen.be': {
                 id: 39,
                 url: this._matomoOntwikkelUrl,
             },
@@ -156,7 +156,7 @@ class AnalyticsUtil {
                     id: 28,
                     url: this._matomoOefenUrl,
                 },
-                'kruispuntbank-oefen.omgeving.vlaanderen.be': {
+                'informatie-oefen.omgeving.vlaanderen.be': {
                     id: 29,
                     url: this._matomoOefenUrl,
                 },
@@ -225,7 +225,7 @@ class AnalyticsUtil {
                     id: 62,
                     url: this._matomoProdUrl,
                 },
-                'kruispuntbank.omgeving.vlaanderen.be': {
+                'informatie.omgeving.vlaanderen.be': {
                     id: 64,
                     url: this._matomoProdUrl,
                 },


### PR DESCRIPTION
De url van de Kruispuntbank Omgeving wijzigt n.a.v. de nieuwe naam "Omgevingsinformatie Vlaanderen". Hierdoor is de Matomo integratie gebroken.

Jira: [UIG-2635](https://www.milieuinfo.be/jira/browse/UIG-2635)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC90)