### PR TITLE
feat: UIG-2601 - vl-cookie-consent - close event

### DIFF
--- a/apps/storybook-e2e/src/e2e/sections/cookie-consent/vl-cookie-consent.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/sections/cookie-consent/vl-cookie-consent.stories.cy.ts
@@ -3,7 +3,8 @@ const cookieConsentUrl =
 
 describe('story vl-cookie-consent', () => {
     it('should contain the `Cookie-toestemming`', () => {
-        cy.visit(`${cookieConsentUrl}`);
+        cy.visit(cookieConsentUrl);
+
         cy.get('button#button-open-cookie-consent').click();
         cy.get('vl-cookie-consent').shadow().find('vl-modal').shadow().find('h2').contains('Cookie-toestemming');
         cy.get('vl-cookie-consent')
@@ -18,9 +19,20 @@ describe('story vl-cookie-consent', () => {
     it('should contain the given matomo id & matomo url', () => {
         const matomoId = 12345;
         const matomoUrl = 'fake-matomo-url';
+
         cy.visit(`${cookieConsentUrl}&args=matomoId:${matomoId};matomoUrl:${matomoUrl}`);
+
         cy.get('script#vl-cookie-consent-matomo-script')
             .should('contain.text', `_paq.push(['setSiteId', ${matomoId}]);`)
             .should('contain.text', `var u='${matomoUrl}'`);
+    });
+
+    it('should emit event on close', () => {
+        cy.visit(cookieConsentUrl);
+
+        cy.createStubForEvent('vl-cookie-consent', 'vl-close');
+        cy.get('button#button-open-cookie-consent').click();
+        cy.get('vl-cookie-consent').shadow().find('vl-modal').find('button[slot="button"]').click();
+        cy.get('@vl-close').should('have.been.calledOnce');
     });
 });

--- a/libs/components/src/lib/modal/vl-modal.component.ts
+++ b/libs/components/src/lib/modal/vl-modal.component.ts
@@ -113,7 +113,7 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
      */
     open() {
         vl.modal.lastClickedToggle = this._dialogElement;
-        if (!this._dialogElement.hasAttribute('open')) {
+        if (!this.isOpen()) {
             awaitUntil(() => this._dialogElement.isConnected).then(() => {
                 vl.modal.toggle(this._dialogElement);
                 this._dialogElement?.focus();
@@ -125,7 +125,7 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
      * Handmatig sluiten van modal.
      */
     close() {
-        if (this._dialogElement.hasAttribute('open')) {
+        if (this.isOpen()) {
             vl.modal.toggle(this._dialogElement);
         }
     }
@@ -137,6 +137,24 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
      */
     on(event: string, callback: any) {
         this._dialogElement?.addEventListener(event, callback);
+    }
+
+    /**
+     * Mogelijkheid om event listeners die op de dialog geplaatst zijn te verwijderen.
+     * Zie dat je dezelfde referentie voor de callback meegeeft als bij het toevoegen van de event listener.
+     * @param {String} event
+     * @param {Function} callback
+     */
+    off(event: string, callback: any) {
+        this._dialogElement?.removeEventListener(event, callback);
+    }
+
+    /**
+     * Geeft terug of de modal geopend is.
+     * @return {boolean}
+     */
+    isOpen() {
+        return this._dialogElement?.hasAttribute('open');
     }
 
     _getCloseButtonTemplate() {

--- a/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-arg.ts
+++ b/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories-arg.ts
@@ -1,5 +1,6 @@
 import { ArgTypes } from '@storybook/web-components';
 import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
+import { action } from '@storybook/addon-actions';
 
 export const cookieConsentArgs = {
     analytics: false,
@@ -9,6 +10,7 @@ export const cookieConsentArgs = {
     link: '',
     matomoId: '',
     matomoUrl: '',
+    onClose: action('vl-close'),
 };
 
 export const cookieConsentArgTypes: ArgTypes<typeof cookieConsentArgs> = {
@@ -78,6 +80,13 @@ export const cookieConsentArgTypes: ArgTypes<typeof cookieConsentArgs> = {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: cookieConsentArgs.matomoUrl },
+        },
+    },
+    onClose: {
+        name: 'vl-close',
+        description: 'Afgevuurd nadat het cookie-consent modal gesloten wordt.',
+        table: {
+            category: CATEGORIES.EVENTS,
         },
     },
 };

--- a/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories.ts
+++ b/libs/sections/src/lib/cookie-consent/stories/vl-cookie-consent.stories.ts
@@ -18,11 +18,10 @@ export default {
 
 export const cookieConsentDefault = story(
     cookieConsentArgs,
-    ({ analytics, autoOptInFunctionalDisabled, owner, link, matomoId, matomoUrl }) =>
+    ({ analytics, autoOptInFunctionalDisabled, owner, link, matomoId, matomoUrl, onClose }) =>
         html`
             <div>
                 <vl-cookie-consent
-                    data-cy="cookie-consent"
                     id="cookie-consent"
                     data-vl-analytics=${analytics}
                     data-vl-matomo-id=${matomoId}
@@ -31,9 +30,9 @@ export const cookieConsentDefault = story(
                     ?data-vl-auto-opt-in-functional-disabled=${autoOptInFunctionalDisabled}
                     data-vl-owner=${owner}
                     data-vl-link=${link}
+                    @vl-close=${onClose}
                 ></vl-cookie-consent>
                 <button
-                    data-cy="button-open-cookie-consent"
                     id="button-open-cookie-consent"
                     is="vl-button"
                     onClick="document.querySelector('#cookie-consent').open();"

--- a/libs/sections/src/lib/cookie-consent/vl-cookie-consent.section.ts
+++ b/libs/sections/src/lib/cookie-consent/vl-cookie-consent.section.ts
@@ -13,7 +13,6 @@ export class VlCookieConsent extends BaseElementOfType(HTMLElement) {
         return ['owner', 'link', 'matomo-id', 'matomo-url', 'analytics'];
     }
 
-    //*
     connectedCallback() {
         super.connectedCallback();
 
@@ -28,6 +27,12 @@ export class VlCookieConsent extends BaseElementOfType(HTMLElement) {
             }
             this.__addAnalyticsIfOptedIn();
         }
+
+        this._modalElement?.on('close', this._dispatchCloseEvent);
+    }
+
+    disconnectedCallback() {
+        this._modalElement?.off('close', this._dispatchCloseEvent);
     }
 
     constructor() {
@@ -155,6 +160,14 @@ export class VlCookieConsent extends BaseElementOfType(HTMLElement) {
      */
     isOptInActive(name: string) {
         return this._optIns[name] ? this._optIns[name].value : false;
+    }
+
+    /**
+     * Geeft terug of de cookie-consent modal geopend is.
+     * @return {boolean}
+     */
+    isOpen() {
+        return this._modalElement?.isOpen();
     }
 
     get _isAutoOpenDisabled() {
@@ -385,6 +398,12 @@ export class VlCookieConsent extends BaseElementOfType(HTMLElement) {
         this._linkElement.innerText = newValue;
         this._linkElement.href = newValue;
     }
+
+    // Deze methode bewust apart gedefiniëerd als een arrow-functie
+    // zodat dezelfde referentie meegegeven kan worden bij het verwijderen van de event listener.
+    _dispatchCloseEvent = () => {
+        this.dispatchEvent(new CustomEvent('vl-close'));
+    };
 }
 
 declare global {


### PR DESCRIPTION
Dispatch close event bij sluiten van de cookie-consent modal 
IsOpen methode toegevoegd aan vl-modal en vl-cookie-consent
Cypress test toegevoegd

[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC101)
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2601)