### PR TITLE
fix: UIG-2636 - vl-cookie-consent - waarschuwing wordt nu enkel getoond zonder de matomo parameters

### DIFF
--- a/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
+++ b/libs/sections/src/lib/cookie-consent/util/analytics.util.ts
@@ -250,14 +250,13 @@ class AnalyticsUtil {
     }
 
     get id(): { id: number; url: string } | undefined {
-        let urlIdResult = this.getUrlIdMatch();
         if (this.matomoParameters) {
             const { matomoId, matomoUrl } = this.matomoParameters;
             if (matomoId && matomoUrl) {
-                urlIdResult = { id: matomoId, url: matomoUrl };
+                return { id: matomoId, url: matomoUrl };
             }
         }
-        return urlIdResult;
+        return this.getUrlIdMatch();
     }
 
     get script(): HTMLScriptElement {


### PR DESCRIPTION
jira: https://www.milieuinfo.be/jira/browse/UIG-2636
bamboo: https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC92