### PR TITLE
fix: UIG-2685 - vl-side-navigation - mobile werkt niet correct

### DIFF
--- a/libs/elements/src/side-navigation/vl-side-navigation.lib.js
+++ b/libs/elements/src/side-navigation/vl-side-navigation.lib.js
@@ -1,3 +1,4 @@
+import '@govflanders/vl-ui-util/src/js/breakpoint';
 import ScrollSpy from './vl-side-navigation.scrollspy.lib';
 
 // UIG-2278: vl lijkt niet in alle gevallen defined te zijn, terwijl deze lib daar precies wel op steunt
@@ -245,20 +246,19 @@ class Sticky {
 
                     // Force _stickyPosition, calc all dimensions, check breakpoint
                     case 'resize': {
-                        // if breakpoint has changed compared to previous one; reset sticky
-                        if (this.previousBreakPointValue !== vl.breakpoint.value) {
-                            this.destroy();
-                            this.updateStyleWhenSmall();
+                        if (vl.util.exists(vl.breakpoint)) {
+                            // if breakpoint has changed compared to previous one; reset sticky
+                            if (this.previousBreakPointValue !== vl.breakpoint.value) {
+                                this.previousBreakPointValue = vl.breakpoint.value;
+                                this.destroy();
+                            }
                         }
-                        this.previousBreakPointValue = vl.breakpoint.value;
                     }
                     // eslint-disable-next-line no-fallthrough
                     default:
                         this._widthBreakpoint();
-                        // if (this.container) {
                         this._calcDimensions();
                         this._stickyPosition(true);
-                        // }
                         break;
                 }
                 this._running = false;


### PR DESCRIPTION
Importeer breakpoint code van DV in vl-side-navigation.lib

De side-navigation op mobile werkte enkel correct in Storybook doordat het tabs component mee gedefineerd werd en deze een import had naar het breakpoint.js bestand van DV.
Ik heb in de side-navigation.lib.js de import toegevoegd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-2685)
[Bamboo]()