### PR TITLE
feat: UIG-2549 - vl-map - OpenLayers bijgewerkt tot v6.15.1

### DIFF
--- a/libs/map/src/lib/actions/draw/draw-line-action.ts
+++ b/libs/map/src/lib/actions/draw/draw-line-action.ts
@@ -1,8 +1,7 @@
-import GeometryType from 'ol/geom/GeometryType';
 import { VlDrawAction } from './draw-action';
 
 export class VlDrawLineAction extends VlDrawAction {
   constructor(layer, onDraw, options = {}) {
-    super(layer, GeometryType.LINE_STRING, onDraw, options);
+    super(layer, 'LineString', onDraw, options);
   }
 }

--- a/libs/map/src/lib/actions/draw/draw-polygon-action.ts
+++ b/libs/map/src/lib/actions/draw/draw-polygon-action.ts
@@ -1,8 +1,7 @@
-import GeometryType from 'ol/geom/GeometryType';
 import { VlDrawAction } from './draw-action';
 
 export class VlDrawPolygonAction extends VlDrawAction {
   constructor(layer, onDraw, options = {}) {
-    super(layer, GeometryType.POLYGON, onDraw, options);
+    super(layer, 'Polygon', onDraw, options);
   }
 }

--- a/libs/map/src/lib/actions/draw/draw-rectangle-action.ts
+++ b/libs/map/src/lib/actions/draw/draw-rectangle-action.ts
@@ -1,5 +1,4 @@
 import { Polygon } from 'ol/geom';
-import GeometryType from 'ol/geom/GeometryType';
 import { VlDrawAction } from './draw-action';
 
 export class VlDrawRectangleAction extends VlDrawAction {
@@ -18,6 +17,6 @@ export class VlDrawRectangleAction extends VlDrawAction {
             maxPoints: 2,
             geometryFunction,
         };
-        super(layer, GeometryType.LINE_STRING, onDraw, options);
+        super(layer, 'LineString', onDraw, options);
     }
 }

--- a/libs/map/src/lib/actions/measure/measure-action.ts
+++ b/libs/map/src/lib/actions/measure/measure-action.ts
@@ -1,7 +1,6 @@
 import { EventsKey } from 'ol/events';
 import Overlay from 'ol/Overlay';
 import { unByKey } from 'ol/Observable';
