### PR TITLE
feat: UIG-2754 - vl-header - skeleton toegevoegd

### DIFF
--- a/apps/playground-lit/src/app/app.element.ts
+++ b/apps/playground-lit/src/app/app.element.ts
@@ -23,8 +23,6 @@ export class AppElement extends LitElement {
             <main>
                 <vl-side-sheet
                     data-vl-left
-                    data-vl-custom-css=""
-                    data-vl-open
                     data-vl-open
                     data-vl-custom-css=${'.vl-layout {padding:0px} .vl-region{padding:10px} .vl-region:first-child{padding:0} :host #vl-side-sheet {padding:0} :host {--vl-side-sheet-width: 600px;}'}
                 >

--- a/apps/playground-lit/src/index.html
+++ b/apps/playground-lit/src/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Playground Lit</title>
-    <base href="/" />
+    <head>
+        <meta charset="utf-8" />
+        <title>Playground Lit</title>
+        <base href="/" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
-  </head>
-  <body>
-    <app-element></app-element>
-  </body>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    </head>
+
+    <body>
+        <app-element></app-element>
+    </body>
 </html>

--- a/apps/storybook-e2e/src/e2e/components/accordion/vl-accordion.stories-wc.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/accordion/vl-accordion.stories-wc.cy.ts
@@ -21,11 +21,11 @@ const shouldBeToggleable = async () => {
     });
 };
 
-const shouldBeOpen = async() => {
+const shouldBeOpen = async () => {
     runTestFor<VlAccordionComponent>('vl-accordion', (component) => {
         expect(component._isOpen).to.be.true;
     });
-}
+};
 
 const shouldDisableAccordion = () => {
     runTestFor<VlAccordionComponent>('vl-accordion', (component) => {

--- a/apps/storybook-e2e/src/e2e/sections/header/vl-header.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/sections/header/vl-header.stories.cy.ts
@@ -18,4 +18,19 @@ describe('story vl-header', () => {
         cy.createStubForEvent('vl-header', 'ready');
         cy.get('@ready').should('have.been.calledOnce');
     });
+
+    describe('vl-header - container', () => {
+        it('should render', () => {
+            cy.visit(headerUrl);
+
+            cy.get('vl-header');
+            cy.get('#header__container').should('exist');
+        });
+
+        it('should render with fixed height', () => {
+            cy.visit(headerUrl);
+
+            cy.get('#header__container').should('have.css', 'min-height', '43px');
+        });
+    });
 });

--- a/libs/sections/src/header/stories/vl-header.stories-arg.ts
+++ b/libs/sections/src/header/stories/vl-header.stories-arg.ts
@@ -4,6 +4,7 @@ import { ArgTypes } from '@storybook/web-components';
 
 export const headerArgs = {
     authenticatedUserUrl: '/sso/ingelogde_gebruiker',
+    skeleton: false,
     development: false,
     identifier: '',
     loginRedirectUrl: '/',
@@ -15,6 +16,15 @@ export const headerArgs = {
 };
 
 export const headerArgTypes: ArgTypes<typeof headerArgs> = {
+    skeleton: {
+        name: 'data-vl-skeleton',
+        description: 'Geeft aan of de header een skeleton mag tonen voordat het rendert.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.skeleton },
+        },
+    },
     authenticatedUserUrl: {
         name: 'data-vl-authenticated-user-url',
         description: 'De url die wordt opgeroepen om te zien of een gebruiker is ingelogd.',

--- a/libs/sections/src/header/stories/vl-header.stories.ts
+++ b/libs/sections/src/header/stories/vl-header.stories.ts
@@ -22,6 +22,7 @@ export default {
 export const HeaderDefault = story(
     headerArgs,
     ({
+        skeleton,
         authenticatedUserUrl,
         development,
         identifier,
@@ -34,6 +35,7 @@ export const HeaderDefault = story(
     }) => html`
         <div is="vl-body">
             <vl-header
+                data-vl-skeleton=${skeleton}
                 data-vl-authenticated-user-url=${authenticatedUserUrl}
                 ?data-vl-development=${development}
                 data-vl-identifier=${identifier}
@@ -47,6 +49,7 @@ export const HeaderDefault = story(
         </div>
     `
 );
+
 HeaderDefault.storyName = 'vl-header - default';
 HeaderDefault.args = {
     development: true,

--- a/libs/sections/src/header/vl-header.section.cy.ts
+++ b/libs/sections/src/header/vl-header.section.cy.ts
@@ -1,0 +1,30 @@
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlHeader } from './index';
+import { html } from 'lit';
+
+registerWebComponents([VlHeader]);
+
+const mountHeaderWithSkeleton = () => {
+    return cy.mount(html`
+        <div is="vl-body">
+            <vl-header
+                data-vl-development="true"
+                data-vl-identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
+                data-vl-skeleton="true"
+            ></vl-header>
+        </div>
+    `);
+};
+
+describe('component vl-header - default', () => {
+    describe('with skeleton', () => {
+        beforeEach(() => {
+            mountHeaderWithSkeleton();
+        });
+
+        it('should render the skeleton container', () => {
+            cy.get('vl-header[data-vl-skeleton="true"]');
+            cy.get('#header__skeleton').should('exist');
+        });
+    });
+});

--- a/libs/sections/src/header/vl-header.section.uig-css.ts
+++ b/libs/sections/src/header/vl-header.section.uig-css.ts
@@ -1,0 +1,21 @@
+import { css } from 'lit';
+
+export const headerContainerStyles = css`
+    #header__container {
+        min-height: 43px;
+    }
+`;
+
+export const headerSkeletonStyles = css`
+    #header__skeleton {
+        content: '';
+        height: 43px;
+        width: 100%;
+        display: block;
+        background: #fff;
+    }
+
+    #header__container ~ #header__skeleton {
+        display: none;
+    }
+`;


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2754)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC164)


**PAS OP** @Goldflow @tonyvandeneynde @kspeltix @ksvlaanderen 

Dit kan "**Braking changes**" hebben voor het **_@inzage team_** omdat zij iets soortgelijks doen voor de header en het skelet, het idee komt van hen. 

Misschien kunnen we hen op de hoogte brengen, zodat ze hun aangepaste header-skeletscherm kunnen verwijderen, zo niet, dan zullen ze dubbele `header__skeleton` hebben.

Je kan het zien hier https://omgevingsloketinzage2-ontwikkel.omgeving.vlaanderen.be/  als je de header inspecteer 

ze noem het `<div id="vl-header-placeholder">`