### PR TITLE
feat: UIG-2699 - vl-popover - z-index toegevoegd

### DIFF
--- a/apps/playground-lit/src/app/app.element.css.ts
+++ b/apps/playground-lit/src/app/app.element.css.ts
@@ -1,9 +1,8 @@
 import { css, CSSResult } from 'lit';
 
 const styles: CSSResult = css`
-    input[is='vl-input-field'] {
-        display: block;
-        margin-bottom: 10px;
+    main {
+        padding: 20px;
     }
 `;
 export default styles;

--- a/apps/playground-lit/src/app/app.element.ts
+++ b/apps/playground-lit/src/app/app.element.ts
@@ -1,7 +1,7 @@
 import { CSSResult, html, LitElement, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { vlElementsStyle } from '@domg-wc/elements';
-import { VlPopoverComponent } from '@domg-wc/components';
+import { VlPopoverComponent, VlPopoverActionComponent } from '@domg-wc/components';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import appElementStyle from './app.element.css';
 
@@ -17,18 +17,24 @@ export class AppElement extends LitElement {
 
     render(): TemplateResult {
         return html`
-            <a is="vl-link" id="btn-acties">Acties</a>
-            <vl-popover data-vl-for="btn-acties" data-vl-placement="bottom-start">
-                <ul is="vl-link-list">
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg gebruiker toe.</a>
-                    </li>
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg adres toe.</a>
-                    </li>
-                </ul>
-            </vl-popover
-
+            <main>
+                <a is="vl-link" id="btn-acties">Acties</a>
+                <vl-popover for="btn-acties" placement="bottom-start">
+                    <vl-popover-action-list
+                        @click=${(event: Event) => {
+                            const actionElement = event.target as VlPopoverActionComponent;
+                            if (actionElement instanceof VlPopoverActionComponent) {
+                                // do action
+                                console.log('vl-popover-action clicked > ' + actionElement.action);
+                            }
+                        }}
+                    >
+                        <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
+                        <vl-popover-action icon="bell" .action=${'report'}>Rapportenoverzicht</vl-popover-action>
+                        <vl-popover-action icon="pin" .action=${'locate'}>Vind locatie</vl-popover-action>
+                    </vl-popover-action-list>
+                </vl-popover>
+            </main>
         `;
     }
 }

--- a/apps/playground-native/src/app/app.element.scss
+++ b/apps/playground-native/src/app/app.element.scss
@@ -1,0 +1,3 @@
+main {
+    padding: 20px;
+}

--- a/apps/playground-native/src/app/app.element.ts
+++ b/apps/playground-native/src/app/app.element.ts
@@ -1,28 +1,45 @@
-import { VlPopoverComponent } from '@domg-wc/components';
+import { VlPopoverComponent, VlPopoverActionComponent } from '@domg-wc/components';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import './app.element.scss';
 
 export class AppElement extends HTMLElement {
     static {
-        registerWebComponents([VlPopoverComponent]);
+        registerWebComponents([VlPopoverComponent, VlPopoverActionComponent]);
     }
 
     constructor() {
         super();
-
         this.innerHTML = `
-            <a is="vl-link" id="btn-acties">Acties</a>
-            <vl-popover data-vl-for="btn-acties" data-vl-placement="bottom-start">
-                <ul is="vl-link-list">
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg gebruiker toe.</a>
-                    </li>
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg adres toe.</a>
-                    </li>
-                </ul>
-            </vl-popover>
+                        <main>
+                           <a is="vl-link" id="btn-acties">Acties</a>
+                                     <vl-popover for="btn-acties" placement="bottom-start" id="popover-acties">
+                                        <vl-popover-action-list>
+                                            <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
+                                            <vl-popover-action icon="bell" .action=${'report'}>Rapportenoverzicht</vl-popover-action>
+                                            <vl-popover-action icon="pin" .action=${'locate'}>Vind locatie</vl-popover-action>
+                                        </vl-popover-action-list>
+                                    </vl-popover>
+                        </main>
         `;
+    }
+
+    connectedCallback(): void {
+        const popover = this.querySelector('#popover-acties');
+        popover?.addEventListener('click', this.handlePopoverActionClicked);
+    }
+
+    disconnectedCallback(): void {
+        const popover = this.querySelector('#popover-acties');
+
+        popover?.removeEventListener('click', this.handlePopoverActionClicked);
+    }
+
+    handlePopoverActionClicked(event: Event): void {
+        const actionElement = event.target as VlPopoverActionComponent;
+        if (actionElement instanceof VlPopoverActionComponent) {
+            // do action
+            console.log('vl-popover-action clicked > ' + actionElement.action);
+        }
     }
 }
 customElements.define('app-element', AppElement);

--- a/apps/playground-react/src/app/app.module.css
+++ b/apps/playground-react/src/app/app.module.css
@@ -1,0 +1,3 @@
+main {
+    padding: 20px;
+}

--- a/apps/playground-react/src/app/app.tsx
+++ b/apps/playground-react/src/app/app.tsx
@@ -1,36 +1,62 @@
-import { VlPopoverComponent } from '@domg-wc/components';
+import { VlPopoverActionComponent, VlPopoverActionListComponent, VlPopoverComponent } from '@domg-wc/components';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import './app.module.css';
+import { DOMAttributes } from 'react';
 
-registerWebComponents([VlPopoverComponent]);
+registerWebComponents([VlPopoverActionComponent, VlPopoverActionListComponent, VlPopoverComponent]);
 
 export function App() {
     return (
-        <div>
+        <main>
             <a is="vl-link" id="btn-acties">
                 Acties
             </a>
-            <vl-popover data-vl-for="btn-acties" data-vl-placement="bottom-start">
-                <ul is="vl-link-list">
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg gebruiker toe.</a>
-                    </li>
-                    <li is="vl-link-list-item">
-                        <a is="vl-link">Voeg adres toe.</a>
-                    </li>
-                </ul>
+            <vl-popover
+                for="btn-acties"
+                placement="bottom-start"
+                onClick={(event: Event) => {
+                    const actionElement = event.target as VlPopoverActionComponent;
+                    if (actionElement instanceof VlPopoverActionComponent) {
+                        // do action
+                        console.log('vl-popover-action clicked > ' + actionElement.action);
+                    }
+                }}
+            >
+                <vl-popover-action-list>
+                    <vl-popover-action icon="search" action="search">
+                        Zoeken
+                    </vl-popover-action>
+                    <vl-popover-action icon="bell" action="report">
+                        Rapportenoverzicht
+                    </vl-popover-action>
+                    <vl-popover-action icon="pin" action="locate">
+                        Vind locatie
+                    </vl-popover-action>
+                </vl-popover-action-list>
             </vl-popover>
-        </div>
+        </main>
     );
 }
 
 export default App;
+
+declare module 'react' {
+    interface HTMLAttributes<T> extends DOMAttributes<T> {
+        for?: string;
+        placement?: string;
+        icon?: string;
+        action?: string;
+        onClick?: (event) => void;
+    }
+}
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace JSX {
         interface IntrinsicElements {
             'vl-popover': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            'vl-popover-action-list': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            'vl-popover-action': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
         }
     }
 }

