### PR TITLE
feat: UIG-2649 - vl-form - validate methode toegevoegd die kan gebruikt worden zonder submit

### DIFF
--- a/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
+++ b/libs/elements/src/lib/form-validation/vl-form-validation.lib.js
@@ -7100,6 +7100,17 @@
                         // feat: UIG-2504 - vl-form - validatie voor dynamische toegevoegde form-elementen
                         { signal: form.abortController.signal }
                     );
+                    // UIG-2649 - valideer methode toegevoegd die kan gebruikt worden zonder submit
+                    form.addEventListener(
+                        'vl-validate',
+                        function validateForm() {
+                            const constraints = validationConfig.constraints;
+                            const errors = validate(form, constraints, fvValidatorOptions);
+                            _handleErrors(form, errors || {}, true);
+                            return errors;
+                        },
+                        { signal: form.abortController.signal }
+                    );
                 },
             },
             {

--- a/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
+++ b/libs/elements/src/lib/form/stories/vl-form-validation.stories-doc.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, DocsStory, PRIMARY_STORY } from '@storybook/addon-docs';
+import { ArgsTable, DocsStory, Source, PRIMARY_STORY } from '@storybook/addon-docs';
 
 # Form Validatie
 
@@ -64,6 +64,31 @@ Met `vl-form-group` wordt styling toegevoegd om makkelijker te onderscheiden tus
 Zie voorbeeld hieronder:
 
 <DocsStory id="elements-form--form-group" />
+
+### Valideren zonder submit
+
+Voor validatie in de context van een single page application, willen we typisch ook geen submit uitvoeren maar enkel de inputs van de form valideren.
+Om dit te doen kan je de functie `requestValidation()` aanroepen op de `vl-form`-instantie.
+
+Dit zal de achterliggende `validate.js`-validatie uitvoeren zonder de form te submitten.
+
+Hieronder zie je een voorbeeld hoe je dit zou kunnen gebruiken:
+
+<details>
+<summary>voorbeeld code</summary>
+<Source
+    language="js"
+    format={true}
+    dark
+    code={`
+    // form instantie ophalen
+    const vlForm = document.querySelector('form[is="vl-form"]#eerste-form');
+    // valideren zonder submit
+    vlForm.requestValidation();
+    // native "checkValidity()" methode geeft validiteit de form terug
+    console.log('vlForm.checkValidity', vlForm.checkValidity());`}
+></Source>
+</details>
 
 ## Referenties
 

--- a/libs/elements/src/lib/form/vl-form.element.ts
+++ b/libs/elements/src/lib/form/vl-form.element.ts
@@ -35,6 +35,13 @@ export class VlFormElement extends BaseElementOfType(HTMLFormElement) {
         this.observer?.disconnect();
     }
 
+    /**
+     * will process validation for all inputs in the form without submitting
+     */
+    requestValidation(): void {
+        this.dispatchEvent(new Event('vl-validate'));
+    }
+
     get _targetElement() {
         return this.querySelector(`iframe[name="${VlFormElement._targetElementName}"]`);
     }


### PR DESCRIPTION
Het is relatief eenvoudig om de `validate()` methode toe te voegen die afnemer toelaat al de inputs te valideren zoals `validate.js` het doet wanneer je op submit drukt (maar dan zonder te submitten).

---

Reden dat ik het via een event doe, is omdat `validate.js` binnen een closure per form configuratie opstelt en interne state bijhoudt. Het is ook die state die ik nodig heb om de valideer methode naar buiten te werken. Als ik de functie naar buiten werk, moet ik de state ook naar buiten werk daarom hier gewerkt met event handling (gelijkaardig aan submit).