### PR TITLE
feat: UIG-2664 - vl-search - visualisatie zoekbalk aangepast

### DIFF
--- a/libs/components/src/search/vl-search.component.ts
+++ b/libs/components/src/search/vl-search.component.ts
@@ -1,7 +1,7 @@
 import { BaseElementOfType, registerWebComponents, webComponent } from '@domg-wc/common-utilities';
 import { VlButtonElement, VlIconElement, VlInputFieldElement, VlSelect } from '@domg-wc/elements';
 import { resetStyle } from '@domg/govflanders-style/common';
-import { buttonStyle, inputFieldStyle, searchStyle, selectStyle } from '@domg/govflanders-style/component';
+import { buttonStyle, inputFieldStyle, selectStyle } from '@domg/govflanders-style/component';
 import searchUigStyle from './vl-search.uig-css';
 
 /**
@@ -51,7 +51,6 @@ export class VlSearchComponent extends BaseElementOfType(HTMLElement) {
         ${buttonStyle}
         ${inputFieldStyle}
         ${selectStyle}
-        ${searchStyle}
         ${searchUigStyle}
       </style>
       <div class="vl-search">
@@ -143,6 +142,12 @@ export class VlSearchComponent extends BaseElementOfType(HTMLElement) {
                 this._submit();
             });
         }
+        if (this.__labelElement) {
+            this.__labelElement.addEventListener('click', () => {
+                const slottedInput = this.querySelector(`:scope > [slot=input]`);
+                slottedInput?.querySelector('input')?.click();
+            });
+        }
     }
 
     _submit() {
@@ -210,7 +215,7 @@ export class VlSearchComponent extends BaseElementOfType(HTMLElement) {
                     this.__observeInputSlot((mutations: any) => {
                         const isOpen = (mutation: any) => mutation.target.classList.contains('is-open');
                         const isFocused = (mutation: any) => mutation.target.classList.contains('is-focused');
-                        if (mutations.find((mutation: any) => isOpen(mutation) || isFocused(mutation)) || slot.value) {
+                        if (mutations.find((mutation: any) => isOpen(mutation) || isFocused(mutation))) {
                             this.__inputSlotElement.classList.add('is-open');
                         } else {
                             this.__inputSlotElement.classList.remove('is-open');

--- a/libs/components/src/search/vl-search.uig-css.ts
+++ b/libs/components/src/search/vl-search.uig-css.ts
@@ -112,7 +112,6 @@ const styles: CSSResult = css`
     .vl-search--inline slot[name='input']:focus,
     .vl-search--inline .vl-search__input:focus + .vl-search__submit,
     .vl-search--inline slot[name='input']:focus + .vl-search__submit {
-        transition: opacity 0.2s, transform 0.2s;
         z-index: 1;
         opacity: 1;
         transform: translateX(0%);
@@ -128,7 +127,6 @@ const styles: CSSResult = css`
     }
     .vl-search--inline .vl-search__input:focus,
     .vl-search--inline slot[name='input']:focus {
-        transition: width 0.2s;
         width: calc(100% - 4.7rem);
         padding-right: 0;
     }
@@ -237,7 +235,6 @@ const styles: CSSResult = css`
     }
     :host([data-vl-inline]) ::slotted(.is-open),
     :host([data-vl-inline]) ::slotted(.is-focused) {
-        transition: margin-right 0.2s;
         margin-right: 4.7rem !important;
         border: 0.1rem solid #687483 !important;
     }


### PR DESCRIPTION
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC266)
[jira](https://www.milieuinfo.be/jira/browse/UIG-2664)

---

De 2 voorstellen, zoals beschreven in ticket zijn te vinden in het desbetreffende commits;

~~1. altijd in actieve modus; zo verspringt het niet van de 1e visuele stijl naar een ander maar dan is het niet conform DV styling
Eenvoudig te implementeren en kunnen MutationObservers ook weg.~~
2. passieve modus (DV styling) behalve wanneer er in getypt wordt (en "open" status krijgt) of wanneer component focus krijgt, dan krijgt het actieve modus