### PR TITLE
feat: UIG-2709 - vl-datepicker-next - introductie component [zonder "visual-format"]

### DIFF
--- a/apps/playground-lit/src/app/app.element.ts
+++ b/apps/playground-lit/src/app/app.element.ts
@@ -9,18 +9,20 @@ import { VlCheckboxComponent } from '@domg-wc/components/next/form/checkbox';
 import { VlRadioComponent, VlRadioGroupComponent } from '@domg-wc/components/next/form/radio';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import appElementStyle from './app.element.css';
+import { VlDatepickerComponent } from '@domg-wc/components/next/form/datepicker';
 
 type SubmittedFormData = {
     voornaam?: string;
     achternaam?: string;
     interesses?: string;
+    geboortedatum?: string;
     geboorteplaats?: string;
     [`hobby's`]?: string;
     leeftijd?: number;
     kinderen?: number;
     adres?: string;
-    waarheidsgetrouw?: boolean;
     contactmethode?: string;
+    waarheidsgetrouw?: boolean;
 };
 
 @customElement('app-element')
@@ -29,30 +31,34 @@ export class AppElement extends LitElement {
     private firstNameRequired = false;
     private lastNameRequired = false;
     private interestsRequired = false;
+    private birthdateRequired = false;
     private birthplaceRequired = false;
     private hobbiesRequired = false;
     private ageRequired = false;
     private kidsRequired = false;
     private addressFieldRequired = false;
-    private filledInTruthfullyRequired = false;
     private preferredContactMethodRequired = false;
+    private filledInTruthfullyRequired = false;
 
     // Disabled state values
     private firstNameDisabled = false;
     private lastNameDisabled = false;
     private interestsDisabled = false;
+    private birthdateDisabled = false;
     private birthplaceDisabled = false;
     private hobbiesDisabled = false;
     private ageDisabled = false;
     private kidsDisabled = false;
     private addressFieldDisabled = false;
-    private filledInTruthfullyDisabled = false;
     private preferredContactMethodDisabled = false;
+
+    private filledInTruthfullyDisabled = false;
 
     // Read only state values
     private firstNameReadonly = false;
     private lastNameReadonly = false;
     private interestsReadonly = false;
+    private birthdateReadonly = false;
     private birthplaceReadonly = false;
     private hobbiesReadonly = false;
     private ageReadonly = false;
@@ -68,6 +74,7 @@ export class AppElement extends LitElement {
     private firstName = '';
     private lastName = '';
     private interests = '';
+    private birthdate = '';
     private birthplaces: SelectOption[] = [
         {
             label: 'België',
@@ -117,6 +124,7 @@ export class AppElement extends LitElement {
             VlCheckboxComponent,
             VlRadioComponent,
             VlRadioGroupComponent,
+            VlDatepickerComponent,
         ]);
     }
 
@@ -129,44 +137,48 @@ export class AppElement extends LitElement {
             firstNameRequired: { type: Boolean, state: true },
             lastNameRequired: { type: Boolean, state: true },
             interestsRequired: { type: Boolean, state: true },
+            birthdateRequired: { type: Boolean, state: true },
             birthplaceRequired: { type: Boolean, state: true },
             hobbiesRequired: { type: Boolean, state: true },
             ageRequired: { type: Boolean, state: true },
             kidsRequired: { type: Boolean, state: true },
             addressFieldRequired: { type: Boolean, state: true },
-            filledInTruthfullyRequired: { type: Boolean, state: true },
             preferredContactMethodRequired: { type: Boolean, state: true },
+            filledInTruthfullyRequired: { type: Boolean, state: true },
             firstNameDisabled: { type: Boolean, state: true },
             lastNameDisabled: { type: Boolean, state: true },
             interestsDisabled: { type: Boolean, state: true },
+            birthdateDisabled: { type: Boolean, state: true },
             birthplaceDisabled: { type: Boolean, state: true },
             hobbiesDisabled: { type: Boolean, state: true },
             ageDisabled: { type: Boolean, state: true },
             kidsDisabled: { type: Boolean, state: true },
             addressFieldDisabled: { type: Boolean, state: true },
-            filledInTruthfullyDisabled: { type: Boolean, state: true },
             preferredContactMethodDisabled: { type: Boolean, state: true },
+            filledInTruthfullyDisabled: { type: Boolean, state: true },
             firstNameReadonly: { type: Boolean, state: true },
             lastNameReadonly: { type: Boolean, state: true },
             interestsReadonly: { type: Boolean, state: true },
+            birthdateReadonly: { type: Boolean, state: true },
             birthplaceReadonly: { type: Boolean, state: true },
             hobbiesReadonly: { type: Boolean, state: true },
             ageReadonly: { type: Boolean, state: true },
             kidsReadonly: { type: Boolean, state: true },
             addressFieldReadonly: { type: Boolean, state: true },
-            filledInTruthfullyReadonly: { type: Boolean, state: true },
             preferredContactMethodReadonly: { type: Boolean, state: true },
+            filledInTruthfullyReadonly: { type: Boolean, state: true },
             firstName: { type: String, state: true },
             lastName: { type: String, state: true },
             interests: { type: String, state: true },
+            birthdate: { type: String, state: true },
             birthplaces: { type: Array, state: true },
             hobbies: { type: Array, state: true },
             age: { type: Number, state: true },
             kids: { type: Number, state: true },
             address: { type: String, state: true },
+            preferredContactMethod: { type: String, state: true },
             filledInTruthfully: { type: Boolean, state: true },
             filledInTruthfullyValue: { type: String, state: true },
-            preferredContactMethod: { type: String, state: true },
             showAddressField: { type: Boolean, state: true },
             submittedFormData: { type: Object, state: true },
             submittedCount: { type: Number, state: true },
@@ -388,6 +400,64 @@ export class AppElement extends LitElement {
                                     @click=${() => (this.interests = 'Coding, spreadsheets')}
                                 >
                                     Set 'Coding, spreadsheets'
+                                </button>
+                            </div>
+                        </div>
+                        <div class="vl-col--2-12">
+                            <label class="vl-form__label vl-form__label--block" for="geboortedatum">
+                                Geboortedatum${this.birthdateRequired ? ' *' : ''}
+                            </label>
+                        </div>
+                        <div class="vl-col--4-12">
+                            <vl-datepicker-next
+                                id="geboortedatum"
+                                name="geboortedatum"
+                                pattern="^(0?[1-9]|[12][0-9]|3[01])\\.(0?[1-9]|1[012])\\.([0-9]{4})$"
+                                block
+                                value=${this.birthdate}
+                                ?required=${this.birthdateRequired}
+                                ?disabled=${this.birthdateDisabled}
+                                @vl-input=${(e: CustomEvent) => (this.birthdate = e.detail.value)}
+                                @reset=${() => (this.birthdate = '')}
+                            >
+                            </vl-datepicker-next>
+                            <vl-error-message-next for="geboortedatum" state="valueMissing">
+                                Gelieve een geboortedatum in te vullen.
+                            </vl-error-message-next>
+                            <vl-error-message-next for="geboortedatum" state="patternMismatch">
+                                Gelieve het volgende datum formaat te gebruiken: "dd.mm.YYYY", bv. 01.12.1976 of
+                                1.2.1993
+                            </vl-error-message-next>
+                        </div>
+                        <div class="vl-col--6-12">
+                            <div class="vl-action-group">
+                                <button
+                                    class="vl-button ${!this.birthdateRequired ? 'vl-button--secondary' : ''}"
+                                    type="button"
+                                    @click=${() => (this.birthdateRequired = !this.birthdateRequired)}
+                                >
+                                    Required
+                                </button>
+                                <button
+                                    class="vl-button ${!this.birthdateDisabled ? 'vl-button--secondary' : ''}"
+                                    type="button"
+                                    @click=${() => (this.birthdateDisabled = !this.birthdateDisabled)}
+                                >
+                                    Disabled
+                                </button>
+                                <button
+                                    class="vl-button ${!this.birthdateReadonly ? 'vl-button--secondary' : ''}"
+                                    type="button"
+                                    @click=${() => (this.birthdateReadonly = !this.birthdateReadonly)}
+                                >
+                                    Readonly
+                                </button>
+                                <button
+                                    class="vl-button vl-button--secondary"
+                                    type="button"
+                                    @click=${() => (this.birthdate = '31.12.1976')}
+                                >
+                                    Select '31.12.1976'
                                 </button>
                             </div>
                         </div>
@@ -680,6 +750,71 @@ export class AppElement extends LitElement {
                                   </div>
                               `
                             : ''}
+
+                        <div class="vl-col--2-12">
+                            <label class="vl-form__label vl-form__label--block" for="contactmethode">
+                                Voorkeurscontactmethode${this.preferredContactMethodRequired ? ' *' : ''}
+                            </label>
+                        </div>
+                        <div class="vl-col--4-12">
+                            <vl-radio-group-next
+                                id="contactmethode"
+                                name="contactmethode"
+                                ?required=${this.preferredContactMethodRequired}
+                                ?disabled=${this.preferredContactMethodDisabled}
+                                ?readonly=${this.preferredContactMethodReadonly}
+                                value=${this.preferredContactMethod}
+                                @vl-checked=${(e: CustomEvent) => (this.preferredContactMethod = e.detail.value)}
+                            >
+                                <vl-radio-next value="e-mail">e-mail</vl-radio-next>
+                                <vl-radio-next value="telefoon">telefoon</vl-radio-next>
+                                <vl-radio-next value="post">post</vl-radio-next>
+                            </vl-radio-group-next>
+                            <vl-error-message-next for="contactmethode" state="valueMissing">
+                                Gelieve een contactmethode te selecteren.
+                            </vl-error-message-next>
+                        </div>
+                        <div class="vl-col--6-12">
+                            <div class="vl-action-group">
+                                <button
+                                    class="vl-button ${!this.preferredContactMethodRequired
+                                        ? 'vl-button--secondary'
+                                        : ''}"
+                                    type="button"
+                                    @click=${() =>
+                                        (this.preferredContactMethodRequired = !this.preferredContactMethodRequired)}
+                                >
+                                    Required
+                                </button>
+                                <button
+                                    class="vl-button ${!this.preferredContactMethodDisabled
+                                        ? 'vl-button--secondary'
+                                        : ''}"
+                                    type="button"
+                                    @click=${() =>
+                                        (this.preferredContactMethodDisabled = !this.preferredContactMethodDisabled)}
+                                >
+                                    Disabled
+                                </button>
+                                <button
+                                    class="vl-button ${!this.preferredContactMethodReadonly
+                                        ? 'vl-button--secondary'
+                                        : ''}"
+                                    type="button"
+                                    @click=${() =>
+                                        (this.preferredContactMethodReadonly = !this.preferredContactMethodReadonly)}
+                                >
+                                    Readonly
+                                </button>
+                                <button
+                                    class="vl-button vl-button--secondary"
+                                    type="button"
+                                    @click=${() => (this.preferredContactMethod = 'post')}
+                                >
+                                    Set 'post'
+                                </button>
+                            </div>
+                        </div>
                         <div class="vl-col--2-12">
                             <label class="vl-form__label vl-form__label--block" for="waarheidsgetrouw">
                                 Waarheidsgetrouw${this.filledInTruthfullyRequired ? ' *' : ''}
@@ -748,69 +883,6 @@ export class AppElement extends LitElement {
                                 </button>
                             </div>
                         </div>
-                        <div class="vl-col--2-12">
-                            <label class="vl-form__label vl-form__label--block" for="contactmethode">
-                                Voorkeurscontactmethode${this.preferredContactMethodRequired ? ' *' : ''}
-                            </label>
-                        </div>
-                        <div class="vl-col--4-12">
-                            <vl-radio-group-next
-                                id="contactmethode"
-                                name="contactmethode"
-                                ?required=${this.preferredContactMethodRequired}
-                                ?disabled=${this.preferredContactMethodDisabled}
-                                ?readonly=${this.preferredContactMethodReadonly}
-                                value=${this.preferredContactMethod}
-                            >
-                                <vl-radio-next value="e-mail">e-mail</vl-radio-next>
-                                <vl-radio-next value="telefoon">telefoon</vl-radio-next>
-                                <vl-radio-next value="post">post</vl-radio-next>
-                            </vl-radio-group-next>
-                            <vl-error-message-next for="contactmethode" state="valueMissing">
-                                Gelieve een contactmethode te selecteren.
-                            </vl-error-message-next>
-                        </div>
-                        <div class="vl-col--6-12">
-                            <div class="vl-action-group">
-                                <button
-                                    class="vl-button ${!this.preferredContactMethodRequired
-                                        ? 'vl-button--secondary'
-                                        : ''}"
-                                    type="button"
-                                    @click=${() =>
-                                        (this.preferredContactMethodRequired = !this.preferredContactMethodRequired)}
-                                >
-                                    Required
-                                </button>
-                                <button
-                                    class="vl-button ${!this.preferredContactMethodDisabled
-                                        ? 'vl-button--secondary'
-                                        : ''}"
-                                    type="button"
-                                    @click=${() =>
-                                        (this.preferredContactMethodDisabled = !this.preferredContactMethodDisabled)}
-                                >
-                                    Disabled
-                                </button>
-                                <button
-                                    class="vl-button ${!this.preferredContactMethodReadonly
-                                        ? 'vl-button--secondary'
-                                        : ''}"
-                                    type="button"
-                                    @click=${() =>
-                                        (this.preferredContactMethodReadonly = !this.preferredContactMethodReadonly)}
-                                >
-                                    Readonly
-                                </button>
-                                <button
-                                    class="vl-button vl-button--secondary"
-                                    type="button"
-                                    @click=${() => (this.preferredContactMethod = 'e-mail')}
-                                >
-                                    Set 'e-mail'
-                                </button>
-                            </div>
-                        </div>
                         <div class="vl-col--6-12 vl-push--2-12">
                             <div class="vl-action-group">
                                 <button class="vl-button" type="submit">Verstuur</button>
@@ -830,12 +902,14 @@ export class AppElement extends LitElement {
                                 <dd class="vl-properties__data">${this.submittedFormData.achternaam}</dd>
                                 <dt class="vl-properties__label">Interesses</dt>
                                 <dd class="vl-properties__data">${this.submittedFormData.interesses}</dd>
-                                <dt class="vl-properties__label">Geboorteplaats</dt>
-                                <dd class="vl-properties__data">${this.submittedFormData.geboorteplaats}</dd>
+                                <dt class="vl-properties__label">Geboortedatum</dt>
+                                <dd class="vl-properties__data">${this.submittedFormData.geboortedatum}</dd>
                             </dl>
                         </div>
                         <div class="vl-properties__column">
                             <dl class="vl-properties__list">
+                                <dt class="vl-properties__label">Geboorteplaats</dt>
+                                <dd class="vl-properties__data">${this.submittedFormData.geboorteplaats}</dd>
                                 <dt class="vl-properties__label">Hobby's</dt>
                                 <dd class="vl-properties__data">${this.submittedFormData[`hobby's`]}</dd>
                                 <dt class="vl-properties__label">Leeftijd</dt>
@@ -850,10 +924,10 @@ export class AppElement extends LitElement {
                         </div>
                         <div class="vl-properties__column">
                             <dl class="vl-properties__list">
-                                <dt class="vl-properties__label">Waarheidsgetrouw</dt>
-                                <dd class="vl-properties__data">${this.submittedFormData.waarheidsgetrouw}</dd>
                                 <dt class="vl-properties__label">Contactmethode</dt>
                                 <dd class="vl-properties__data">${this.submittedFormData.contactmethode}</dd>
+                                <dt class="vl-properties__label">Waarheidsgetrouw</dt>
+                                <dd class="vl-properties__data">${this.submittedFormData.waarheidsgetrouw}</dd>
                             </dl>
                         </div>
                     </div>
@@ -877,13 +951,14 @@ export class AppElement extends LitElement {
         this.lastName = '';
         this.interests = '';
         this.resetBirthplace();
+        this.birthdate = '';
         this.resetHobbies();
         this.age = null;
         this.kids = null;
         this.address = '';
+        this.preferredContactMethod = '';
         this.filledInTruthfully = false;
         this.filledInTruthfullyValue = '';
-        this.preferredContactMethod = '';
         this.submittedFormData = {};
         this.submittedCount = 0;
 
@@ -891,33 +966,36 @@ export class AppElement extends LitElement {
             this.firstNameRequired = false;
             this.lastNameRequired = false;
             this.interestsRequired = false;
+            this.birthdateRequired = false;
             this.birthplaceRequired = false;
             this.hobbiesRequired = false;
             this.ageRequired = false;
             this.kidsRequired = false;
             this.addressFieldRequired = false;
-            this.filledInTruthfullyRequired = false;
             this.preferredContactMethodRequired = false;
+            this.filledInTruthfullyRequired = false;
             this.firstNameDisabled = false;
             this.lastNameDisabled = false;
             this.interestsDisabled = false;
+            this.birthdateDisabled = false;
             this.birthplaceDisabled = false;
             this.hobbiesDisabled = false;
             this.ageDisabled = false;
             this.kidsDisabled = false;
             this.addressFieldDisabled = false;
-            this.filledInTruthfullyDisabled = false;
             this.preferredContactMethodDisabled = false;
+            this.filledInTruthfullyDisabled = false;
             this.firstNameReadonly = false;
             this.lastNameReadonly = false;
             this.interestsReadonly = false;
+            this.birthdateReadonly = false;
             this.birthplaceReadonly = false;
             this.hobbiesReadonly = false;
             this.ageReadonly = false;
             this.kidsReadonly = false;
             this.addressFieldReadonly = false;
-            this.filledInTruthfullyReadonly = false;
             this.preferredContactMethodReadonly = false;
+            this.filledInTruthfullyReadonly = false;
         }
     }
 

--- a/apps/storybook-e2e/src/e2e/components/next/form/datepicker/vl-datepicker.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/next/form/datepicker/vl-datepicker.stories.cy.ts
@@ -1,0 +1,10 @@
+const datepickerNextUrl =
+    'http://localhost:8080/iframe.html?args=&id=components-next-form-datepicker-next--datepicker-default&viewMode=story';
+
+describe('story vl-datepicker-next default', () => {
+    it('should render story', () => {
+        cy.visit(`${datepickerNextUrl}`);
+
+        cy.get('vl-datepicker-next').shadow();
+    });
+});

--- a/libs/components/src/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/components/src/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -21,10 +21,10 @@ export const datepickerArgs = {
 export const datepickerArgTypes: ArgTypes = {
     type: {
         name: 'data-vl-type',
-        description: "Attribuut bepaalt het soort datepicker; range | time | date-time | '' (default)",
+        description: "Type van de datepicker; range | time | date-time | '' (default)",
+        options: ['range', 'time', 'date-time', ''],
         control: {
             type: 'select',
-            options: ['range', 'time', 'date-time', ''],
         },
         table: {
             type: { summary: TYPES.STRING },
@@ -35,7 +35,7 @@ export const datepickerArgTypes: ArgTypes = {
     format: {
         name: 'data-vl-format',
         description:
-            "Attribuut bepaalt het formaat van de datum/tijd waarde, standaard 'd.m.Y' (-> 31.12.2019). Bv. 'l d M Y' geeft dinsdag 03 jan 2023.",
+            "Formaat van de datum/tijd waarde, standaard 'd.m.Y' (-> 31.12.2019). Bv. 'l d M Y' geeft dinsdag 03 jan 2023.",
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -46,7 +46,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     visualFormat: {
         name: 'data-vl-visual-format',
-        description: 'Attribuut bepaalt het visueel formaat van de datum/tijd waarde.',
+        description: 'Visueel formaat van de datum/tijd waarde.',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
@@ -56,7 +56,7 @@ export const datepickerArgTypes: ArgTypes = {
     selectedDate: {
         name: 'data-vl-selected-date',
         description:
-            "Attribuut voor een vooringestelde datum conform het ingestelde formaat (bv. '03-10-2019') of 'today' voor vandaag.",
+            "Vooraf ingestelde datum conform het ingestelde formaat (bv. '03-10-2019') of 'today' voor vandaag.",
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
@@ -65,8 +65,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     minDate: {
         name: 'data-vl-min-date',
-        description:
-            "Attribuut voor een minimum datum conform het ingestelde formaat (bv. '01-01-2019') of 'today' voor vandaag.",
+        description: "Minimum datum conform het ingestelde formaat (bv. '01-01-2019') of 'today' voor vandaag.",
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -77,8 +76,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     maxDate: {
         name: 'data-vl-max-date',
-        description:
-            "Attribuut voor een maximum datum conform het ingestelde format (bv. '31-12-2019') of 'today' voor vandaag.",
+        description: "Maximum datum conform het ingestelde format (bv. '31-12-2019') of 'today' voor vandaag.",
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -89,7 +87,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     minTime: {
         name: 'data-vl-min-time',
-        description: "Attribuut voor een minimum tijd conform het ingestelde formaat (bv. '09:00').",
+        description: "Minimum tijd conform het ingestelde formaat (bv. '09:00').",
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -100,7 +98,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     maxTime: {
         name: 'data-vl-max-time',
-        description: "Attribuut voor een maximum tijd conform het ingestelde format (bv. '17:00').",
+        description: "Maximum tijd conform het ingestelde format (bv. '17:00').",
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -111,7 +109,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     amPm: {
         name: 'data-vl-am-pm',
-        description: 'Attribuut om de 12-uurs AM/PM timepicker te activeren.',
+        description: 'Activeert de 12-uurs AM/PM timepicker.',
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -122,7 +120,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     error: {
         name: 'data-vl-error',
-        description: 'Attribuut om aan te geven dat de datepicker een error bevat.',
+        description: 'Stelt een error in op de datepicker.',
         table: {
             type: {
                 summary: TYPES.BOOLEAN,
@@ -133,7 +131,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     success: {
         name: 'data-vl-success',
-        description: 'Attribuut om aan te geven dat de datepicker geen error bevat.',
+        description: 'Geeft aan dat de datepicker geen error bevat.',
         table: {
             type: {
                 summary: TYPES.BOOLEAN,
@@ -144,7 +142,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     value: {
         name: 'data-vl-value',
-        description: 'Attribuut om de waarde te definiëren.',
+        description: 'De waarde van de datepicker.',
         table: {
             type: {
                 summary: TYPES.BOOLEAN,
@@ -155,7 +153,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     pattern: {
         name: 'data-vl-pattern',
-        description: 'Attribuut om aan te geven aan welk patroon de input moet voldoen.',
+        description: 'Patroon waaraan de input moet voldoen.',
         table: {
             type: {
                 summary: TYPES.STRING,
@@ -166,7 +164,7 @@ export const datepickerArgTypes: ArgTypes = {
     },
     name: {
         name: 'data-vl-name',
-        description: 'Attribuut om aan de naam te definiëren.',
+        description: 'Naam van de input.',
         table: {
             type: {
                 summary: TYPES.STRING,

--- a/libs/components/src/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/components/src/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -1,0 +1,39 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs';
+import * as VlDatepickerStories from './vl-datepicker.stories';
+
+# Datepicker
+
+Gebruik de `datepicker` component om de gebruiker op een gebruiksvriendelijke manier een datum of tijd te laten selecteren.
+
+Deze [vl-datepicker](?path=/story/components-datepicker--datepicker-default) versie is behouden voor backwards-compatibility, in v2.0.0 gaat dit verdwijnen.<br/>
+Dit is de volgende versie van de [vl-datepicker](?path=/docs/components-next-form-datepicker--datepicker-default) component (`vl-datepicker-next`), we raden aan deze versie te gebruiken.<br />
+
+## Voorbeeld
+
+```js
+import { VlDatepickerComponent } from '@domg-lib/components';
+```
+
+```html
+<vl-datepicker></vl-datepicker>
+```
+
+<Canvas of={VlDatepickerStories.DatepickerDefault} />
+
+## Configuratie
+
+<ArgTypes of={VlDatepickerStories.DatepickerDefault} />
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Datepicker](https://overheid.vlaanderen.be/webuniversum/v3/documentation/components/vl-ui-datepicker/)
+
+### Legacy Documentatie
+
+[Legacy Storybook - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/storybook/?path=/docs/custom-elements-vl-datepicker--default)
+
+[Legacy Documentatie - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/doc/VlDatepicker.html)
+
+[Legacy Demo - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-datepicker.html)

--- a/libs/components/src/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/datepicker/stories/vl-datepicker.stories.ts
@@ -3,12 +3,19 @@ import { html } from 'lit-html';
 import '../vl-datepicker.component';
 import { datepickerArgs, datepickerArgTypes } from './vl-datepicker.stories-arg';
 import { story } from '@domg-wc/common-storybook';
+import datepickerDocs from './vl-datepicker.stories-doc.mdx';
 
 export default {
     title: 'Components/datepicker',
     tags: ['autodocs'],
     args: datepickerArgs,
     argTypes: datepickerArgTypes,
+    parameters: {
+        docs: {
+            page: datepickerDocs,
+        },
+    },
+    decorators: [(story: () => unknown) => html` <div style="height: 400px;">${story()}</div>`],
 } as Meta<typeof datepickerArgs>;
 
 const Template = story(

--- a/libs/components/src/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/datepicker/vl-datepicker.component.ts
@@ -33,7 +33,7 @@ declare const vl: any;
  * @property {(range | time | date-time)} data-vl-type - Attribuut bepaalt het soort datepicker.
  * @property {string} data-vl-format - Attribuut bepaalt het formaat van de datum/tijd waarde, standaard 'd.m.Y' (-> 31.12.2019).
  * @property {string} data-vl-visual-format - Attribuut bepaalt het visueel formaat van de datum/tijd waarde.
- * @property {string} data-vl-selected-date - Attribuut voor een vooringestelde datum conform het ingestelde formaat (bv. '03-10-2019') of 'today' voor vandaag.
+ * @property {string} data-vl-selected-date - Attribuut voor een vooraf ingestelde datum conform het ingestelde formaat (bv. '03-10-2019') of 'today' voor vandaag.
  * @property {string} data-vl-min-date - Attribuut voor een minimum datum conform het ingestelde formaat (bv. '01-01-2019') of 'today' voor vandaag.
  * @property {string} data-vl-max-date - Attribuut voor een maximum datum conform het ingestelde format (bv. '31-12-2019') of 'today' voor vandaag.
  * @property {string} data-vl-min-time - Attribuut voor een minimum tijd conform het ingestelde formaat (bv. '09:00').

--- a/libs/components/src/next/form/datepicker/index.ts
+++ b/libs/components/src/next/form/datepicker/index.ts
@@ -1,0 +1,1 @@
+export { VlDatepickerComponent, DatepickerDefaults } from './vl-datepicker.component';

--- a/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -1,0 +1,150 @@
+import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@domg-wc/common-storybook';
+import { ArgTypes } from '@storybook/web-components';
+import { formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
+import { DatepickerDefaults } from '../vl-datepicker.component';
+import { action } from '@storybook/addon-actions';
+
+export const datepickerArgs: typeof defaultArgs & typeof DatepickerDefaults & { onVlInput: () => void } = {
+    ...defaultArgs,
+    ...DatepickerDefaults,
+    onVlInput: action('vl-input'),
+};
+
+export const datepickerArgTypes: ArgTypes = {
+    ...defaultArgTypes(true),
+    ...formControlArgTypes,
+    block: {
+        name: 'block',
+        description: 'Duidt aan dat de component de volledige breedte van zijn parent mag innemen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.block },
+        },
+    },
+    readonly: {
+        name: 'readonly',
+        description: 'Duidt aan dat het veld enkel `readonly` is.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.readonly },
+        },
+    },
+    type: {
+        name: 'type',
+        description: "Type van de datepicker; range | time | date-time | '' (default)",
+        control: {
+            type: 'select',
+            labels: {
+                range: 'range',
+                time: 'time',
+                'date-time': 'date-time',
+                '': 'default',
+            },
+        },
+        options: ['range', 'time', 'date-time', ''],
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.type },
+        },
+    },
+    value: {
+        name: 'value',
+        description: 'De waarde van het veld.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.value },
+        },
+    },
+    format: {
+        name: 'format',
+        description:
+            "Het formaat van de datum/tijd waarde, standaard 'd.m.Y' (-> 31.12.2019). Bv. 'l d M Y' geeft dinsdag 03 jan 2023.",
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.format },
+        },
+    },
+    minDate: {
+        name: 'min-date',
+        control: { type: 'date' },
+        description: "Minimum datum conform het ingestelde formaat (bv. '01-01-2019') of 'today' voor vandaag.",
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.minDate },
+        },
+    },
+    maxDate: {
+        name: 'max-date',
+        description: "Maximum datum conform het ingestelde format (bv. '31-12-2019') of 'today' voor vandaag.",
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.maxDate },
+        },
+    },
+    minTime: {
+        name: 'min-time',
+        description:
+            "Minimum tijd conform het ingestelde formaat (bv. '09:00'). \n\nEnkel van toepassing bij type: `time` of `date-time`.",
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.minTime },
+        },
+    },
+    maxTime: {
+        name: 'max-time',
+        description:
+            "Maximum tijd conform het ingestelde format (bv. '17:00'). \n\nEnkel van toepassing bij type: `time` of `date-time`.",
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.maxTime },
+        },
+    },
+    amPm: {
+        name: 'am-pm',
+        description: 'Activeert de 12-uurs AM/PM timepicker. \n\nEnkel van toepassing bij type: `time` of `date-time`.',
+        table: {
+            type: {
+                summary: TYPES.STRING,
+            },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.amPm },
+        },
+    },
+    pattern: {
+        name: 'pattern',
+        description: 'Het patroon dat je moet volgen bij het ingeven van een waarde.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.pattern },
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat afgevuurd wordt als de waarde van het datepicker-input veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+};

--- a/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -1,0 +1,73 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs';
+import * as VlDatepickerStories from './vl-datepicker.stories';
+
+# Datepicker
+
+Gebruik de `datepicker` component om de gebruiker op een gebruiksvriendelijke manier een datum of tijd te laten selecteren.
+Dit component is de volgende versie van de [vl-datepicker](?path=/story/components-next-form-datepicker--datepicker-default) component,we raden aan deze versie te gebruiken.<br />
+
+## Voorbeeld
+
+```js
+import { VlDatepickerComponent } from '@domg-wc/components/next/form/datepicker';
+```
+
+```html
+<vl-datepicker-next></vl-datepicker-next>
+```
+
+<Canvas of={VlDatepickerStories.DatepickerDefault} />
+
+
+## Formaat
+
+Je kan het `format` attribuut gebruiken om de datumnotatie te wijzigen. Standaard is het formaat `d.m.Y`.
+
+In onderstaand voorbeeld wordt de datumnotatie expliciet ingesteld op `d/m/Y`.
+> `format="d/m/Y"` zal de datum tonen als `31/12/2023`
+
+```html
+<vl-datepicker-next format="d/m/Y"></vl-datepicker-next>
+```
+
+Het formaat dat getoond wordt aan de gebruiker, is hetzelfde formaat dat ook als `value` wordt ingesteld.
+
+### Conversie
+
+Wanneer je in jouw implementatie een ander formaat wilt gebruiken dan het formaat dat aan de gebruiker wordt getoond,
+is het noodzakelijk dat je zelf een omzetting uitvoert.
+
+Hiervoor kan je gebruik maken van de `flatpickr`-functie `formatDate`:
+
+```ts
+import flatpickr from 'flatpickr';
+
+function convertDate(date: Date, format: string) {
+  return flatpickr.formatDate(date, format);
+}
+```
+
+Meer documentatie over `flatpickr`-formaten kan je terugvinden in de [Flatpickr documentatie](https://flatpickr.js.org/formatting/).
+
+
+## Configuratie
+
+<ArgTypes of={VlDatepickerStories.DatepickerDefault} />
+
+## Referenties
+
+### Flatpickr
+
+[Documentatie Flatpickr](https://flatpickr.js.org/)
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Datepicker](https://overheid.vlaanderen.be/webuniversum/v3/documentation/components/vl-ui-datepicker/)
+
+### Legacy Documentatie
+
+[Legacy Storybook - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/storybook/?path=/docs/custom-elements-vl-datepicker--default)
+
+[Legacy Documentatie - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/doc/VlDatepicker.html)
+
+[Legacy Demo - Datepicker](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-datepicker.html)

--- a/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-util.ts
+++ b/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories-util.ts
@@ -1,0 +1,10 @@
+import flatpickr from 'flatpickr';
+
+export const formatEpoch = (epoch: number | string | symbol, format: string | symbol): string | symbol => {
+    if (epoch && (typeof epoch === 'string' || typeof epoch === 'number')) {
+        const dateFormat = format && typeof format !== 'symbol' ? format : 'd.m.Y';
+        return flatpickr.formatDate(new Date(Number(epoch)), dateFormat);
+    } else {
+        return epoch as symbol;
+    }
+};

--- a/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/next/form/datepicker/stories/vl-datepicker.stories.ts
@@ -1,0 +1,74 @@
+import { Meta } from '@storybook/web-components';
+import { html } from 'lit-html';
+import { datepickerArgs, datepickerArgTypes } from './vl-datepicker.stories-arg';
+import { story } from '@domg-wc/common-storybook';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { formatEpoch } from './vl-datepicker.stories-util';
+import datepickerDocs from './vl-datepicker.stories-doc.mdx';
+import { VlDatepickerComponent } from '../vl-datepicker.component';
+
+registerWebComponents([VlDatepickerComponent]);
+
+export default {
+    title: 'Components-next/form/datepicker-next',
+    tags: ['autodocs'],
+    args: datepickerArgs,
+    argTypes: datepickerArgTypes,
+    parameters: {
+        docs: {
+            page: datepickerDocs,
+        },
+    },
+    decorators: [(story: () => unknown) => html` <div style="height: 400px;">${story()}</div>`],
+} as Meta<typeof datepickerArgs>;
+
+export const DatepickerDefault = story(
+    datepickerArgs,
+    ({
+        id,
+        type,
+        format,
+        minDate,
+        maxDate,
+        minTime,
+        maxTime,
+        amPm,
+        success,
+        block,
+        disabled,
+        error,
+        readonly,
+        required,
+        value,
+        label,
+        pattern,
+        name,
+    }) => {
+        return html`
+            <div style="height: 400px;">
+                <vl-datepicker-next
+                    id=${id}
+                    name=${name}
+                    label=${label}
+                    value=${value}
+                    ?error=${error}
+                    ?success=${success}
+                    ?required=${required}
+                    ?readonly=${readonly}
+                    ?disabled=${disabled}
+                    ?block=${block}
+                    type=${type}
+                    format=${format}
+                    min-date=${formatEpoch(minDate, format)}
+                    max-date=${formatEpoch(maxDate, format)}
+                    min-time=${minTime}
+                    max-time=${maxTime}
+                    am-pm=${amPm}
+                    pattern=${pattern}
+                >
+                </vl-datepicker-next>
+            </div>
+        `;
+    }
+);
+DatepickerDefault.storyName = 'vl-datepicker-next - default';

--- a/libs/components/src/next/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/next/form/datepicker/vl-datepicker.component.cy.ts
@@ -1,0 +1,407 @@
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlErrorMessageComponent } from '../error-message';
+import { DatepickerDefaults, VlDatepickerComponent } from './vl-datepicker.component';
+import { html, nothing } from 'lit';
+
+registerWebComponents([VlDatepickerComponent, VlErrorMessageComponent]);
+
+/**
+ * Deze functie maakt een datumstring aan in het formaat Y-m-d, d-m-Y of d/m/Y.
+ * @param selectedYear
+ * @param selectedDay
+ * @param selectedMonth
+ * @param format
+ */
+const createDateString = ({
+    selectedYear,
+    selectedDay,
+    selectedMonth,
+    format,
+}: {
+    selectedYear?: number;
+    selectedMonth?: number;
+    selectedDay?: number;
+    format?: 'Y-m-d' | 'd-m-Y' | 'd/m/Y';
+}) => {
+    const date = new Date();
+    const year = selectedYear ? selectedYear : date.getFullYear();
+    const month = selectedMonth ? selectedMonth : date.getMonth() + 1;
+    const day = selectedDay ? selectedDay : date.getDate();
+    // als de dag kleiner is dan 10, voeg een 0 toe voor de dag
+    const dayString = day < 10 ? `0${day}` : `${day}`;
+    const monthString = month < 10 ? `0${month}` : `${month}`;
+
+    switch (format) {
+        case 'Y-m-d':
+            return `${year}-${monthString}-${dayString}`;
+        case 'd-m-Y':
+            return `${dayString}-${monthString}-${year}`;
+        case 'd/m/Y':
+            return `${dayString}/${monthString}/${year}`;
+        default:
+            return `${dayString}.${monthString}.${year}`;
+    }
+};
+
+describe('component vl-datepicker', () => {
+    it('should mount', () => {
+        cy.mount(html`<vl-datepicker-next></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow();
+    });
+
+    it('should be accessible', () => {
+        cy.mount(
+            html`
+                <label id="label-for-date" for="date">Datum: </label>
+                <vl-datepicker-next id="date" name="date" label="date"></vl-datepicker-next>
+            `
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should open the datepicker on button click', () => {
+        cy.mount(html`<vl-datepicker-next></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').should('be.visible');
+    });
+
+    it('should set id', () => {
+        cy.mount(html`<vl-datepicker-next id="test-id"></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').should('have.id', 'test-id');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.id', 'test-id');
+    });
+
+    it('should set name', () => {
+        cy.mount(html`<vl-datepicker-next name="test-name" label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'name', 'test-name');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.attr', 'name', 'test-name');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set label', () => {
+        cy.mount(html`<vl-datepicker-next label="test-label"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'label', 'test-label');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.attr', 'aria-label', 'test-label');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set block', () => {
+        cy.mount(html`<vl-datepicker-next block label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'block');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--block');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set required', () => {
+        cy.mount(html`<vl-datepicker-next required label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'required');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.attr', 'required');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set disabled', () => {
+        cy.mount(html`<vl-datepicker-next disabled label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'disabled');
+        cy.get('vl-datepicker-next').should('be.disabled');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--disabled');
+        cy.get('vl-datepicker-next').shadow().find('input').should('be.disabled');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set readonly', () => {
+        cy.mount(html`<vl-datepicker-next readonly label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'readonly');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.attr', 'readonly');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set error', () => {
+        cy.mount(html`<vl-datepicker-next error label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'error');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--error');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.attr', 'error');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set success', () => {
+        cy.mount(html`<vl-datepicker-next success label="geboortedatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.attr', 'success');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--success');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set date in format', () => {
+        const format = 'Y-m-d';
+        cy.mount(html`<vl-datepicker-next format=${format}></vl-datepicker-next>`);
+
+        const testDate = createDateString({ selectedDay: 15, format: format });
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
+        cy.get('vl-datepicker-next').should('have.value', testDate);
+    });
+
+    it('should set prefilled date', () => {
+        const date = '01.11.2021';
+        cy.mount(html`<vl-datepicker-next value=${date} label="startdatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').should('have.value', date);
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set min date', () => {
+        const minDate = createDateString({ selectedDay: 15 });
+        cy.mount(html`<vl-datepicker-next min-date=${minDate}></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('span.flatpickr-day')
+            .contains('14')
+            .and('contain.class', 'flatpickr-disabled');
+    });
+
+    it('should set max date', () => {
+        const maxDate = createDateString({ selectedDay: 20 });
+        cy.mount(html`<vl-datepicker-next max-date=${maxDate}></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.flatpickr-day')
+            .contains('21')
+            .and('contain.class', 'flatpickr-disabled');
+    });
+
+    it('should set min time', () => {
+        const minTime = '09:15';
+        cy.mount(html`<vl-datepicker-next type="time" min-time=${minTime}></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-hour')
+            .should('have.value', '09');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '15');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute + .arrowUp')
+            .click();
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '20');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute + .arrowUp + .arrowDown')
+            .click()
+            .click()
+            .click();
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '15');
+    });
+
+    it('should set max time', () => {
+        const maxTime = '16:45';
+        cy.mount(html`<vl-datepicker-next type="time" max-time=${maxTime}></vl-datepicker-next>`);
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-hour')
+            .should('have.value', '16');
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '45');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute + .arrowUp')
+            .click();
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '45');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute + .arrowUp + .arrowDown')
+            .click();
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('.flatpickr-calendar')
+            .find('.numInput.flatpickr-minute')
+            .should('have.value', '40');
+    });
+
+    it('should set range', () => {
+        cy.mount(html`<vl-datepicker-next type="range"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        const startDate = createDateString({ selectedDay: 15 });
+        const endDate = createDateString({ selectedDay: 25 });
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
+        cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('25').click();
+
+        cy.get('vl-datepicker-next').should('have.value', `${startDate} tot en met ${endDate}`);
+    });
+});
+
+const mountDatepickerInForm = ({ value, disabled, block, required }: typeof DatepickerDefaults) => {
+    cy.mount(html`
+        <div class="container">
+            <form id="form" class="vl-form">
+                <div class="vl-form-grid vl-form-grid--is-stacked">
+                    <div class="vl-col--3-12">
+                        <label class="vl-form__label vl-form__label--block" for="geboortedatum">
+                            Geboortedatum: *
+                        </label>
+                    </div>
+                    <div class="vl-col--9-12">
+                        <vl-datepicker-next
+                            id="geboortedatum"
+                            name="geboortedatum"
+                            ?block=${block}
+                            ?required=${required}
+                            ?disabled=${disabled}
+                            value=${value || nothing}
+                        >
+                        </vl-datepicker-next>
+                        <vl-error-message-next input="geboortedatum" state="valueMissing">
+                            Gelieve een geboortedatum in te vullen.
+                        </vl-error-message-next>
+                    </div>
+                    <div class="vl-col--9-12 vl-push--3-12">
+                        <div class="vl-action-group">
+                            <button class="vl-button" type="submit">Verstuur</button>
+                            <button class="vl-button" type="reset">Reset</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    `);
+};
+
+describe('component vl-datepicker in form', () => {
+    it('should reset datepicker with initial value', () => {
+        const initialValue = '02.12.2023';
+        mountDatepickerInForm({ ...DatepickerDefaults, value: initialValue, block: true });
+        cy.get('form').then((form$) => {
+            form$.on('submit', (e) => {
+                e.preventDefault();
+            });
+        });
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow();
+        cy.get('vl-datepicker-next').should('have.value', initialValue);
+        cy.checkA11y('vl-datepicker-next');
+
+        cy.get('vl-datepicker-next').invoke('attr', 'value', '21.12.2023');
+        cy.get('vl-datepicker-next').should('have.value', '21.12.2023');
+
+        cy.get('button[type="reset"]').click();
+        cy.get('vl-datepicker-next').should('have.value', initialValue);
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should process required validation', () => {
+        mountDatepickerInForm({ ...DatepickerDefaults, required: true });
+        cy.get('form').then((form$) => {
+            form$.on('submit', (e) => {
+                e.preventDefault();
+            });
+        });
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input').should('not.have.class', 'vl-input-field--error');
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--error');
+        cy.checkA11y('vl-datepicker-next');
+
+        cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
+        cy.get('vl-datepicker-next').should('have.value', createDateString({ selectedDay: 15 }));
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-datepicker-next').shadow().find('input').should('not.have.class', 'vl-input-field--error');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should process disabled validation', () => {
+        mountDatepickerInForm({ ...DatepickerDefaults, disabled: true });
+        cy.get('form').then((form$) => {
+            form$.on('submit', (e) => {
+                e.preventDefault();
+            });
+        });
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--disabled');
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--disabled');
+        cy.checkA11y('vl-datepicker-next');
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('button#toggle-calendar')
+            .should('have.class', 'vl-input-addon--disabled');
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.class', 'vl-input-field--disabled');
+
+        cy.get('button[type="submit"]').click();
+        cy.checkA11y('vl-datepicker-next');
+    });
+});

--- a/libs/components/src/next/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/next/form/datepicker/vl-datepicker.component.ts
@@ -1,0 +1,338 @@
+import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
+import {
+    datepickerStyle,
+    iconStyle,
+    inputAddonStyle,
+    inputFieldStyle,
+    inputGroupStyle,
+    tooltipStyle,
+} from '@domg/govflanders-style/component';
+import datepickerUigStyle from './vl-datepicker.uig-css';
+import { CSSResult, html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { FormControl, FormControlDefaults } from '../form-control/FormControl';
+
+import { Options } from 'flatpickr/dist/types/options';
+import { Instance } from 'flatpickr/dist/types/instance';
+import flatpickr from 'flatpickr';
+
+import Dutch from 'flatpickr/dist/l10n/nl.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlButtonInputAddon, VlIconElement } from '@domg-wc/elements';
+import { live } from 'lit/directives/live.js';
+
+export const DatepickerDefaults = {
+    ...FormControlDefaults,
+    value: '',
+    type: '' as 'range' | 'time' | 'date-time',
+    block: false,
+    readonly: false,
+    format: 'd.m.Y',
+    minDate: '',
+    maxDate: '',
+    minTime: '',
+    maxTime: '',
+    amPm: '',
+    pattern: '',
+};
+
+@customElement('vl-datepicker-next')
+export class VlDatepickerComponent extends FormControl {
+    // Properties
+    private value = DatepickerDefaults.value;
+    private type = DatepickerDefaults.type;
+    private block = DatepickerDefaults.block;
+    private readonly = DatepickerDefaults.readonly;
+    private format = DatepickerDefaults.format;
+    private minDate = DatepickerDefaults.minDate;
+    private maxDate = DatepickerDefaults.maxDate;
+    private minTime = DatepickerDefaults.minTime;
+    private maxTime = DatepickerDefaults.maxTime;
+    private amPm = DatepickerDefaults.amPm;
+    private pattern = DatepickerDefaults.pattern;
+
+    // Variables
+    private instance: Instance | null = null;
+    private initialValue = '';
+
+    static {
+        registerWebComponents([VlButtonInputAddon, VlIconElement]);
+    }
+
+    static get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            resetStyle,
+            baseStyle,
+            iconStyle,
+            inputFieldStyle,
+            inputAddonStyle,
+            inputGroupStyle,
+            tooltipStyle,
+            datepickerStyle,
+            datepickerUigStyle,
+        ];
+    }
+
+    static get properties() {
+        return {
+            block: { type: Boolean },
+            readonly: { type: Boolean },
+            value: { type: String, reflect: true },
+            type: { type: String },
+            format: { type: String },
+            minDate: { type: String, attribute: 'min-date' },
+            maxDate: { type: String, attribute: 'max-date' },
+            minTime: { type: String, attribute: 'min-time' },
+            maxTime: { type: String, attribute: 'max-time' },
+            amPm: { type: String, attribute: 'am-pm' },
+            pattern: { type: String },
+        };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        if (Dutch?.nl) {
+            Dutch.nl.rangeSeparator = ' tot en met ';
+            flatpickr.l10ns.default.rangeSeparator = ' tot en met ';
+        }
+
+        if (!this.initialValue) {
+            this.initialValue = this.value;
+        }
+    }
+
+    protected firstUpdated(changedProperties: Map<string, unknown>): void {
+        super.firstUpdated(changedProperties);
+
+        this.initializeComponent();
+    }
+
+    updated(changedProperties: Map<string, unknown>): void {
+        super.updated(changedProperties);
+
+        const options = this.getDynamicOptions();
+        this.updateOptionsForInstance(options);
+
+        if (changedProperties.has('value')) {
+            this.updateValue(this.value);
+        }
+
+        if (changedProperties.has('block')) {
+            if (this.block) {
+                this.getFlatpickrWrapper()?.classList.add('flatpickr-wrapper--block');
+            } else {
+                this.getFlatpickrWrapper()?.classList.remove('flatpickr-wrapper--block');
+            }
+        }
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+
+        this.instance?.destroy();
+    }
+
+    protected render(): TemplateResult {
+        const inputClasses = {
+            'vl-input-field': true,
+            'js-vl-datepicker-toggle': true,
+            'vl-input-field--error': this.error || this.isInvalid,
+            'vl-input-field--success': this.success,
+            'vl-input-field--block': this.block,
+            'vl-input-field--disabled': this.disabled,
+        };
+
+        const buttonClasses = {
+            'vl-input-addon': true,
+            'js-vl-datepicker-toggle': true,
+            'vl-input-addon--error': this.error || this.isInvalid,
+            'vl-input-addon--success': this.success,
+            'vl-input-addon--disabled': this.disabled,
+        };
+
+        return html`
+            <div class="vl-input-group" id="datepicker-wrapper">
+                <input
+                    id=${this.id}
+                    name=${this.name || this.id}
+                    type="text"
+                    class=${classMap(inputClasses)}
+                    ?required=${this.required}
+                    ?disabled=${this.disabled}
+                    ?error=${this.error}
+                    ?readonly=${this.readonly}
+                    pattern=${this.pattern}
+                    aria-label=${this.label}
+                    .value=${live(this.value)}
+                    @input=${this.onInput}
+                />
+                <button
+                    id="toggle-calendar"
+                    type="button"
+                    class=${classMap(buttonClasses)}
+                    ?disabled=${this.disabled}
+                    aria-label="toggle calendar"
+                    @click=${this.toggleCalendar}
+                >
+                    <span class="vl-icon vl-icon--small vl-vi vl-vi-calendar" aria-hidden="true"></span>
+                </button>
+            </div>
+        `;
+    }
+
+    get validationTarget(): HTMLInputElement | undefined | null {
+        return this.getVisibleInputElement();
+    }
+
+    resetFormControl() {
+        super.resetFormControl();
+
+        this.instance?.clear();
+        this.value = this.initialValue;
+        if (this.initialValue) this.instance?.setDate(this.initialValue, true, this.format);
+    }
+
+    focus() {
+        this.getVisibleInputElement()?.focus();
+    }
+
+    private parseDate(dateString: 'today' | string | undefined): string | undefined {
+        const formatDate = (date: Date) => flatpickr.formatDate(date, this.format);
+        if (dateString === 'today') {
+            return formatDate(new Date());
+        } else {
+            return dateString;
+        }
+    }
+
+    private getDynamicOptions(): Options {
+        // minTime en maxTime gebruiken om defaultHour en defaultMinute te bepalen
+        let defaultHour: number | undefined;
+        let defaultMinute: number | undefined;
+        if (this.minTime) {
+            defaultHour = Number(this.minTime.split(':')[0]);
+            defaultMinute = Number(this.minTime.split(':')[1]);
+        } else if (this.maxTime) {
+            defaultHour = Number(this.maxTime.split(':')[0]);
+            defaultMinute = Number(this.maxTime.split(':')[1]);
+        }
+
+        const defaultDate = this.parseDate(this.initialValue);
+        return {
+            allowInput: !(this.disabled || this.readonly),
+            dateFormat: this.format,
+            defaultHour: defaultHour,
+            defaultMinute: defaultMinute,
+            maxDate: this.maxDate,
+            minDate: this.minDate,
+            defaultDate: defaultDate,
+            enableTime: this.type === 'time' || this.type === 'date-time',
+            noCalendar: this.type === 'time',
+            time_24hr: !this.amPm,
+            minTime: this.minTime,
+            maxTime: this.maxTime,
+            mode: this.type !== 'range' ? 'single' : 'range',
+        };
+    }
+
+    private getOptions(): Options {
+        const datepickerButton = this.shadowRoot?.querySelector('button');
+        const datepicker = this.shadowRoot?.querySelector('#datepicker-wrapper') as HTMLInputElement;
+
+        const staticOptions = {
+            autoFillDefaultTime: true,
+            locale: Dutch.nl,
+            clickOpens: false,
+            onChange: this.handleDateChange,
+            positionElement: datepickerButton,
+            static: true,
+            appendTo: datepicker,
+        };
+
+        const options = {
+            ...staticOptions,
+            ...this.getDynamicOptions(),
+        } as Options;
+
+        Object.keys(options).forEach((key) => {
+            if (options[key as keyof Options] === undefined) delete options[key as keyof Options];
+        });
+        return options;
+    }
+
+    private getDatePicker(): HTMLDivElement | undefined | null {
+        return this.shadowRoot?.querySelector('#datepicker-wrapper') as HTMLDivElement;
+    }
+
+    private getFlatpickrWrapper(): HTMLDivElement {
+        return this.shadowRoot?.querySelector('.flatpickr-wrapper') as HTMLDivElement;
+    }
+
+    private getVisibleInputElement(): HTMLInputElement | undefined | null {
+        return this.renderRoot?.querySelector('input:not([type="hidden"])') as HTMLInputElement;
+    }
+
+    private updateOptionsForInstance(options: Options) {
+        Object.keys(options)
+            .map((key) => key as keyof Options)
+            .forEach((key) => {
+                this.instance?.set(key, options[key as keyof Options]);
+            });
+    }
+
+    private initializeComponent() {
+        if (this.getDatePicker() && !this.instance) {
+            this.instance = flatpickr(this.getDatePicker()!, this.getOptions()) as unknown as Instance;
+            this.getDatePicker()?.classList.add('static');
+        }
+    }
+
+    private toggleCalendar = () => {
+        this.instance?.toggle();
+    };
+
+    private onInput = (event: Event & { target: HTMLInputElement }) => {
+        const dateString = event.target.value;
+        if (this.pattern) {
+            if (!dateString.match(this.pattern)) {
+                this.value = dateString;
+                return;
+            }
+        }
+        let parsedDate;
+        try {
+            parsedDate = flatpickr.parseDate(dateString, this.format);
+        } finally {
+            this.value = dateString;
+            if (parsedDate instanceof Date && !isNaN(parsedDate as unknown as number)) {
+                this.instance?.setDate(dateString, false, this.format);
+            }
+        }
+    };
+
+    private handleDateChange = (dates: Date[]) => {
+        const format = (date: Date) => flatpickr.formatDate(new Date(date), this.format);
+        if (dates.length !== 2) {
+            this.value = format(dates[0]);
+        } else {
+            this.value = `${format(dates[0])}${Dutch?.nl?.rangeSeparator}${format(dates[1])}`;
+        }
+    };
+
+    private updateValue = (value: string) => {
+        if (this.getVisibleInputElement() && value) this.getVisibleInputElement()!.value = value;
+        this.setValue(value);
+
+        this.dispatchEvent(
+            new CustomEvent('vl-input', { composed: true, bubbles: true, detail: { value: this.value } })
+        );
+    };
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-datepicker-next': VlDatepickerComponent;
+    }
+}

--- a/libs/components/src/next/form/datepicker/vl-datepicker.uig-css.ts
+++ b/libs/components/src/next/form/datepicker/vl-datepicker.uig-css.ts
@@ -1,0 +1,36 @@
+import { css, CSSResult } from 'lit';
+
+const styles: CSSResult = css`
+    :host {
+        --vl-error-color: rgb(210, 55, 60);
+        --vl-success-color: rgb(0, 158, 71);
+    }
+    button {
+        cursor: pointer;
+    }
+    .vl-input-field {
+        border-radius: 0.3rem 0 0 0.3rem;
+        border-right-width: 0;
+    }
+    .vl-input-addon--success {
+        border-color: var(--vl-success-color);
+    }
+    .vl-input-addon--success .vl-vi {
+        color: var(--vl-success-color) !important;
+    }
+    .vl-input-addon--error {
+        border-color: var(--vl-error-color);
+    }
+    .vl-input-addon--error .vl-vi {
+        color: var(--vl-error-color) !important;
+    }
+
+    .flatpickr-calendar {
+        z-index: 1000 !important;
+    }
+
+    .flatpickr-wrapper--block {
+        width: 100%;
+    }
+`;
+export default styles;

--- a/libs/components/src/next/form/input-field/stories/vl-input-field.stories-arg.ts
+++ b/libs/components/src/next/form/input-field/stories/vl-input-field.stories-arg.ts
@@ -24,7 +24,7 @@ export const inputFieldArgTypes: ArgTypes<typeof inputFieldArgs> = {
     },
     readonly: {
         name: 'readonly',
-        description: 'Duidt aan dat het veld enkel leesbaar is.',
+        description: 'Duidt aan dat het veld enkel `readonly` is.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/next/form/textarea/stories/vl-textarea.stories-arg.ts
+++ b/libs/components/src/next/form/textarea/stories/vl-textarea.stories-arg.ts
@@ -24,7 +24,7 @@ export const textareaArgTypes: ArgTypes<typeof textareaArgs> = {
     },
     readonly: {
         name: 'readonly',
-        description: 'Duidt aan dat het veld enkel leesbaar is.',
+        description: 'Duidt aan dat het veld `readonly` is.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/map/src/components/action/click-action/vl-map-click-action.cy.ts
+++ b/libs/map/src/components/action/click-action/vl-map-click-action.cy.ts
@@ -73,9 +73,9 @@ describe('vl-map-click-action marker functionality', () => {
     });
 
     it('should add a marker on the map if vl-map-click-action is present in the DOM and the map has been clicked ', () => {
-        cy.get('vl-map').should('exist');
+        cy.get('vl-map').shadow();
 
-        cy.get('vl-map-click-action').should('exist');
+        cy.get('vl-map-click-action').shadow();
 
         cy.get('vl-map').click();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "composed-offset-position": "0.0.4",
                 "construct-style-sheets-polyfill": "3.1.0",
                 "core-js": "3.34.0",
+                "flatpickr": "4.6.13",
                 "jsts": "2.11.0",
                 "lit": "3.1.0",
                 "prettier": "2.8.8",
@@ -22700,6 +22701,11 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/flatpickr": {
+            "version": "4.6.13",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/flatpickr/-/flatpickr-4.6.13.tgz",
+            "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
         },
         "node_modules/flatted": {
             "version": "3.2.9",

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
         "choices.js": "10.2.0",
         "construct-style-sheets-polyfill": "3.1.0",
         "core-js": "3.34.0",
+        "flatpickr": "4.6.13",
         "jsts": "2.11.0",
         "lit": "3.1.0",
         "prettier": "2.8.8",


### PR DESCRIPTION
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC186)
[jira](https://www.milieuinfo.be/jira/browse/UIG-2709)

---

we adviseren vanaf nu zelf conversie van het datum formaat applicatief te doen
`visual-format` / `altFormat` wordt niet meer ondersteund

meer info: https://github.com/milieuinfo/uigov-web-components/pull/197

---

Er zijn een paar courante formaten die binnen DV / Departement Omgeving worden gebruik; o.m. het standaard formaat voor de datepicker `d.m.Y` (die resulteert in `21.02.2023`).

In de huidige implementatie, kunnen afnemers dus voor het gekozen formaat in het attribuut `pattern` ook een regex voorzien, er additioneel ook validatie is op het formaat.

Vraag me af of het wenselijk is, om afnemers hierbij te helpen:
- dat afnemers ofwel per (meest gebruikte) formaten een regex voorzien krijgen in documentatie (die ze dan zelf in het attribuut `pattern` kunnen steken)
- dat wij automagisch; al dan niet met een extra attribuut (bv. `auto-pattern`) zelf een RegEx voorzien voor de meest courante formaten (maar ik voel aan dat dit een stap te ver is)


