### PR TITLE
feat: UIG-2757 - vl-input-field-element - voorbeeld toegevoegd voor debounced-input

### DIFF
--- a/apps/storybook-e2e/src/e2e/elements/input-field/vl-input-field.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/input-field/vl-input-field.stories.cy.ts
@@ -2,50 +2,7 @@ const inputFieldUrl = 'http://localhost:8080/iframe.html?id=elements-input-field
 
 describe('story vl-input-field - default', () => {
     it('should be accessible', () => {
-        cy.visitWithA11y(`${inputFieldUrl}`);
-        cy.get('[is="vl-input-field"]');
-        cy.checkA11y('[is="vl-input-field"]');
-        cy.get('[is="vl-input-field"]').should('have.class', 'vl-input-field');
-    });
-
-    it('should contain an input field', () => {
-        cy.visit(`${inputFieldUrl}`);
-        cy.get('[is="vl-input-field"]').should('have.class', 'vl-input-field');
-    });
-
-    it('should contain an input field with a block state', () => {
-        cy.visit(`${inputFieldUrl}&args=block:true`);
-        cy.get('[is="vl-input-field"]')
-            .should('have.class', 'vl-input-field')
-            .should('have.class', 'vl-input-field--block');
-    });
-
-    it('should contain an input field with an error state ', () => {
-        cy.visit(`${inputFieldUrl}&args=error:true`);
-        cy.get('[is="vl-input-field"]')
-            .should('have.class', 'vl-input-field')
-            .should('have.class', 'vl-input-field--error');
-    });
-
-    it('should contain an input field with an success state ', () => {
-        cy.visit(`${inputFieldUrl}&args=success:true`);
-        cy.get('[is="vl-input-field"]')
-            .should('have.class', 'vl-input-field')
-            .should('have.class', 'vl-input-field--success');
-    });
-
-    it('should contain an input field with an disabled state ', () => {
-        cy.visitWithA11y(`${inputFieldUrl}&args=small:true;disabled:true`);
-        cy.get('[is="vl-input-field"]')
-            .should('have.class', 'vl-input-field')
-            .should('have.class', 'vl-input-field--disabled')
-            .should('have.attr', 'disabled');
-    });
-
-    it('should contain an input field with a small state', () => {
-        cy.visit(`${inputFieldUrl}&args=small:true`);
-        cy.get('[is="vl-input-field"]')
-            .should('have.class', 'vl-input-field')
-            .should('have.class', 'vl-input-field--small');
+        cy.visit(inputFieldUrl);
+        cy.get('input[is="vl-input-field"]').should('have.class', 'vl-input-field');
     });
 });

--- a/apps/storybook/docs/d_applicatief/a_design/1_design-aanpak.stories.mdx
+++ b/apps/storybook/docs/d_applicatief/a_design/1_design-aanpak.stories.mdx
@@ -1,7 +1,0 @@
-import {Meta} from '@storybook/addon-docs';
-
-<Meta title="Applicatief/Design/Aanpak"/>
-
-# Aanpak
-
-TODO

--- a/apps/storybook/docs/d_applicatief/a_design/2_design-patronen.stories.mdx
+++ b/apps/storybook/docs/d_applicatief/a_design/2_design-patronen.stories.mdx
@@ -1,7 +1,0 @@
-import {Meta} from '@storybook/addon-docs';
-
-<Meta title="Applicatief/Design/Patronen"/>
-
-# Patronen
-
-TODO

