### PR TITLE
feat: UIG-2745 - vl-map-multiselect-actions

### DIFF
--- a/apps/storybook-e2e/src/e2e/map/action/layer-action/select-actions/vl-map-multiselect-actions.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/action/layer-action/select-actions/vl-map-multiselect-actions.stories.cy.ts
@@ -1,0 +1,18 @@
+describe('story vl-map-multiselect-actions default', () => {
+    const mapMultiselectActionUrl =
+        'http://localhost:8080/iframe.html?args=&id=map-action-layer-action-select-action-multiselect-actions--map-multiselect-actions-default&viewMode=story';
+
+    beforeEach(() => {
+        cy.visit(mapMultiselectActionUrl);
+    });
+
+    describe('<vl-map-multiselect-actions/> visibility on the DOM', () => {
+        it('should render a map', () => {
+            cy.get('vl-map').shadow().find('div#map');
+        });
+
+        it('should render vl-map-multiselect-actions', () => {
+            cy.get('vl-map').find('vl-map-multiselect-actions');
+        });
+    });
+});

--- a/libs/map/src/actions/select/multiselect-actions.ts
+++ b/libs/map/src/actions/select/multiselect-actions.ts
@@ -1,0 +1,33 @@
+import { VlSelectActions } from './select-actions';
+import { SelectEvent as OlSelectEvent } from 'ol/interaction/Select';
+import { ActionOptions, OlVectorLayerType } from '../../vl-map.model';
+
+export class VlMultiselectActions extends VlSelectActions {
+    public getLayers: () => OlVectorLayerType[];
+
+    constructor(layers: OlVectorLayerType[], onSelect?: (...args: any[]) => void, options?: ActionOptions) {
+        super(layers, onSelect, options);
+
+        this.getLayers = (): OlVectorLayerType[] => {
+            const layers = [];
+            this.getSelectedFeatures()?.forEach((feature) => {
+                layers.push(this.getLayerByFeature(this.layers, feature));
+            });
+            return layers;
+        };
+    }
+
+    _onSelectHandler = (event: OlSelectEvent) => {
+        if (!this.onSelect) return;
+
+        if (this.getSelectedFeatures().getLength() > 0) {
+            this.onSelect(this.getSelectedFeatures().getArray().slice(), event, this.getLayers());
+        } else {
+            this.onSelect([]);
+        }
+    };
+
+    // Overrides `_fixClusterBehavior` from VlSelectActions,
+    // Does nothing in `VlMultiselectActions`.
+    _fixClusterBehavior(): void {}
+}

--- a/libs/map/src/actions/select/select-actions.ts
+++ b/libs/map/src/actions/select/select-actions.ts
@@ -24,7 +24,7 @@ export class VlSelectActions extends VlSelectAction {
         this._layer = layer;
     }
 