--- a/libs/components/src/popover/vl-floating-ui.controller.ts
+++ b/libs/components/src/popover/vl-floating-ui.controller.ts
@@ -69,6 +69,10 @@ export default class FloatingController implements ReactiveController {
     }
 
     async updatePosition(): Promise<void> {
+        if (!this.getReferenceElement) {
+            return;
+        }
+
         const { x, y, strategy, placement, middlewareData } = await computePosition(
             this.getReferenceElement()!,
             this.host,

--- a/libs/components/src/popover/vl-popover.uig-css.ts
+++ b/libs/components/src/popover/vl-popover.uig-css.ts
@@ -6,6 +6,7 @@ const styles: CSSResult = css`
         width: max-content;
         top: 0;
         left: 0;
+        z-index: 10010;
     }
 
     i#popover-arrow {
@@ -26,6 +27,7 @@ const styles: CSSResult = css`
         */
         filter: drop-shadow(rgba(0, 0, 0, 0.1) 0px 0px 2.1rem) drop-shadow(rgb(207, 213, 221) -1px -1px 1px)
             drop-shadow(rgb(207, 213, 221) 1px 1px 1px);
+        will-change: filter;
         background-color: #fff;
         padding: 1rem;
     }


### PR DESCRIPTION
DV stelt zelf de z-index maximaal in op 1300 en via tinyMCE's styling zitten we aan 10002. Popover's z-index verhoogd tot 10010.
Playground voorbeelden bijgewerkt.
Nullcheck toegevoegd voor getReferenceElement.

---

[jira](https://www.milieuinfo.be/jira/browse/UIG-2699)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC124)

---

Playground React probleem voor `vl-popover`;

`Property 'for' does not exist on type 'DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>'.`

Geen `data-`-prefix gebruiken op custom elementen in een React app geeft problemen; 2 verschillende oplossingen in playground voorgesteld:
1. de 1 door HTMLAttributes te extenden (oplossing hier gevonden [https://github.com/styled-components/styled-components/issues/2528#issuecomment-509780963](https://github.com/styled-components/styled-components/issues/2528#issuecomment-509780963))
2. de ander door `@lit-labs/react`-package te gebruiken met `createComponent`-wrappers
Meer info: [https://lit.dev/docs/frameworks/react/#why-are-wrappers-needed](https://lit.dev/docs/frameworks/react/#why-are-wrappers-needed)

Voorkeur voor mij gaat naar 2. (of mss is er nog een betere oplossing dan bovenstaande manieren)