--- a/apps/storybook/docs/d_applicatief/d_voorbeelden/common-utilities/debounce.stories.mdx
+++ b/apps/storybook/docs/d_applicatief/d_voorbeelden/common-utilities/debounce.stories.mdx
@@ -1,0 +1,26 @@
+import {Meta} from '@storybook/addon-docs';
+
+<Meta title="Applicatief/Voorbeelden/Common Utilities/Debounce"/>
+
+# Debounce (Common Utilities)
+
+De `debounce` methode beperkt het aantal keren dat een functie aangeroepen wordt.
+
+
+## Voorbeeld
+
+```ts
+import { debounce } from '@domg-wc/common-utilities';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const inputField = document.getElementById('input-field'); // <input id="input-field" is="vl-input-field" />
+    if (inputField) {
+        inputField.addEventListener(
+            'input',
+            debounce((event) => {
+                // doe iets
+            }, 200)
+        );
+    }
+});
+```

--- a/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu-accordion/popover-menu-accordion.stories-doc.mdx
+++ b/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu-accordion/popover-menu-accordion.stories-doc.mdx
@@ -1,10 +1,10 @@
 import { Meta } from '@storybook/addon-docs';
 import { Canvas } from '@storybook/blocks';
-import * as AccordionPopoverMenuStories from './accordion-popover-menu.stories'
+import * as PopoverMenuAccordionStories from './popover-menu-accordion.stories'
 
-<Meta of={AccordionPopoverMenuStories} />
+<Meta of={PopoverMenuAccordionStories} />
 
-# Accordion met popover menu's
+# Popover Menu in Accordion
 
 De accordion is een UI-element dat wordt gebruikt om inhoud te organiseren in een uitklapbaar formaat. Elk
 accordion-item kan een popover bevatten dat extra opties biedt voor dat specifieke item.
@@ -30,4 +30,4 @@ accordion-item kan een popover bevatten dat extra opties biedt voor dat specifie
 
 ## Voorbeeld
 
-<Canvas of={AccordionPopoverMenuStories.AccordionPopoverMenu} />
+<Canvas of={PopoverMenuAccordionStories.PopoverMenuAccordion} />

--- a/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu-accordion/popover-menu-accordion.stories.ts
+++ b/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu-accordion/popover-menu-accordion.stories.ts
@@ -7,7 +7,7 @@ import {
     VlPopoverComponent,
 } from '@domg-wc/components';
 import { VlIconElement, VlLinkElement } from '@domg-wc/elements';