-    private getLayerByFeature(layers: OlVectorLayerType[], feature: OlFeature): OlVectorLayerType {
+    protected getLayerByFeature(layers: OlVectorLayerType[], feature: OlFeature): OlVectorLayerType {
         return layers.find((layer) => {
             const features = layer?.getSource()?.getFeatures() || [];
             const clusteredFeature = feature?.get('features')?.[0];

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-arg.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-arg.ts
@@ -1,0 +1,13 @@
+import { ArgTypes } from '@storybook/web-components';
+import {
+    mapSelectActionsArgTypes,
+    mapSelectActionsArgs,
+} from '../../select-actions/stories/vl-map-select-actions.stories-arg';
+
+export const mapMultiselectActionsArgs = {
+    ...mapSelectActionsArgs,
+};
+
+export const mapMultiselectActionsArgTypes: ArgTypes<typeof mapSelectActionsArgs> = {
+    ...mapSelectActionsArgTypes,
+};

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-default.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-default.ts
@@ -1,0 +1,72 @@
+import { html } from 'lit';
+
+const featuresLayer1 = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: 1,
+            geometry: {
+                type: 'Point',
+                coordinates: [175000, 184000],
+            },
+        },
+    ],
+};
+
+const featuresLayer2 = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: 2,
+            geometry: {
+                type: 'Point',
+                coordinates: [175000, 185000],
+            },
+        },
+    ],
+};
+
+const featuresLayer3 = {
+    type: 'Feature',
+    id: 3,
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [144000, 171000],
+                [200000, 171000],
+                [200000, 205000],
+                [144000, 205000],
+                [144000, 171000],
+            ],
+        ],
+    },
+};
+
+const layers = ['layer-1', 'layer-2', 'layer-3'];
+
+export const component = (active: boolean, defaultActive: boolean) => html`
+    <vl-map>
+        <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+        <vl-map-features-layer data-vl-name="layer-3" .features=${featuresLayer3}>
+            <vl-map-layer-style data-vl-border-size="2"></vl-map-layer-style>
+            <vl-map-layer-circle-style></vl-map-layer-circle-style>
+        </vl-map-features-layer>
+        <vl-map-features-layer .features=${featuresLayer1} data-vl-name="layer-1">
+            <vl-map-layer-circle-style
+                data-vl-color="rgba(0, 255, 21, 1)"
+                data-vl-border-color="#000000"
+            ></vl-map-layer-circle-style>
+        </vl-map-features-layer>
+        <vl-map-features-layer .features=${featuresLayer2} data-vl-name="layer-2">
+            <vl-map-layer-circle-style
+                data-vl-color="rgba(255, 230, 21, 1)"
+                data-vl-border-color="#000000"
+            ></vl-map-layer-circle-style>
+        </vl-map-features-layer>
+        <vl-map-multiselect-actions .active=${active} .layers=${layers} ?data-vl-default-active=${defaultActive}>
+        </vl-map-multiselect-actions>
+    </vl-map>
+`;

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-doc.mdx
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-doc.mdx
@@ -1,0 +1,33 @@
+import { ArgTypes, Canvas, Source } from '@storybook/blocks';
+import * as VlMapMultiselectActionsStories from './vl-map-multiselect-actions.stories';
+import defaultStorySource from './vl-map-multiselect-actions.stories-default?raw';
+
+# Map Multiselect Actions
+
+Gebruik de `map-multiselect-actions` component om meerdere overlappende features samen te selecteren.<br/>
+Deze component erft over van de
+[map-select-actions](/docs/map-action-layer-action-select-action--map-select-actions-default) component.
+
+
+## Voorbeeld
+
+```js
+import { VlMapMultiselectActions } from '@domg-wc/map';
+```
+
+```html
+<vl-map-multiselect-actions></vl-map-multiselect-actions>
+```
+
+<Canvas of={VlMapMultiselectActionsStories.MapMultiselectActionsDefault} />
+
+
+<details>
+    <summary>Toon code</summary>
+    <Source code={defaultStorySource} language="ts" dark={true} />
+</details>
+
+
+## Configuratie
+
+<ArgTypes of={VlMapMultiselectActionsStories.MapMultiselectActionsDefault} />

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories.ts
@@ -1,0 +1,31 @@
+import { story } from '@domg-wc/common-storybook';
+import { Meta } from '@storybook/web-components';
+import '../../../../../../vl-map';
+import '../../../../../baselayer/vl-map-base-layer-grb-gray/vl-map-base-layer-grb-gray';
+import '../../../../../layer-style/vl-map-layer-circle-style/vl-map-layer-circle-style';
+import '../../../../../layer/vector-layer/vl-map-features-layer/vl-map-features-layer';
+import '../../select-actions/vl-map-select-actions';
+import '../vl-map-multiselect-actions';
+import { mapMultiselectActionsArgs, mapMultiselectActionsArgTypes } from './vl-map-multiselect-actions.stories-arg';
+import { component as defaultComponent } from './vl-map-multiselect-actions.stories-default';
+import mapMultiselectActionsDoc from './vl-map-multiselect-actions.stories-doc.mdx';
+
+export default {
+    title: 'map/action/layer-action/select-action/multiselect-actions',
+    tags: ['autodocs'],
+    args: mapMultiselectActionsArgs,
+    argTypes: mapMultiselectActionsArgTypes,
+    parameters: {
+        docs: {
+            page: mapMultiselectActionsDoc,
+        },
+    },
+} as Meta<typeof mapMultiselectActionsArgs>;
+
+export const MapMultiselectActionsDefault = story(mapMultiselectActionsArgs, ({ active, defaultActive }) => {
+    return defaultComponent(active, defaultActive);
+});
+MapMultiselectActionsDefault.storyName = 'vl-map-multiselect-actions - default';
+MapMultiselectActionsDefault.args = {
+    active: true,
+};

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.cy.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.cy.ts
@@ -1,0 +1,181 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlMap } from '../../../../../vl-map';
+import { VlMapBaseLayerGRBGray } from '../../../../baselayer/vl-map-base-layer-grb-gray/vl-map-base-layer-grb-gray';
+import { VlMapFeaturesLayer } from '../../../../layer/vector-layer/vl-map-features-layer/vl-map-features-layer';
+import { VlMapMultiselectActions } from './vl-map-multiselect-actions';
+
+registerWebComponents([VlMap, VlMapBaseLayerGRBGray, VlMapFeaturesLayer, VlMapMultiselectActions]);
+
+const featuresLayer1 = {
+    type: 'Feature',
+    id: 1,
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [100000, 150000],
+                [200000, 150000],
+                [200000, 250000],
+                [100000, 250000],
+                [100000, 150000],
+            ],
+        ],
+    },
+};
+
+const featuresLayer2 = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: 2,
+            geometry: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [100000, 140000],
+                        [190000, 140000],
+                        [190000, 200000],
+                        [100000, 200000],
+                        [100000, 140000],
+                    ],
+                ],
+            },
+        },
+    ],
+};
+
+const layers = ['layer-1', 'layer-2'];
+
+describe('component vl-map-multiselect-actions', () => {
+    beforeEach(() => {
+        cy.mount(html`
+            <vl-map>
+                <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+                <vl-map-features-layer data-vl-name="layer-1" .features=${featuresLayer1}>
+                    <vl-map-layer-style data-vl-border-size="2"></vl-map-layer-style>
+                </vl-map-features-layer>
+                <vl-map-features-layer .features=${featuresLayer2} data-vl-name="layer-2">
+                    <vl-map-layer-style data-vl-border-size="2"></vl-map-layer-style
+                ></vl-map-features-layer>
+                <vl-map-multiselect-actions .active=${true} .layers=${layers} ?data-vl-default-active=${true}>
+                </vl-map-multiselect-actions>
+            </vl-map>
+        `);
+    });
+
+    it('should mount', () => {
+        cy.get('vl-map-multiselect-actions');
+    });
+
+    it('should be accessible', () => {
+        cy.injectAxe();
+
+        cy.checkA11y('vl-map-multiselect-actions');
+    });
+
+    it('should fire the onSelect event', () => {
+        cy.window().then((win) => {
+            // @ts-ignore
+            win.selectStub = cy.stub().as('selectStub');
+        });
+
+        cy.get('vl-map').should('exist');
+        cy.get('vl-map-multiselect-actions').should('exist');
+
+        cy.document().then((doc) => {
+            const multiselectActions = doc.querySelector('vl-map-multiselect-actions') as VlMapMultiselectActions;
+
+            multiselectActions.onSelect((...args) => {
+                // @ts-ignore
+                window.selectStub(args);
+            });
+        });
+        cy.wait(1000);
+        cy.get('vl-map').click(100, 200);
+
+        // Assertions to verify if the stub was called as expected
+        cy.window().its('selectStub').should('have.been.calledOnce');
+    });
+
+    it('should have the correct features and layers in the event args when selecting 1 feature', () => {
+        let selectArgs = [];
+
+        cy.window().then((win) => {
+            // @ts-ignore
+            win.selectStub = cy.stub().as('selectStub');
+        });
+
+        cy.get('vl-map').should('exist');
+        cy.get('vl-map-multiselect-actions').should('exist');
+
+        cy.document().then((doc) => {
+            const multiselectActions = doc.querySelector('vl-map-multiselect-actions') as VlMapMultiselectActions;
+            // Use the stub function here
+            // @ts-ignore
+            multiselectActions.onSelect((...args) => {
+                // @ts-ignore
+                window.selectStub(args);
+                selectArgs = args;
+            });
+        });
+        cy.wait(1000);
+        cy.get('vl-map').click(100, 200);
+
+        // Assertions to verify if the stub was called as expected
+        cy.window()
+            .its('selectStub')
+            .should('have.been.calledOnce')
+            .then(() => {
+                const [selectedFeatures, event, layers] = selectArgs;
+
+                expect(selectedFeatures).to.be.an('array').that.has.lengthOf(1);
+                expect(selectedFeatures[0].id_).to.equal(1);
+
+                expect(layers).to.be.an('array').that.has.lengthOf(1);
+                expect(layers[0].get('title')).to.equal('layer-1');
+            });
+    });
+
+    it('should have the correct features and layers in the event args when selecting 2 features', () => {
+        let selectArgs = [];
+
+        cy.window().then((win) => {
+            // @ts-ignore
+            win.selectStub = cy.stub().as('selectStub');
+        });
+
+        cy.get('vl-map').should('exist');
+        cy.get('vl-map-multiselect-actions').should('exist');
+
+        cy.document().then((doc) => {
+            const multiselectActions = doc.querySelector('vl-map-multiselect-actions') as VlMapMultiselectActions;
+            // Use the stub function here
+            // @ts-ignore
+            multiselectActions.onSelect((...args) => {
+                // @ts-ignore
+                window.selectStub(args);
+                selectArgs = args;
+            });
+        });
+        cy.wait(1000);
+        cy.get('vl-map').click(100, 300);
+
+        // Assertions to verify if the stub was called as expected
+        cy.window()
+            .its('selectStub')
+            .should('have.been.calledOnce')
+            .then(() => {
+                const [selectedFeatures, event, layers] = selectArgs;
+
+                expect(selectedFeatures).to.be.an('array').that.has.lengthOf(2);
+                expect(selectedFeatures[0].id_).to.equal(2);
+                expect(selectedFeatures[1].id_).to.equal(1);
+
+                expect(layers).to.be.an('array').that.has.lengthOf(2);
+                expect(layers[0].get('title')).to.equal('layer-2');
+                expect(layers[1].get('title')).to.equal('layer-1');
+            });
+    });
+});

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.ts
@@ -1,0 +1,32 @@
+import { webComponent } from '@domg-wc/common-utilities';
+import { VlMapSelectActions } from '../select-actions/vl-map-select-actions';
+import { ActionOptions, OlVectorLayerType } from '../../../../../vl-map.model';
+import { VlMultiselectActions } from '../../../../../actions/select/multiselect-actions';
+
+/**
+ * VlMapMultiselectActions
+ * @class
+ * @classdesc Component om een multi select-actie voor overlappende features toe te voegen.
+ *
+ * @property {string[]} layers - Array met de namen van de te koppelen kaartlagen. Dit moet meegegeven worden als property.
+ *
+ * @extends VlMapSelectActions
+ */
+@webComponent('vl-map-multiselect-actions')
+export class VlMapMultiselectActions extends VlMapSelectActions {
+    _createAction(layers?: OlVectorLayerType | OlVectorLayerType[]): VlMultiselectActions {
+        const options: ActionOptions = {
+            style: this.style,
+            cluster: this._cluster !== undefined,
+            filter: this.appliesTo.bind(this),
+        };
+
+        return new VlMultiselectActions(layers as OlVectorLayerType[], this._callback, options);
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-map-multiselect-actions': VlMapMultiselectActions;
+    }
+}


### PR DESCRIPTION
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC217)
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2745)

Meerdere features samen selecteren is nu mogelijk met de vl-map-multiselect-actions.

Met de reeds bestaande select actions vl-map-select-action en vl-map-select-actions is het nu ook mogelijk om "onderliggende" features te selecteren. Deze code was reeds aanwezig maar deed niets omdat de select interaction configuratie multi niet aanstond.
Nu kan je per klik door de overlappende features lopen.