### PR TITLE
fix: UIG-2724 - vl-search-result - null checks toegevoegd

### DIFF
--- a/libs/elements/src/search-results/vl-search-result.element.ts
+++ b/libs/elements/src/search-results/vl-search-result.element.ts
@@ -101,17 +101,17 @@ export class VlSearchResult extends BaseElementOfType(HTMLLIElement) {
     }
 
     _setMetaDataClasses() {
-        this._metaDataElement.classList.add(`${this._classPrefix}__meta-data`);
+        this._metaDataElement?.classList.add(`${this._classPrefix}__meta-data`);
     }
 
     _setTitleClasses() {
-        this._titleLinkElement.classList.add(`${this._classPrefix}__title__link`);
+        this._titleLinkElement?.classList.add(`${this._classPrefix}__title__link`);
     }
 
     _setContentClasses(element: Element) {
         const dlClass = `${this._classPrefix}__description-list`;
-        element.classList.add(dlClass);
-        element.querySelectorAll('dt').forEach((dt) => dt.classList.add(`${dlClass}__description`));
+        element?.classList.add(dlClass);
+        element?.querySelectorAll('dt').forEach((dt) => dt.classList.add(`${dlClass}__description`));
     }
 }
 


### PR DESCRIPTION
[jira](https://www.milieuinfo.be/jira/browse/UIG-2724)

[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC131)

---

in deze branch heb ik playground example toegevoegd: https://github.com/milieuinfo/uigov-web-components/tree/feature/UIG-2724_vl-search-results_playground-example
