### PR TITLE
fix: UIG-2639 - vl-infoblock - title verwerking verbeterd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/contact-card/vl-contact-card.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/contact-card/vl-contact-card.stories.cy.ts
@@ -2,14 +2,18 @@ const contactCardUrl =
     'http://localhost:8080/iframe.html?id=components-contact-card--contact-card-default&viewMode=story';
 
 describe('story vl-contact-card', () => {
+    it('should be accessible', () => {
+        cy.visitWithA11y(`${contactCardUrl}`);
+    });
+
     it('should contain a title', () => {
         cy.visit(`${contactCardUrl}`);
-        cy.getDataCy('contact-card').find('h2').contains('Departement Onderwijs en Vorming');
+        cy.get('vl-contact-card').find('vl-infoblock').shadow().find('h2').contains('Departement Onderwijs en Vorming');
     });
 
     it('should contain an address', () => {
         cy.visit(`${contactCardUrl}`);
-        cy.getDataCy('contact-card')
+        cy.get('vl-contact-card')
             .get('.vl-properties__list')
             .children()
             .eq(0)

--- a/apps/storybook-e2e/src/e2e/components/infoblock/vl-infoblock.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/infoblock/vl-infoblock.stories.cy.ts
@@ -1,85 +1,25 @@
 const infoblockUrl = 'http://localhost:8080/iframe.html?id=components-infoblock--infoblock-contact&viewMode=story';
 
 describe('story vl-infoblock', () => {
-    it('should contain a title', () => {
+    it('should display default story', () => {
         cy.visit(`${infoblockUrl}`);
-        cy.getDataCy('infoblock').find('h2[slot="title"]').contains('Contactenlijst');
     });
 
-    it('should contain content', () => {
-        cy.visit(`${infoblockUrl}`);
-        cy.getDataCy('infoblock').contains(
-            'Hieronder bevindt zich een overzicht van al uw contacten binnen de Vlaamse Overheid.'
-        );
+    const types = ['contact', 'publications', 'faq', 'news', 'timeline'];
+    types.forEach((type) => {
+        it(`should display story for type ${type}`, () => {
+            const urlForType = `http://localhost:8080/iframe.html?id=components-infoblock--infoblock-${type}&viewMode=story`;
+            cy.visit(urlForType);
+        });
     });
 
-    it('should contain contact type infoblock', () => {
-        cy.visit(`${infoblockUrl}`);
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--contact');
-    });
-
-    it('should contain publications type infoblock', () => {
-        cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-publications&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--publications');
-    });
-
-    it('should contain FAQ type infoblock', () => {
-        cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-faq&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--faq');
-    });
-
-    it('should contain news type infoblock', () => {
-        cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-news&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--news');
-    });
-
-    it('should contain timeline type infoblock', () => {
-        cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-timeline&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--timeline');
-    });
-
-    it('should contain FAQ type infoblock', () => {
-        cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-faq&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock-element')
-            .should('have.class', 'vl-infoblock')
-            .should('have.class', 'vl-infoblock--faq');
-    });
-
-    it('should contain an infoblock with a custom icon', () => {
+    it('should display story for custom icon', () => {
         cy.visit('http://localhost:8080/iframe.html?id=components-infoblock--infoblock-custom-icon&viewMode=story');
-        cy.getDataCy('infoblock')
-            .shadow()
-            .find('#infoblock_icon')
-            .should('have.class', 'vl-infoblock__header__icon')
-            .should('have.attr', 'data-vl-icon', 'calendar');
     });
 
-    it('should contain an infoblock with a title set through a slot', () => {
+    it('should display story for slot elements', () => {
         cy.visit(
             'http://localhost:8080/iframe.html?id=components-infoblock--infoblock-with-slot-elements&viewMode=story'
         );
-        cy.getDataCy('infoblock-with-slot-elements').shadow().find('.vl-infoblock__title');
     });
 });

--- a/libs/common/utilities/src/base/base.html.element.ts
+++ b/libs/common/utilities/src/base/base.html.element.ts
@@ -2,7 +2,7 @@ declare const vl: any;
 
 export class BaseHTMLElement extends HTMLElement {
     protected allowCustomCSS = true;
-    private _shadow: any;
+    protected _shadow: ShadowRoot | undefined;
 
     /**
      * VlElement constructor die een shadow DOM voorziet op basis van de HTML {Literal} parameter.

--- a/libs/components/src/contact-card/stories/vl-contact-card.stories.ts
+++ b/libs/components/src/contact-card/stories/vl-contact-card.stories.ts
@@ -15,7 +15,7 @@ export default {
 
 export const contactCardDefault = story(
     {},
-    () => html` <vl-contact-card data-cy="contact-card">
+    () => html` <vl-contact-card>
         <vl-infoblock
             slot="info"
             data-vl-title="Departement Onderwijs en Vorming"

--- a/libs/components/src/infoblock/stories/vl-infoblock.stories.ts
+++ b/libs/components/src/infoblock/stories/vl-infoblock.stories.ts
@@ -14,12 +14,7 @@ const infoblockTemplate = story(
     infoblockArgs,
     ({ title, content, type, icon }) =>
         html`
-            <vl-infoblock
-                slot="info"
-                data-vl-title=${title}
-                data-vl-type=${type}
-                data-vl-icon=${icon}
-                data-cy="infoblock"
+            <vl-infoblock slot="info" data-vl-title=${title} data-vl-type=${type} data-vl-icon=${icon}
                 >${content}
             </vl-infoblock>
         `
@@ -91,7 +86,7 @@ infoblockCustomIcon.argTypes = {
 export const infoblockWithSlotElements = story(
     infoblockArgs,
     ({ title, content, type }) => html`
-        <vl-infoblock data-vl-type=${type} data-cy="infoblock-with-slot-elements">
+        <vl-infoblock data-vl-type=${type}>
             <h2 is="vl-h2" slot="title">${title}</h2>
             ${content}
         </vl-infoblock>

--- a/libs/components/src/infoblock/vl-infoblock.component.cy.ts
+++ b/libs/components/src/infoblock/vl-infoblock.component.cy.ts
@@ -1,0 +1,108 @@
+import { html } from 'lit-html';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlInfoblockComponent } from './index';
+
+registerWebComponents([VlInfoblockComponent]);
+
+const mountDefault = ({ title, content, type, icon }: { title: string; content: string; type: string; icon: string }) =>
+    cy.mount(html`
+        <vl-infoblock slot="info" data-vl-title=${title} data-vl-type=${type} data-vl-icon=${icon}
+            >${content}
+        </vl-infoblock>
+    `);
+
+export const mountWithSlotElements = ({
+    title,
+    content,
+    type,
+}: {
+    title: string;
+    content: string;
+    type: string;
+    icon: string;
+}) =>
+    cy.mount(html`
+        <vl-infoblock data-vl-type=${type}>
+            <h2 is="vl-h2" slot="title">${title}</h2>
+            ${content}
+        </vl-infoblock>
+    `);
+
+describe('story vl-infoblock - default', () => {
+    const title = 'Contactenlijst';
+    const content = 'Hieronder bevindt zich een overzicht van al uw contacten binnen de Vlaamse Overheid.';
+    const type = 'contact';
+    const icon = 'calendar';
+
+    beforeEach(() => {
+        mountDefault({ title, content, type, icon });
+    });
+
+    it('should mount', () => {
+        cy.get('vl-infoblock');
+    });
+
+    it('should be accessible', () => {
+        cy.injectAxe();
+
+        cy.checkA11y('vl-infoblock');
+    });
+
+    it('should contain a title', () => {
+        cy.get('vl-infoblock').shadow().find('h2').contains('Contactenlijst');
+    });
+
+    it('should contain content', () => {
+        cy.get('vl-infoblock').contains(
+            'Hieronder bevindt zich een overzicht van al uw contacten binnen de Vlaamse Overheid.'
+        );
+    });
+
+    it('should contain an infoblock with a custom icon', () => {
+        cy.get('vl-infoblock')
+            .shadow()
+            .find('#infoblock_icon')
+            .should('have.class', 'vl-infoblock__header__icon')
+            .should('have.attr', 'data-vl-icon', 'calendar');
+    });
+});
+
+describe('story vl-infoblock - types', () => {
+    const title = 'Contactenlijst';
+    const content = 'Hieronder bevindt zich een overzicht van al uw contacten binnen de Vlaamse Overheid.';
+    const icon = 'calendar';
+
+    const types = ['contact', 'publications', 'faq', 'news', 'timeline'];
+
+    types.forEach((type) => {
+        it(`should contain contact type ${type}`, () => {
+            mountDefault({ title, content, icon, type });
+
+            cy.get('vl-infoblock')
+                .shadow()
+                .find('#infoblock-element')
+                .should('have.class', 'vl-infoblock')
+                .should('have.class', `vl-infoblock--${type}`);
+        });
+    });
+});
+
+describe('story vl-infoblock with slots', () => {
+    const title = 'Contactenlijst';
+    const content = 'Hieronder bevindt zich een overzicht van al uw contacten binnen de Vlaamse Overheid.';
+    const icon = 'calendar';
+
+    beforeEach(() => {
+        mountWithSlotElements({ title, content, type: 'contact', icon });
+    });
+
+    it('should be accessible', () => {
+        cy.injectAxe();
+
+        cy.checkA11y('vl-infoblock');
+    });
+
+    it('should contain an infoblock with a title set through a slot', () => {
+        cy.get('vl-infoblock').shadow().find('.vl-infoblock__title');
+    });
+});

--- a/libs/components/src/infoblock/vl-infoblock.component.ts
+++ b/libs/components/src/infoblock/vl-infoblock.component.ts
@@ -1,4 +1,4 @@
-import { BaseElementOfType, registerWebComponents, webComponent } from '@domg-wc/common-utilities';
+import { BaseHTMLElement, registerWebComponents, webComponent } from '@domg-wc/common-utilities';
 import { VlH2Element, VlIconElement } from '@domg-wc/elements';
 import { resetStyle } from '@domg/govflanders-style/common';
 import { infoblockStyle } from '@domg/govflanders-style/component';
@@ -16,7 +16,7 @@ import { infoblockStyle } from '@domg/govflanders-style/component';
  * @property {string} data-vl-type - Er kan een vast icoon gekozen worden (contact, publications, faq, news, timeline, question)
  */
 @webComponent('vl-infoblock')
-export class VlInfoblockComponent extends BaseElementOfType(HTMLElement) {
+export class VlInfoblockComponent extends BaseHTMLElement {
     static {
         registerWebComponents([VlH2Element, VlIconElement]);
     }
@@ -34,7 +34,9 @@ export class VlInfoblockComponent extends BaseElementOfType(HTMLElement) {
           <section id="infoblock-element" class="vl-infoblock">
             <header class="vl-infoblock__header" role="presentation">
               <span is="vl-icon" id="infoblock_icon" class="vl-infoblock__header__icon"></span>
-              <slot name="title" class="vl-infoblock__title">Testa</slot>
+              <slot name="title">
+                    <h2 id="title_content" is="vl-h2" class="vl-infoblock__title"></h2>
+              </slot>
             </header>
             <div class="vl-infoblock__content" id="infoblock_content">
               <slot></slot>
@@ -48,16 +50,15 @@ export class VlInfoblockComponent extends BaseElementOfType(HTMLElement) {
 
         const title = this.getAttribute('title');
         if (title) {
-            this._titleChangedCallback('', this.getAttribute('title'));
+            this._titleChangedCallback('', title);
         }
     }
 
     _titleChangedCallback(oldValue: string, newValue: string) {
-        const currentSlot = this.querySelector('[slot="title"]');
+        const currentSlot = this.shadowRoot?.querySelector('#title_content');
         if (currentSlot) {
-            currentSlot.remove();
+            (currentSlot as HTMLElement).innerText = newValue;
         }
-        this.appendChild(this._template(`<h2 is="vl-h2" slot='title'>${newValue}</h2>`));
     }
 
     _iconChangedCallback(oldValue: string, newValue: string) {


### PR DESCRIPTION
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC140)

[vl-infoblock UIG-2725](https://www.milieuinfo.be/jira/browse/UIG-2725)

Voorheen werd een slot verwijderd als die niet ingevuld werd en dan dynamisch een `<h2 is="vl-h2">`-element toegevoegd. Het verwijderen van dat slot, verwijderde ook potentiëel de slots met zelfde naam van geslotte child components.

Nu, wordt de `<h2>` als default content in titleslot gestoken, en kan de afnemer zonder probleem dit slot ook overschreven en er wordt op geen enkel moment `<slot>`-elementen verwijderd.

- BaseHTMLElement typing verbeterd
- Cypress testen aangepast


