### PR TITLE
fix: UIG-2663 - vl-map-search - features niet klikbaar dichtbij search

### DIFF
--- a/libs/components/src/search/vl-search.uig-css.ts
+++ b/libs/components/src/search/vl-search.uig-css.ts
@@ -125,7 +125,6 @@ const styles: CSSResult = css`
         display: block;
         width: 100%;
         text-align: left;
-        padding-right: 5rem;
     }
     .vl-search--inline .vl-search__input:focus,
     .vl-search--inline slot[name='input']:focus {
@@ -218,11 +217,15 @@ const styles: CSSResult = css`
     :host([data-vl-inline]) slot[name='input'] {
         box-sizing: content-box;
     }
+    :host([data-vl-inline]) slot[name='input'] + .vl-search__submit {
+        display: none;
+    }
     :host([data-vl-inline]) slot[name='input'].is-open + .vl-search__submit {
         transition: opacity 0.2s, transform 0.2s;
         z-index: 1000;
         opacity: 1;
         transform: translateX(0%);
+        display: block;
     }
     :host([data-vl-inline]) ::slotted(.js-vl-select) {
         background: white !important;

--- a/libs/map/src/components/search/vl-map-search.ts
+++ b/libs/map/src/components/search/vl-map-search.ts
@@ -46,6 +46,11 @@ export class VlMapSearch extends BaseElementOfType(HTMLElement) {
             :host {
               display: block;
             }
+
+            vl-search {
+                display: block;
+                height: 3.5rem;
+            }
           </style>
           <vl-search id="search" data-vl-inline>
             <select is="vl-select-location" slot="input"></select>


### PR DESCRIPTION
Fix voor features die niet klikbaar zijn indien ze zich dichtbij de search bar bevinden

[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC112)
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2663)