-import AccordionPopoverMenuDoc from './accordion-popover-menu.stories-doc.mdx';
+import PopoverMenuAccordionDoc from './popover-menu-accordion.stories-doc.mdx';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 
 registerWebComponents([
@@ -20,11 +20,10 @@ registerWebComponents([
 ]);
 
 export default {
-    title: 'Applicatief/Voorbeelden/accordion-popover-menu',
-    component: 'accordion popover menu',
+    title: 'Applicatief/Voorbeelden/Popover Menu in Accordion',
     parameters: {
         docs: {
-            page: AccordionPopoverMenuDoc,
+            page: PopoverMenuAccordionDoc,
             story: {
                 inline: false,
                 iframeHeight: 500,
@@ -47,7 +46,7 @@ const subAccordionCss = `
     .vl-accordion__subtitle {margin: 0;}
 `;
 
-export const AccordionPopoverMenu = () => html`
+export const PopoverMenuAccordion = () => html`
     <style>
         .laaginfo {
             display: flex;
@@ -350,3 +349,4 @@ export const AccordionPopoverMenu = () => html`
         </div>
     </div>
 `;
+PopoverMenuAccordion.storyName = 'Popover Menu in Accordion';

--- a/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu/popover-menu.stories-doc.mdx
+++ b/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu/popover-menu.stories-doc.mdx
@@ -4,7 +4,7 @@ import * as popoverMenuStories from './popover-menu.stories'
 
 <Meta of={popoverMenuStories} />
 
-# Popover menu
+# Popover Menu
 
 Een popover menu is een UI-element dat wordt gebruikt om extra navigatieopties weer te geven die niet direct zichtbaar
 zijn. Het wordt vaak weergegeven als een pictogram, zoals een hamburger menu, kebab menu, of een ander herkenbaar

--- a/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu/popover-menu.stories.ts
+++ b/apps/storybook/docs/d_applicatief/d_voorbeelden/popover-menu/popover-menu.stories.ts
@@ -7,8 +7,7 @@ import popoverMenuDoc from './popover-menu.stories-doc.mdx';
 registerWebComponents([VlPopoverComponent, VlPopoverActionListComponent]);
 
 export default {
-    title: 'Applicatief/Voorbeelden/popover-menu',
-    component: 'popover menu',
+    title: 'Applicatief/Voorbeelden/Popover Menu',
     parameters: {
         docs: {
             page: popoverMenuDoc,

--- a/libs/common/utilities/src/index.ts
+++ b/libs/common/utilities/src/index.ts
@@ -17,7 +17,6 @@ export {
     sleep,
     awaitUntil,
     unwrap,
-    deferred,
     debounce,
     returnNotEmptyString,
     returnNumber,

--- a/libs/common/utilities/src/util/utils.ts
+++ b/libs/common/utilities/src/util/utils.ts
@@ -103,39 +103,21 @@ export const unwrap = (element: Element) => {
 };
 
 /**
- * creates new Promise that resolves in x milliseconds
- * returns created Promise & function to cancel the Promise
- * @param ms
+ * De `debounce` methode beperkt het aantal keren dat een functie aangeroepen wordt.
+ * Opmerking: deze methode volgt de closure opzet, daarom is deze bewust niet beter ge-typed!
+ *  → zie https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures
+ *
+ * @param func - de aan te roepen functie
+ * @param ms - het aantal milliseconden dat er gewacht wordt alvorens de functie aan te roepen; als er in die
+ *             tijdspanne een nieuwe aanroep gebeurd herstart de timer
  */
-export const deferred = (ms: number): { promise: Promise<unknown>; cancel: any } => {
-    let cancel: unknown;
-    const promise = new Promise((resolve, reject) => {
-        cancel = reject;
-        setTimeout(resolve, ms);
-    });
-    return { promise, cancel };
-};
-
-/**
- * debouncing a task will wait to execute the given task until it hasn't been called for the amount of given milliseconds
- * @param task - function to debounce
- * @param ms - milliseconds to delay until last iteration of function should be called
- */
-export const debounce = (task: (...args: any) => void, ms: number) => {
-    // t: local binding for local state
-    let t: { cancel: any; promise: Promise<unknown> } = {
-        promise: null!,
-        cancel: (_?: any) => void 0,
-    };
-    return async (...args: any) => {
-        try {
-            t.cancel();
-            t = deferred(ms);
-            await t.promise;
-            await task(...args);
-        } catch (_) {
-            //
-        }
+export const debounce = (func: any, ms: number) => {
+    let timer: any = undefined; // type van timer is number in oudere browsers, Timeout in nieuwste (wij kennen dat type niet)
+    return (...args: unknown[]): void => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            func.apply(this, args);
+        }, ms);
     };
 };
 

--- a/libs/elements/src/input-field/stories/vl-input-field.stories-doc.mdx
+++ b/libs/elements/src/input-field/stories/vl-input-field.stories-doc.mdx
@@ -5,6 +5,7 @@ import * as VlInputFieldStories from './vl-input-field.stories';
 
 Gebruik het `input-field`-component om tekst van de gebruiker op te vangen.
 
+
 ## Voorbeeld
 
 ```js
@@ -12,7 +13,7 @@ import { VlInputFieldElement } from '@domg-wc/elements';
 ```
 
 ```html
- <input is="vl-input-field" />
+<input is="vl-input-field" />
 ```
 
 <Canvas of={VlInputFieldStories.InputFieldDefault} />

--- a/libs/elements/src/input-field/vl-input-field.element.cy.ts
+++ b/libs/elements/src/input-field/vl-input-field.element.cy.ts
@@ -1,0 +1,98 @@
+import { debounce, registerWebComponents } from '@domg-wc/common-utilities';
+import { html } from 'lit';
+import { VlInputFieldElement } from './vl-input-field.element';
+
+registerWebComponents([VlInputFieldElement]);
+
+const mountDefault = ({ block = false, disabled = false, error = false, success = false, small = false }) => {
+    return cy.mount(html` <label for="input-field">Ingave:</label>
+        <input
+            id="input-field"
+            is="vl-input-field"
+            ?data-vl-block=${block}
+            ?data-vl-disabled=${disabled}
+            ?data-vl-error=${error}
+            ?data-vl-success=${success}
+            ?data-vl-small=${small}
+            data-cy="input-field"
+        />`);
+};
+
+describe('vl-input-field - component', () => {
+    beforeEach(() => {
+        mountDefault({});
+    });
+
+    it('should mount', () => {
+        cy.get('input[is="vl-input-field"]').should('have.class', 'vl-input-field');
+    });
+
+    it('should be accessible', () => {
+        cy.injectAxe();
+        cy.checkA11y('input[is="vl-input-field"]');
+    });
+});
+
+describe('vl-input-field - properties reflect ', () => {
+    it('should reflect the <block> attribute', () => {
+        mountDefault({ block: true });
+
+        cy.get('input[is="vl-input-field"]').should('have.attr', 'data-vl-block');
+    });
+
+    it('should reflect the <disabled> attribute', () => {
+        mountDefault({ disabled: true });
+
+        cy.get('input[is="vl-input-field"]').should('have.attr', 'data-vl-disabled');
+    });
+
+    it('should reflect the <error> attribute', () => {
+        mountDefault({ error: true });
+
+        cy.get('input[is="vl-input-field"]').should('have.attr', 'data-vl-error');
+    });
+
+    it('should reflect the <success> attribute', () => {
+        mountDefault({ success: true });
+
+        cy.get('input[is="vl-input-field"]').should('have.attr', 'data-vl-success');
+    });
+
+    it('should reflect the <small> attribute', () => {
+        mountDefault({ small: true });
+
+        cy.get('input[is="vl-input-field"]').should('have.attr', 'data-vl-small');
+    });
+});
+
+describe('vl-input-field - functionality', () => {
+    it('should allow me to type in the input field', () => {
+        mountDefault({});
+
+        cy.get('input[is="vl-input-field"]').type('Hello World');
+
+        cy.get('input[is="vl-input-field"]').should('have.value', 'Hello World');
+    });
+});
+
+describe.only('vl-input-field - with debounce ', () => {
+    const mountWithDebounce = (debounceDelay: number) => {
+        const debounceSpy = cy.spy().as('debounceSpy');
+        const debouncedFunction = debounce(debounceSpy, debounceDelay);
+
+        return cy.mount(html`
+            <label for="input-field">Ingave:</label>
+            <input id="input-field" is="vl-input-field" data-cy="input-field" @input=${debouncedFunction} />
+        `);
+    };
+
+    it('should debounce when the <debounce> helper function is passed', () => {
+        mountWithDebounce(300);
+
+        cy.get('input[is="vl-input-field"]').type('Hello World', { delay: 50 });
+        cy.wait(500); // wacht langer dan de debounceDelay
+
+        cy.get('@debounceSpy').should('have.been.calledOnce');
+        cy.get('@debounceSpy').its('callCount').should('be.lessThan', 'Hello World'.length);
+    });
+});


### PR DESCRIPTION
- [x] Voorbeeld toegevoegd voor debounced-input in storybook
- [x] types toegevoegd voor `debounce` en ``deferred` methoden


* _FYI: de `qlik` lib heeft ook een `debounce` maar dit is  allen in `qlik` gebruikt. Maar 't is meer concise en heeft hetzelfde functionaliteit/intentie dan onze, misschien kan het worden gebruikt als inspiratie voor onze debounce?_
---
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC220)
[JIra](https://www.milieuinfo.be/jira/browse/UIG-2757)
