### PR TITLE
feat: UIG-2770 - configuratie opzet om voorkeuren te wijzigen

### DIFF
--- a/apps/storybook/docs/a_afnemen/3_cookbook.stories.mdx
+++ b/apps/storybook/docs/a_afnemen/3_cookbook.stories.mdx
@@ -204,6 +204,43 @@ VlButtonElement;
 ```
 
 
+## Configuratie
+
+M.b.v. de statische klasse `UigConfig` kunnen voorkeuren gewijzigd worden.
+
+De defaults zijn:
+    - autoRegisterStyles: true
+    - logWebComponentRegistration: false
+
+
+### Afname via de npm-packages
+
+Wijzig de defaults als volgt; voordat het eerste element geïmporteerd wordt.
+
+```
+import { UigConfig } from '@domg-wc/common-utilities';
+
+UigConfig.setPreferences({ logWebComponentRegistration: true });
+```
+
+**Opmerking**: ervoor zorgen dat deze code als eerste uitgevoerd wordt (alvorens de eerste component geregistreerd
+wordt) is specifiek aan de opzet en bundeling van de toepassing. Wat altijd zou moeten werken is:
+ - een bestand aanmaken met bovenstaande code in (de import en het setPreferences statement) bvb. in `app.config.ts`
+ - en dan dit bestand via een neven-effect import `import './app/app.config';` als aller eerste importeren
+
+### Afname via 'fat-js'
+
+Wijzig de defaults m.b.v. het desbetreffende attribuut.
+
+```
+<script type="module"
+        auto-register-styles="false"
+        log-web-component-registration="true"
+        src="https://cdn.omgeving.vlaanderen.be/domg/domg-wc/1.20.1/domg-wc-1.20.1.min.js">
+</script>
+```
+
+
 ## Styling
 
 ### Elementen & CSS
@@ -245,28 +282,8 @@ class RegisterStyles {
 
 ### Deactivatie Globale Styling
 
-Indien gewenst kan je de automatische registratie van de globale (document) styling de-activeren:
-
-#### Afname via de 'fat-js'
-
-Zet het attribuut `auto-register-styles` op false.
-
-```
-<script type="module"
-        auto-register-styles="false"
-        src="https://cdn.omgeving.vlaanderen.be/domg/domg-wc/1.20.1/domg-wc-1.20.1.min.js">
-</script>
-```
-
-#### Afname via de npm-package
-
-Wijzig de RegisterStyles properties als volgt; voordat het eerste element geïmporteerd wordt.
-
-```
-RegisterStyles.autoRegisterStyles = false;
-RegisterStyles.initialised = true;
-```
-
+Indien gewenst kan je de automatische registratie van globale (document) styling de-activeren via de
+`autoRegisterStyles` property (zie hierboven onder Configuratie).
 
 ### Custom CSS
 

--- a/libs/common/utilities/jest.config.ts
+++ b/libs/common/utilities/jest.config.ts
@@ -1,16 +1,12 @@
 /* eslint-disable */
 export default {
     displayName: 'common-utilities',
-    preset: '../../../jest.preset.js',
-    globals: {},
+    preset: 'ts-jest',
     transform: {
-        '^.+\\.[tj]sx?$': [
-            'ts-jest',
-            {
-                tsconfig: '<rootDir>/tsconfig.spec.json',
-            },
-        ],
+        '^.+\\.(ts|tsx)?$': 'ts-jest',
+        '^.+\\.(js|jsx)$': 'babel-jest',
     },
+    globals: {},
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     coverageDirectory: '../../../coverage/libs/common/utilities',
 };

--- a/libs/common/utilities/src/config/uig-config.spec.ts
+++ b/libs/common/utilities/src/config/uig-config.spec.ts
@@ -1,0 +1,35 @@
+import { UigConfig } from './uig-config';
+
+describe('uig-config preferences', () => {
+    beforeEach(() => {
+        // foefel om te zorgen dat elke test met niet geïnitialiseerde preferences start
+        UigConfig['preferences'] = null;
+    });
+
+    it('should use the default preferences', () => {
+        const uigPreferences = UigConfig.getPreferences();
+        expect(uigPreferences.autoRegisterStyles).toEqual(true);
+        expect(uigPreferences.logWebComponentRegistration).toEqual(false);
+    });
+
+    it('should use the custom specified preferences', () => {
+        UigConfig.setPreferences({ autoRegisterStyles: false, logWebComponentRegistration: true });
+        const uigPreferences = UigConfig.getPreferences();
+        expect(uigPreferences.autoRegisterStyles).toEqual(false);
+        expect(uigPreferences.logWebComponentRegistration).toEqual(true);
+    });
+
+    it('should use the custom specified preference, otherwise the default', () => {
+        UigConfig.setPreferences({ logWebComponentRegistration: true });
+        const uigPreferences = UigConfig.getPreferences();
+        expect(uigPreferences.autoRegisterStyles).toEqual(true);
+        expect(uigPreferences.logWebComponentRegistration).toEqual(true);
+    });
+
+    it('should use the default preferences when the custom ones are set too late', () => {
+        const uigPreferences = UigConfig.getPreferences();
+        UigConfig.setPreferences({ autoRegisterStyles: false, logWebComponentRegistration: true });
+        expect(uigPreferences.autoRegisterStyles).toEqual(true);
+        expect(uigPreferences.logWebComponentRegistration).toEqual(false);
+    });
+});

--- a/libs/common/utilities/src/config/uig-config.ts
+++ b/libs/common/utilities/src/config/uig-config.ts
@@ -1,0 +1,47 @@
+export interface Preferences {
+    autoRegisterStyles?: boolean;
+    logWebComponentRegistration?: boolean;
+}
+
+const defaultPreferences = (): Preferences => ({
+    autoRegisterStyles: true,
+    logWebComponentRegistration: false,
+});
+
+export class UigConfig {
+    private static preferences: Preferences | null = null;
+
+    static setPreferences(preferences: Preferences) {
+        if (!this.preferences) {
+            this.preferences = { ...defaultPreferences(), ...preferences };
+            console.info('expliciete uig preferences: ', this.preferences);
+        } else {
+            console.error('er worden expliciete uig preferences gezet, maar te laat');
+        }
+    }
+
+    static getPreferences(): Preferences {
+        this.initialisePreferences();
+        return <Preferences>this.preferences;
+    }
+
+    private static initialisePreferences() {
+        if (this.preferences) return;
+        // de preferences werden niet expliciet gezet dus de defaults nemen
+        this.preferences = defaultPreferences();
+        // indien de fat-js variant gebruikt wordt kunnen de defaults nog gewijzigd worden op de script-tag
+        if (typeof document !== 'undefined') {
+            for (const script of document?.scripts) {
+                if (script.src.indexOf('domg-wc') >= 0) {
+                    if (script.getAttribute('auto-register-styles') === 'false') {
+                        this.preferences.autoRegisterStyles = false;
+                    }
+                    if (script.getAttribute('log-web-component-registration') === 'true') {
+                        this.preferences.logWebComponentRegistration = true;
+                    }
+                }
+            }
+        }
+        console.info('geconfigureerde uig preferences: ', this.preferences);
+    }
+}

--- a/libs/common/utilities/src/decorator/decorators.ts
+++ b/libs/common/utilities/src/decorator/decorators.ts
@@ -1,3 +1,4 @@
+import { UigConfig } from '../config/uig-config';
 import { defineWebComponent } from '../util/utils';
 
 export const webComponent =
@@ -23,7 +24,9 @@ export const webComponentPromised =
     // eslint-disable-next-line @typescript-eslint/ban-types
     (constructor: Function): any => {
         if (customElements.get(tagName)) {
-            console.debug(`${tagName} werd reeds geregistreerd`);
+            if (UigConfig.getPreferences().logWebComponentRegistration) {
+                console.debug(`${tagName} werd reeds geregistreerd`);
+            }
         } else {
             Promise.all(promises).then(() => defineWebComponent(constructor, tagName, options));
         }
@@ -37,7 +40,9 @@ export const webComponentConditional =
     // eslint-disable-next-line @typescript-eslint/ban-types
     (constructor: Function): any => {
         if (customElements.get(tagName)) {
-            console.debug(`${tagName} werd reeds geregistreerd`);
+            if (UigConfig.getPreferences().logWebComponentRegistration) {
+                console.debug(`${tagName} werd reeds geregistreerd`);
+            }
         } else {
             window.customElements.whenDefined(defined).then(() => defineWebComponent(constructor, tagName, options));
         }

--- a/libs/common/utilities/src/index.ts
+++ b/libs/common/utilities/src/index.ts
@@ -1,6 +1,7 @@
 export { BaseElementOfType } from './base/base.element';
 export { BaseHTMLElement } from './base/base.html.element';
 export { BaseLitElement } from './base/base.lit.element';
+export { UigConfig, Preferences } from './config/uig-config';
 export { MARGINS, PADDINGS } from './constants/constants';
 export {
     webComponent,

--- a/libs/common/utilities/src/util/utils.ts
+++ b/libs/common/utilities/src/util/utils.ts
@@ -1,4 +1,5 @@
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { UigConfig } from '../config/uig-config';
 import { VL } from '../models';
 
 declare const vl: VL;
@@ -25,9 +26,13 @@ export const registerWebComponents = (webComponents: any[]) => {};
  */
 export const defineWebComponent = (constructor: Function, tagName: string, options?: ElementDefinitionOptions) => {
     if (customElements.get(tagName)) {
-        console.debug(`${tagName} werd reeds geregistreerd`);
+        if (UigConfig.getPreferences().logWebComponentRegistration) {
+            console.debug(`${tagName} werd reeds geregistreerd`);
+        }
     } else {
-        console.debug('registratie', tagName);
+        if (UigConfig.getPreferences().logWebComponentRegistration) {
+            console.debug('registratie', tagName);
+        }
         window.customElements.define(tagName, constructor as CustomElementConstructor, options);
     }
 };

--- a/libs/elements/src/vl-elements.uig-css.ts
+++ b/libs/elements/src/vl-elements.uig-css.ts
@@ -1,4 +1,5 @@
 import 'construct-style-sheets-polyfill';
+import { UigConfig } from '@domg-wc/common-utilities';
 import { CSSResult } from 'lit';
 
 // @govflanders common styles
@@ -123,29 +124,15 @@ export const allElementStyles = [...commonStyles, ...componentStyles, ...element
 export default allElementStyles;
 
 class RegisterStyles {
-    static initialised = false;
-    static autoRegisterStyles = true;
     static elementStylesRegistered = false;
 
-    static initialise() {
-        if (RegisterStyles.initialised) return;
-        for (const script of document.scripts) {
-            if (script.src.indexOf('domg-wc') >= 0 && script.getAttribute('auto-register-styles') === 'false') {
-                RegisterStyles.autoRegisterStyles = false;
-                console.log('RegisterStyles: element-styling wordt niet toegevoegd aan het document');
-            }
-        }
-        RegisterStyles.initialised = true;
-    }
-
     static registerElementsStyles() {
-        RegisterStyles.initialise();
-        if (RegisterStyles.autoRegisterStyles && !RegisterStyles.elementStylesRegistered) {
+        if (UigConfig.getPreferences().autoRegisterStyles && !this.elementStylesRegistered) {
             document.adoptedStyleSheets = [
                 ...document.adoptedStyleSheets,
                 ...(allElementStyles.map((style) => style.styleSheet) as CSSStyleSheet[]),
             ];
-            RegisterStyles.elementStylesRegistered = true;
+            this.elementStylesRegistered = true;
             console.log('RegisterStyles: element-styling toegevoegd aan het document');
         }
     }


### PR DESCRIPTION
- defaults en sturen van de configuratie gebeurd via de nieuwe klasse UigConfig
- autoRegisterStyles (bestond al) en logWebComponentRegistration (nieuw, doel van dit ticket) zijn momenteel de enige te sturen voorkeuren
- ik schreef de testen die ik kon
- de fat-js opzet is behouden (en uitgebreidt); deze moet ik nog manueel testen (als ik een fat-js heb) - ooit, nadat https://www.milieuinfo.be/jira/browse/UIG-2763 doorgevoerd is, kan daar ook een test voor geschreven worden