### PR TITLE
feat: UIG-2717 - vl-tooltip deprecated in storybook.

### DIFF
--- a/libs/components/src/steps/vl-duration-step.component.ts
+++ b/libs/components/src/steps/vl-duration-step.component.ts
@@ -2,6 +2,9 @@ import { BaseElementOfType, webComponent } from '@domg-wc/common-utilities';
 
 /**
  * VlDurationStep
+ *
+ * @deprecated gebruik de vl-steps-next component
+ *
  * @class
  * @classdesc De step duration component stelt een moment tussen twee stappen voor.
  *

--- a/libs/components/src/steps/vl-step.component.ts
+++ b/libs/components/src/steps/vl-step.component.ts
@@ -5,6 +5,9 @@ declare const vl: any;
 
 /**
  * VlStep
+ *
+ * @deprecated gebruik de vl-steps-next component
+ *
  * @class
  * @classdesc De step component stelt een enkele stap voor in de steps component.
  *

--- a/libs/components/src/steps/vl-steps.component.ts
+++ b/libs/components/src/steps/vl-steps.component.ts
@@ -5,6 +5,9 @@ import stepsUigStyle from './vl-steps.uig-css';
 
 /**
  * VlSteps
+ *
+ * @deprecated gebruik de vl-steps-next component
+ *
  * @class
  * @classdesc De steps component bevat een verticale lijst van genummerde stappen. Stappen kunnen gebruikt worden om de gebruiker stap voor stap door een procedure te begeleiden.
  *

--- a/libs/components/src/tooltip/stories/vl-tooltip.stories-doc.mdx
+++ b/libs/components/src/tooltip/stories/vl-tooltip.stories-doc.mdx
@@ -1,0 +1,50 @@
+import { ArgTypes, Canvas } from '@storybook/blocks';
+import * as VlTooltipStories from './vl-tooltip.stories';
+
+# Tooltip
+
+❗**DEPRECATED: gebruik de [vl-popover](?path=/docs/components-popover--documentatie) component** ❗
+
+<br />
+
+Gebruik de `tooltip` component om beschrijvende informatie over de functie van een knop, label of ander element weer te
+geven. Wanneer een gebruiker met de muis over een element beweegt of het selecteert, verschijnt de tooltip om extra
+informatie te geven.
+
+## Voorbeeld
+
+```js
+import { VlTooltipComponent } from '@domg-wc/components';
+```
+
+```html
+<vl-tooltip></vl-tooltip>
+```
+
+## Default
+
+<Canvas of={VlTooltipStories.TooltipDefault} />
+
+## Configuratie
+
+<ArgTypes of={VlTooltipStories.TooltipDefault} />
+
+## Varianten
+
+### Static
+
+<Canvas of={VlTooltipStories.TooltipStatic} />
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Tooltip](https://overheid.vlaanderen.be/webuniversum/v3/documentation/js-components/vl-ui-tooltip)
+
+### Legacy Documentatie
+
+[Legacy Storybook - Tooltip](https://webcomponenten.omgeving.vlaanderen.be/storybook/?path=/docs/custom-elements-vl-tooltip--default)
+
+[Legacy Documentatie - Tooltip](https://webcomponenten.omgeving.vlaanderen.be/doc/VlTooltip.html)
+
+[Legacy Demo - Tooltip](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-tooltip.html)

--- a/libs/components/src/tooltip/stories/vl-tooltip.stories.ts
+++ b/libs/components/src/tooltip/stories/vl-tooltip.stories.ts
@@ -3,15 +3,21 @@ import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import '../vl-tooltip.component';
 import { tooltipArgs, tooltipArgTypes } from './vl-tooltip.stories-arg';
+import tooltipDoc from './vl-tooltip.stories-doc.mdx';
 
 export default {
     title: 'Components/tooltip',
     tags: ['autodocs'],
     args: tooltipArgs,
     argTypes: tooltipArgTypes,
+    parameters: {
+        docs: {
+            page: tooltipDoc,
+        },
+    },
 } as Meta<typeof tooltipArgs>;
 
-export const tooltipDefault = ({ placement, tooltipContent, vlStatic }: typeof tooltipArgs) => {
+export const TooltipDefault = ({ placement, tooltipContent, vlStatic }: typeof tooltipArgs) => {
     return html` <div
         style=${styleMap({
             display: 'flex',
@@ -25,8 +31,8 @@ export const tooltipDefault = ({ placement, tooltipContent, vlStatic }: typeof t
         </button>
     </div>`;
 };
-tooltipDefault.storyName = 'vl-tooltip - default';
-tooltipDefault.argTypes = {
+TooltipDefault.storyName = 'vl-tooltip - default';
+TooltipDefault.argTypes = {
     vlStatic: {
         control: {
             disable: true,
@@ -34,7 +40,7 @@ tooltipDefault.argTypes = {
     },
 };
 
-export const tooltipStatic = ({ placement, tooltipContent, vlStatic }: typeof tooltipArgs) => {
+export const TooltipStatic = ({ placement, tooltipContent, vlStatic }: typeof tooltipArgs) => {
     return html` <div
         style=${styleMap({
             border: '1px solid #e8ebee',
@@ -45,5 +51,5 @@ export const tooltipStatic = ({ placement, tooltipContent, vlStatic }: typeof to
         <vl-tooltip ?data-vl-static=${vlStatic} data-vl-placement=${placement}>${tooltipContent}</vl-tooltip>
     </div>`;
 };
-tooltipStatic.storyName = 'vl-tooltip - static';
-tooltipStatic.args = { vlStatic: true };
+TooltipStatic.storyName = 'vl-tooltip - static';
+TooltipStatic.args = { vlStatic: true };

--- a/libs/components/src/tooltip/vl-tooltip.component.ts
+++ b/libs/components/src/tooltip/vl-tooltip.component.ts
@@ -8,6 +8,9 @@ declare const vl: VL;
 
 /**
  * VlTooltip
+ *
+ * @deprecated gebruik de vl-popover component
+ *
  * @class
  * @classdesc Gebruik de vl-tooltip om beschrijvende informatie over een knop, label of eender welk element weer te geven.
  *


### PR DESCRIPTION
Ik heb dit ook op het ticket zelf in JIRA geschreven, maar ik schrijf het hier ook.

Hier heb ik gewoon de `vl-tooltip` gemarkeerd als deprecated in storybook.

In het ideale gevaal,  denk ik dat  we het gebruik van `vl-tooltip` in andere componenten moeten vervangen en in plaats daarvan `vl-popover` moeten gebruiken. Maar ik was hier niet zeker van.

De `vl-tooltip` wordt momenteel gebruikt in `vl-progress-bar` en die op zijn beurt wordt gebruikt in `vl-wizard`.  

Ik heb geprobeerd om de instantie van `vl-tooltip` in de `vl-progress-bar` te veranderen en in plaats daarvan `vl-popover` te gebruiken. Het werkt, er is wat css dat in de war raakt in de `vl-wizard`, omdat nu de `vl-popover` css altijd verschijnt, maar dit kan eenvoudig worden gecorrigeerd. 

Ik heb ervoor gekozen om dit niet in dit ticket op te lossen en hiervoor in de plaats een ticket [UIG-2790](https://www.milieuinfo.be/jira/browse/UIG-2790) aan te maken, omdat ik niet zeker was van de scope en intentie van UIG-2717. 

---

[Bambo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC216)
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2717)