-import GeometryType from 'ol/geom/GeometryType';
 import { VlDrawAction } from '../draw/draw-action';
 
 export class VlMeasureAction extends VlDrawAction {
@@ -13,7 +12,7 @@ export class VlMeasureAction extends VlDrawAction {
   constructor(layer, options?) {
     super(
       layer,
-      GeometryType.LINE_STRING,
+      'LineString',
       () => {
         unByKey(this.measurePointermoveHandler);
       },

--- a/libs/map/src/lib/components/action/draw-action/draw-point-action/vl-map-draw-point-action.ts
+++ b/libs/map/src/lib/components/action/draw-action/draw-point-action/vl-map-draw-point-action.ts
@@ -1,5 +1,4 @@
 import { webComponent } from '@domg-wc/common-utilities';
-import GeometryType from 'ol/geom/GeometryType';
 import { VlDrawAction } from '../../../../actions';
 import { VlMapDrawAction } from '../vl-map-draw-action';
 
@@ -17,7 +16,7 @@ import { VlMapDrawAction } from '../vl-map-draw-action';
 @webComponent('vl-map-draw-point-action')
 export class VlMapDrawPointAction extends VlMapDrawAction {
     _createAction(layer?): any {
-        return new VlDrawAction(layer, GeometryType.POINT, this._callback, this.__drawOptions);
+        return new VlDrawAction(layer, 'Point', this._callback, this.__drawOptions);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
                 "mochawesome-report-generator": "6.2.0",
                 "node-fetch": "3.3.1",
                 "nx": "15.8.6",
-                "ol": "6.14.1",
+                "ol": "6.15.1",
                 "react": "17.0.2",
                 "react-dom": "17.0.2",
                 "semantic-release": "20.1.1",
@@ -6587,9 +6587,9 @@
             }
         },
         "node_modules/@petamoriken/float16": {
-            "version": "3.8.1",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@petamoriken/float16/-/float16-3.8.1.tgz",
-            "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg==",
+            "version": "3.8.3",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@petamoriken/float16/-/float16-3.8.3.tgz",
+            "integrity": "sha512-an2OZ7/6er9Jja8EDUvU/tmtGIutdlb6LwXOwgjzoCjDRAsUd8sRZMBjoPEy78Xa9iOp+Kglk2CHgVwZuZbWbw==",
             "dev": true
         },
         "node_modules/@phenomnomnominal/tsquery": {
@@ -24325,22 +24325,41 @@
             }
         },
         "node_modules/geotiff": {
-            "version": "2.0.7",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/geotiff/-/geotiff-2.0.7.tgz",
-            "integrity": "sha512-FKvFTNowMU5K6lHYY2f83d4lS2rsCNdpUC28AX61x9ZzzqPNaWFElWv93xj0eJFaNyOYA63ic5OzJ88dHpoA5Q==",
+            "version": "2.0.4",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/geotiff/-/geotiff-2.0.4.tgz",
+            "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
             "dev": true,
             "dependencies": {
                 "@petamoriken/float16": "^3.4.7",
                 "lerc": "^3.0.0",
+                "lru-cache": "^6.0.0",
                 "pako": "^2.0.4",
                 "parse-headers": "^2.0.2",
-                "quick-lru": "^6.1.1",
                 "web-worker": "^1.2.0",
                 "xml-utils": "^1.0.2"
             },
             "engines": {
+                "browsers": "defaults",
                 "node": ">=10.19"
             }
+        },
+        "node_modules/geotiff/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/geotiff/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
@@ -37333,26 +37352,25 @@
             "dev": true
         },
         "node_modules/ol": {
-            "version": "6.14.1",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/ol/-/ol-6.14.1.tgz",
-            "integrity": "sha512-sIcUWkGud3Y2gT3TJubSHlkyMXiPVh1yxfCPHxmY8+qtm79bB9oRnei9xHVIbRRG0Ro6Ldp5E+BMVSvYCxSpaA==",
+            "version": "6.15.1",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/ol/-/ol-6.15.1.tgz",
+            "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
             "dev": true,
             "dependencies": {
-                "geotiff": "^2.0.2",
-                "ol-mapbox-style": "^7.1.1",
+                "geotiff": "2.0.4",
+                "ol-mapbox-style": "^8.0.5",
                 "pbf": "3.2.1",
                 "rbush": "^3.0.1"
             }
         },
         "node_modules/ol-mapbox-style": {
-            "version": "7.1.1",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
-            "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
+            "version": "8.2.1",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
+            "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
             "dev": true,
             "dependencies": {
-                "@mapbox/mapbox-gl-style-spec": "^13.20.1",
-                "mapbox-to-css-font": "^2.4.1",
-                "webfont-matcher": "^1.1.0"
+                "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+                "mapbox-to-css-font": "^2.4.1"
             }
         },
         "node_modules/on-finished": {
@@ -39267,15 +39285,6 @@
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
-        },
-        "node_modules/quick-lru": {
-            "version": "6.1.1",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-6.1.1.tgz",
-            "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
         },
         "node_modules/quickselect": {
             "version": "2.0.0",
@@ -45936,12 +45945,6 @@
             "version": "1.2.0",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/web-worker/-/web-worker-1.2.0.tgz",
             "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
-            "dev": true
-        },
-        "node_modules/webfont-matcher": {
-            "version": "1.1.0",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-            "integrity": "sha512-ov8lMvF9wi4PD7fK2Axn9PQEpO9cYI0fIoGqErwd+wi8xacFFDmX114D5Q2Lw0Wlgmb+Qw/dKI2KTtimrJf85g==",
             "dev": true
         },
         "node_modules/webfonts-generator": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "mochawesome-report-generator": "6.2.0",
         "node-fetch": "3.3.1",
         "nx": "15.8.6",
-        "ol": "6.14.1",
+        "ol": "6.15.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "semantic-release": "20.1.1",


### PR DESCRIPTION
Voornaamste aanpassing in kader van upgrade was: Replacement of string enums with union types.
Volledige lijst van changes voor v6.15.1: https://github.com/openlayers/openlayers/releases/tag/v6.15.0