### PR TITLE
feat: UIG-2549 - vl-map - disableRotation attribuut uitgebreid zodat …

### DIFF
--- a/libs/map/src/lib/actions/map/custom-map.ts
+++ b/libs/map/src/lib/actions/map/custom-map.ts
@@ -6,6 +6,7 @@ import View from 'ol/View';
 import Overlay from 'ol/Overlay';
 import { Zoom, Rotate, ScaleLine, OverviewMap } from 'ol/control';
 import { VlMapWithActions } from './map-with-actions';
+import { MapOptions } from '../../vl-map.model';
 
 /**
  * Dit is een versie van de VlMapWithActions die nog enkele extra functies bevat zoals het zoomen naar een bepaalde extent (of bounding box), het togglen van de layers, en alle functionaliteit omtrent een overzichtskaartje (ol.control.OverviewMap).
@@ -22,15 +23,18 @@ export class VlCustomMap extends VlMapWithActions {
     private maxZoomViewToExtent: any;
     private overviewMapLayers: any;
 
-    constructor(options) {
+    constructor(options: MapOptions) {
+        const { disableRotation } = options;
+
         options.layers = [options.customLayers.baseLayerGroup, options.customLayers.overlayGroup];
 
         options.controls = [
+            ...(options.controls || []),
             new Rotate(),
             new ScaleLine({
                 minWidth: 128,
             }),
-        ].concat(options.controls || []);
+        ];
 
         options.view = new View({
             // default
@@ -40,6 +44,7 @@ export class VlCustomMap extends VlMapWithActions {
             minZoom: 2,
             center: [140860.69299028325, 190532.7165957574],
             zoom: 2,
+            enableRotation: !disableRotation,
             // overwrite default
             ...options.view,
         });

--- a/libs/map/src/lib/actions/map/map-with-actions.ts
+++ b/libs/map/src/lib/actions/map/map-with-actions.ts
@@ -1,15 +1,6 @@
 import { defaults } from 'ol/interaction';
 import Map from 'ol/Map';
-import { CONTROL_TYPE } from '../../vl-map.model';
-
-export interface VlMapActionOptions {
-    disableEscapeKey?: Boolean;
-    actions?: any;
-    interactions?: any;
-    disableKeyboard?: Boolean;
-    disableRotation?: Boolean;
-    disableMouseWheelZoom?: Boolean;
-}
+import { CONTROL_TYPE, MapOptions } from '../../vl-map.model';
 
 /**
  * Deze map bevat enkel de functionaliteit om de acties te behandelen. Aan het eerste argument van de constructor kan het gebruikelijke object map opties worden weergegeven die ook op de ol.Map worden gezet, samen met een extra parameter 'acties' in dat object. Deze array bevat MapActions.
@@ -24,7 +15,7 @@ export class VlMapWithActions extends Map {
         return 300;
     }
 
-    constructor(options: VlMapActionOptions = <VlMapActionOptions>{}) {
+    constructor(options: MapOptions = <MapOptions>{}) {
         const { disableRotation, disableMouseWheelZoom, disableKeyboard } = options;
         const enableRotation = !disableRotation;
         const enableMouseWheelZoom = !disableMouseWheelZoom;

--- a/libs/map/src/lib/vl-map.model.ts
+++ b/libs/map/src/lib/vl-map.model.ts
@@ -3,6 +3,13 @@ import OlVectorLayer from 'ol/layer/Vector';
 import OlClusterSource from 'ol/source/Cluster';
 import { FilterFunction as OlFilterFunction } from 'ol/interaction/Select';
 import { StyleLike as OlStyleLike } from 'ol/style/Style';
+import LayerGroup from 'ol/layer/Group';
+import Projection from 'ol/proj/Projection';
+import Control from 'ol/control/Control';
+import View from 'ol/View';
+import Interaction from 'ol/interaction/Interaction';
+import Collection from 'ol/Collection';
+import { VlBaseMapAction } from './actions/mapaction';
 
 export const EVENT = {
     ACTIVE_ACTION_CHANGED: 'vl-active-action-changed',
@@ -38,4 +45,26 @@ export interface MapActionPayload {
     layer?: OlVectorLayerType;
     callback?: (...args: any[]) => void;
     options?: ActionOptions;
+}
+
+export interface MapOptions {
+    actions?: VlBaseMapAction[];
+    custom?: any;
+    defaultZoom?: boolean;
+    disableEscapeKey?: boolean;
+    disableRotation?: boolean;
+    disableMouseWheelZoom?: boolean;
+    disableKeyboard?: boolean;
+    maxZoomViewToExtent?: number;
+    controls?: Control[];
+    customLayers?: {
+        baseLayerGroup: LayerGroup;
+        overviewMapLayers: any;
+        overlayGroup: LayerGroup;
+    };
+    interactions?: Collection<Interaction>;
+    layers?: LayerGroup[];
+    projection?: Projection;
+    target?: any;
+    view?: View;
 }


### PR DESCRIPTION
…er niet meer geroteerd kan worden

---

bamboo: https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC99
jira: https://www.milieuinfo.be/jira/browse/UIG-2549

---

toen ik verder in code keek zag ik dat er al een parameter `disableRotation` beschikbaar is; op zich kan door deze parameter op "true" te zetten vandaag bovenstaand probleem al verhelpen.

Echter, die gaat rotatie niet uitzetten maar wel de volgende interacties door de gebruiker uitzetten:
- altShiftDragRotate
- pinchRotate
wat er voor zorgt dat althans met bovenstaande acties het moeilijk is om de gebruiker om te roteren (maar waarbij de gebruiker in theorie nog steeds kan rotatie uitvoeren).

Heb `disableRotation` nu uitgebreid dat het ook "enableRotation" van OpenLayers op false gaat zetten (default is true)

zie OpenLayer docs: https://openlayers.org/en/v6.15.1/apidoc/module-ol_View.html#~ViewOptions