### PR TITLE
feat: UIG-2825 - vl-data-table - werking uitklapbare rijen verbeterd

### DIFF
--- a/apps/storybook-e2e/src/e2e/elements/data-table/vl-data-table.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/elements/data-table/vl-data-table.stories.cy.ts
@@ -5,201 +5,26 @@ const dataTableExpandableUrl =
 const dataTableExpandableWithCustomToggleUrl =
     'http://localhost:8080/iframe.html?args=&id=elements-data-table--data-table-expandable-custom-toggle-details-column&viewMode=story';
 
-const shouldHaveDataTableWithHeaders = () => {
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
-    cy.get('[is="vl-data-table"]')
-        .should('have.class', 'vl-data-table')
-        .find('thead > tr')
-        .children()
-        .each((cell, index) => {
-            cy.wrap(cell).should('have.text', 'Entry Header ' + (index + 1));
-        });
-};
-const shouldContainDataTableWithColumns = () => {
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
-    cy.get('[is="vl-data-table"]')
-        .should('have.class', 'vl-data-table')
-        .find('tbody')
-        .children()
-        .each((row, rowIndex) => {
-            if (!row.attr('data-details-id')) {
-                cy.wrap(row)
-                    .children()
-                    .each((cell, cellIndex) => {
-                        if (!cell.children('button').length) {
-                            cy.wrap(cell).should('contain.text', 'Entry line ' + (cellIndex + 1));
-                        } else {
-                            cy.wrap(cell).find('button').should('have.class', 'vl-button');
-                        }
-                    });
-            } else {
-                cy.wrap(row)
-                    .find('td')
-                    .should('contain.text', 'Details ' + (rowIndex + 1) / 2);
-            }
-        });
-};
-describe('story elements / data-table / vl-data-table - default', () => {
-    it('should contain a data table with headers', () => {
-        cy.visit(`${dataTableDefaultUrl}`);
-        shouldHaveDataTableWithHeaders();
-    });
+describe('story - vl-data-table - default', () => {
+    it('should render', () => {
+        cy.visit(dataTableDefaultUrl);
 
-    it('should contain a data table with columns', () => {
-        cy.visit(`${dataTableDefaultUrl}`);
-        shouldContainDataTableWithColumns();
-    });
-
-    it('should contain a data table with hover styling', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=hover:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--hover');
-    });
-
-    it('should contain a data table with a matrix', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=matrix:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--matrix');
-    });
-
-    it('should contain a data table with a grid', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=grid:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--grid');
-    });
-
-    it('should contain a data table with a zebra grid', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=zebra:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--zebra');
-    });
-
-    it('should contain a data table that collapsed on the medium breakpoint', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=collapsedM:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-m');
-    });
-
-    it('should contain a data table that collapsed on the small breakpoint', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=collapsedS:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-s');
-    });
-
-    it('should contain a data table that collapsed on the extra small breakpoint', () => {
-        cy.visit(`${dataTableDefaultUrl}&args=collapsedXS:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-xs');
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
     });
 });
 
-const shouldDetailsRowBeVisible = (isVisible: boolean, detailRowIndex = 0) => {
-    const haveStyle = !isVisible ? 'have.css' : 'not.have.css';
-    cy.get('[is="vl-data-table"]')
-        .should('have.class', 'vl-data-table')
-        .find('tbody')
-        .find('[data-details-id]')
-        .eq(detailRowIndex)
-        .should(haveStyle, 'display', 'none');
-};
-const toggleDetailsButton = () => {
-    cy.get('[is="vl-data-table"]').find('tbody > tr').first().find('td').last().find('button').click();
-};
+describe('story - vl-data-table - expandable', () => {
+    it('should render', () => {
+        cy.visit(dataTableExpandableUrl);
 
-describe('story elements / data-table / vl-data-table - expandable', () => {
-    it('should contain a data table with headers', () => {
-        cy.visit(`${dataTableExpandableUrl}`);
-        shouldHaveDataTableWithHeaders();
-    });
-
-    it('should contain a data table with columns', () => {
-        cy.visit(`${dataTableExpandableUrl}`);
-        shouldContainDataTableWithColumns();
-    });
-
-    it('should contain a data table with hover styling', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=hover:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--hover');
-    });
-
-    it('should contain a data table with a matrix', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=matrix:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--matrix');
-    });
-
-    it('should contain a data table with a grid', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=grid:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--grid');
-    });
-
-    it('should contain a data table with a zebra grid', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=zebra:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--zebra');
-    });
-
-    it('should contain a data table that collapsed on the medium breakpoint', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=collapsedM:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-m');
-    });
-
-    it('should contain a data table that collapsed on the small breakpoint', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=collapsedS:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-s');
-    });
-
-    it('should contain a data table that collapsed on the extra small breakpoint', () => {
-        cy.visit(`${dataTableExpandableUrl}&args=collapsedXS:true`);
-        cy.get('[is="vl-data-table"]')
-            .should('have.class', 'vl-data-table')
-            .should('have.class', 'vl-data-table--collapsed-xs');
-    });
-
-    it('should toggle expanding a detail row when clicking the button', () => {
-        cy.visit(`${dataTableExpandableUrl}`);
-
-        shouldDetailsRowBeVisible(false);
-        toggleDetailsButton();
-        shouldDetailsRowBeVisible(true);
-        toggleDetailsButton();
-        shouldDetailsRowBeVisible(false);
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
     });
 });
 
-describe('story elements / data-table / vl-data-table - expandable with custom button', () => {
-    it('should toggle expanding a detail row when clicking the button', () => {
-        cy.visit(`${dataTableExpandableWithCustomToggleUrl}`);
+describe('story - vl-data-table - expandable with custom toggle', () => {
+    it('should render', () => {
+        cy.visit(dataTableExpandableWithCustomToggleUrl);
 
-        shouldDetailsRowBeVisible(false);
-        toggleDetailsButton();
-        shouldDetailsRowBeVisible(true);
-        toggleDetailsButton();
-        shouldDetailsRowBeVisible(false);
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
     });
 });

--- a/libs/elements/src/data-table/stories/vl-data-table.stories-arg.ts
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories-arg.ts
@@ -1,23 +1,20 @@
+import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
+import { ArgTypes } from '@storybook/web-components';
+import { dataTableDefaults } from '../vl-data-table.element';
+
 export const dataTableArgs = {
-    hover: false,
-    matrix: false,
-    grid: false,
-    zebra: false,
-    uigZebra: false,
-    collapsedM: false,
-    collapsedS: false,
-    collapsedXS: false,
+    ...dataTableDefaults,
 };
 
-export const dataTableArgTypes = {
+export const dataTableArgTypes: ArgTypes<typeof dataTableArgs> = {
     hover: {
         name: 'data-vl-hover',
         description:
             'Attribuut wordt gebruikt om een rij te highlighten waneer de gebruiker erover hovert met muiscursor.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.hover },
         },
     },
     matrix: {
@@ -25,18 +22,18 @@ export const dataTableArgTypes = {
         description:
             'Attribuut wordt gebruikt om data in 2 dimensies te tonen. Zowel de rijen als de kolommen krijgen een titel. Deze titels worden gescheiden door een dikke lijn.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.matrix },
         },
     },
     grid: {
         name: 'data-vl-grid',
         description: 'Variant met een lijn tussen elke rij en kolom.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.grid },
         },
     },
     zebra: {
@@ -45,9 +42,9 @@ export const dataTableArgTypes = {
             'Variant waarin de rijen afwisslend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. ' +
             'Deze zebra werkt niet voor tabellen met detail rijen, gebruik hiervoor data-vl-uig-zebra.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.zebra },
         },
     },
     uigZebra: {
@@ -55,9 +52,9 @@ export const dataTableArgTypes = {
         description:
             'Variant waarin de rijen afwisslend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. Deze zebra werkt voor tabellen met en zonder detail rijen.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.uigZebra },
         },
     },
     collapsedM: {
@@ -65,9 +62,9 @@ export const dataTableArgTypes = {
         description:
             'Vanaf een medium schermgrootte zullen de cellen van elke rij onder elkaar ipv naast elkaar getoond worden.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.collapsedM },
         },
     },
     collapsedS: {
@@ -75,9 +72,9 @@ export const dataTableArgTypes = {
         description:
             'Vanaf een small schermgrootte zullen de cellen van elke rij onder elkaar ipv naast elkaar getoond worden.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.collapsedS },
         },
     },
     collapsedXS: {
@@ -85,9 +82,9 @@ export const dataTableArgTypes = {
         description:
             'Vanaf een extra small schermgrootte zullen de cellen van elke rij onder elkaar ipv naast elkaar getoond worden.',
         table: {
-            category: 'Attributes',
-            type: { summary: 'boolean' },
-            defaultValue: { summary: 'false' },
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: dataTableArgs.collapsedXS },
         },
     },
 };

--- a/libs/elements/src/data-table/stories/vl-data-table.stories-doc.mdx
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories-doc.mdx
@@ -5,7 +5,6 @@ import * as VlDataTableStories from './vl-data-table.stories';
 
 Gebruik het `data-table` component om op een gestructureerde manier (grote hoeveelheden) relationele data te tonen.
 
-
 ## Voorbeeld
 
 ```js
@@ -69,10 +68,11 @@ Om dit toe passen maak je zelf gebruik van native html-attribuut `rowspan`.
 ## Expandable
 
 Om een rijen te laten uitklappen ("expanden") moet je het volgende doen:<br/>
-Als je 2 rijen hebt, en je wil rij A altijd zichtbaar zetten en rij B verborgen tot die word opengeklapt:
+Als je 2 rijen hebt, en je wil rij A altijd zichtbaar zetten en rij B verborgen tot die wordt opengeklapt:
 
 - maak een nieuwe rij B direct na rij A
 - zet je het attribuut `data-details-id` op de rij B
+- je kan ook meerdere rijen uitklapbaar maken, zolang je maar dezelfde `data-details-id` hergebruikt
 
 <details>
     <summary>voorbeeld expandable row</summary>
@@ -94,12 +94,16 @@ Als je 2 rijen hebt, en je wil rij A altijd zichtbaar zetten en rij B verborgen 
 </details>
 
 Dan zal er automatisch een `button` toegevoegd worden die de gebruiker toelaat de rij B te zien wanneer op de
-desbetreffende knop bij rij A word gedrukt.
+desbetreffende knop bij rij A wordt gedrukt.
 
 <Canvas of={VlDataTableStories.DataTableExpandable} layout="padded" />
 
+### Colspan
 
-## Expandable with custom toggle
+We berekenen automatisch de `colspan` van de rij die uitklapt, zodat de rij die uitklapt de volledige breedte van de tabel inneemt.
+Dit doen we enkel als de rij die uitklapt een enkele cel bevat. Als de rij die uitklapt meerdere cellen bevat, moet je zelf de `colspan` instellen.
+
+### Expandable with custom toggle
 
 Je kan ook de knop die de rij open en dicht klapt zelf kiezen.<br/>
 Als je 2 rijen hebt, en je wil rij A altijd zichtbaar zetten en rij B verborgen tot die word opengeklapt:<br/>

--- a/libs/elements/src/data-table/stories/vl-data-table.stories.ts
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories.ts
@@ -2,9 +2,9 @@ import { html } from 'lit-html';
 import '../vl-data-table.element';
 import { dataTableArgs, dataTableArgTypes } from './vl-data-table.stories-arg';
 import { Meta } from '@storybook/web-components';
-import { VlDataTable } from '../vl-data-table.element';
 import dataTableDoc from './vl-data-table.stories-doc.mdx';
 import { story } from '@domg-wc/common-storybook';
+import { VlDataTable } from '../vl-data-table.element';
 
 export default {
     title: 'Elements/data-table',
@@ -139,10 +139,6 @@ DataTableJoinedRowTitles.args = dataTableArgs;
 export const DataTableExpandable = story(
     dataTableArgs,
     ({ hover, matrix, grid, zebra, uigZebra, collapsedM, collapsedS, collapsedXS }: typeof dataTableArgs) => {
-        let table: VlDataTable & HTMLElement;
-        customElements.whenDefined('vl-data-table').then(() => {
-            table = document.querySelector('#vl-data-table-with-expandable-details') as VlDataTable & HTMLElement;
-        });
         return html`
             <table
                 is="vl-data-table"
@@ -175,15 +171,7 @@ export const DataTableExpandable = story(
                         <td data-title="Entry Header 4">Entry line 4</td>
                     </tr>
                     <tr class="vl-data-table__element--disabled" data-details-id="details-row1">
-                        <td data-title="details-title 1">
-                            <div>
-                                <ul>
-                                    <li>Extra Details 1</li>
-                                    <li>Extra Details 1</li>
-                                    <li>Extra Details 1</li>
-                                </ul>
-                            </div>
-                        </td>
+                        <td data-title="details-title 1">Title 1: generic details</td>
                     </tr>
                     <tr>
                         <td data-title="Entry Header 1">Entry line 1</td>
@@ -191,32 +179,43 @@ export const DataTableExpandable = story(
                         <td data-title="Entry Header 3">Entry line 3</td>
                     </tr>
                     <tr data-details-id="details-row2">
-                        <td data-title="details-title 2">
-                            <div>
-                                <ul>
-                                    <li>Extra Details 2</li>
-                                    <li>Extra Details 2</li>
-                                    <li>Extra Details 2</li>
-                                </ul>
-                            </div>
-                        </td>
+                        <td data-title="details-title 2">Title 2: generic details</td>
                     </tr>
-                    <tr>
+                    <tr id="multiple-cells">
                         <td data-title="Entry Header 1">Entry line 1</td>
                         <td data-title="Entry Header 2">Entry line 2</td>
                         <td data-title="Entry Header 3">Entry line 3</td>
                         <td data-title="Entry Header 4">Entry line 4</td>
                     </tr>
                     <tr data-details-id="details-row3">
-                        <td data-title="details-title 3">
-                            <div>
-                                <ul>
-                                    <li>Extra Details 3</li>
-                                    <li>Extra Details 3</li>
-                                    <li>Extra Details 3</li>
-                                </ul>
-                            </div>
-                        </td>
+                        <td data-title="details-title 3">Title 3: Zij die ter kaperen varen:</td>
+                        <td>*</td>
+                        <td>*</td>
+                        <td>*</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Jan</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Piet</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Joris</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Korneel</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
                     </tr>
                 </tbody>
             </table>
@@ -224,14 +223,13 @@ export const DataTableExpandable = story(
     }
 );
 DataTableExpandable.storyName = 'vl-data-table - expandable';
-DataTableExpandable.args = dataTableArgs;
 
 export const DataTableExpandableCustomToggleDetailsColumn = story(
     dataTableArgs,
     ({ hover, matrix, grid, zebra, uigZebra, collapsedM, collapsedS, collapsedXS }) => {
-        let table: any;
+        let table: (VlDataTable & Element) | null;
         customElements.whenDefined('vl-data-table').then(() => {
-            table = document.querySelector('#vl-data-table-with-custom-expandable-details');
+            table = document.querySelector<VlDataTable & Element>('#vl-data-table-with-custom-expandable-details');
         });
         return html`
             <table
@@ -276,7 +274,7 @@ export const DataTableExpandableCustomToggleDetailsColumn = story(
                         </td>
                     </tr>
                     <tr data-details-id="details-row1">
-                        <td data-title="details-title 1">
+                        <td data-title="details-title 1" colspan="5">
                             <div>
                                 <ul>
                                     <li>Extra Details 1</li>
@@ -285,6 +283,52 @@ export const DataTableExpandableCustomToggleDetailsColumn = story(
                                 </ul>
                             </div>
                         </td>
+                    </tr>
+                    <tr>
+                        <td data-title="Entry Header 1">Entry line 1</td>
+                        <td data-title="Entry Header 2" colspan="2">Entry line 2</td>
+                        <td data-title="Entry Header 3">Entry line 3</td>
+                    </tr>
+                    <tr data-details-id="details-row2">
+                        <td data-title="details-title 2" colspan="1">
+                            <div>
+                                <ul>
+                                    <li>Extra Details 2</li>
+                                    <li>Extra Details 2</li>
+                                    <li>Extra Details 2</li>
+                                </ul>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td data-title="Entry Header 1">Entry line 1</td>
+                        <td data-title="Entry Header 2">Entry line 2</td>
+                        <td data-title="Entry Header 3">Entry line 3</td>
+                        <td data-title="Entry Header 4">Entry line 4</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Jan</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Piet</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Joris</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
+                    </tr>
+                    <tr data-details-id="details-row3">
+                        <td data-title="naam">Korneel</td>
+                        <td data-title="familienaam">familienaam</td>
+                        <td data-title="telefoon">telefoon</td>
+                        <td data-title="adres">adres</td>
                     </tr>
                 </tbody>
             </table>

--- a/libs/elements/src/data-table/vl-data-table.component.cy.ts
+++ b/libs/elements/src/data-table/vl-data-table.component.cy.ts
@@ -1,0 +1,571 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { dataTableDefaults, VlDataTable } from '../data-table/vl-data-table.element';
+
+registerWebComponents([VlDataTable]);
+
+const mountDefault = ({
+    hover,
+    matrix,
+    grid,
+    zebra,
+    uigZebra,
+    collapsedM,
+    collapsedS,
+    collapsedXS,
+}: Partial<typeof dataTableDefaults>) =>
+    cy.mount(html`
+        <table
+            is="vl-data-table"
+            ?data-vl-hover=${hover}
+            ?data-vl-matrix=${matrix}
+            ?data-vl-grid=${grid}
+            ?data-vl-zebra=${zebra}
+            ?data-vl-uig-zebra=${uigZebra}
+            ?data-vl-collapsed-m=${collapsedM}
+            ?data-vl-collapsed-s=${collapsedS}
+            ?data-vl-collapsed-xs=${collapsedXS}
+        >
+            <caption>
+                Data table
+            </caption>
+            <thead>
+                <tr>
+                    <th>Entry Header 1</th>
+                    <th>Entry Header 2</th>
+                    <th>Entry Header 3</th>
+                    <th>Entry Header 4</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                </tr>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2" colspan="2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                </tr>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+
+describe('story elements / data-table / vl-data-table - default', () => {
+    it('should mount', () => {
+        mountDefault({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        expect(customElements.get('vl-data-table')).to.not.be.undefined;
+    });
+
+    it('should be accessible', () => {
+        mountDefault({});
+        cy.injectAxe();
+
+        cy.checkA11y('[is="vl-data-table"]');
+    });
+
+    it('should contain a data table with headers', () => {
+        mountDefault({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        cy.get('[is="vl-data-table"]')
+            .find('thead > tr')
+            .children()
+            .each((cell, index) => {
+                cy.wrap(cell).should('have.text', 'Entry Header ' + (index + 1));
+            });
+    });
+
+    it('should contain a data table with columns', () => {
+        mountDefault({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        cy.get('[is="vl-data-table"]')
+            .find('tbody')
+            .children()
+            .each((row) => {
+                if (!row.attr('data-details-id')) {
+                    cy.wrap(row)
+                        .children()
+                        .each((cell, cellIndex) => {
+                            if (!cell.children('button').length) {
+                                cy.wrap(cell).should('contain.text', 'Entry line ' + (cellIndex + 1));
+                            }
+                        });
+                }
+            });
+    });
+
+    it('should contain a data table with hover styling', () => {
+        mountDefault({ hover: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--hover');
+    });
+
+    it('should contain a data table with a matrix', () => {
+        mountDefault({ matrix: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--matrix');
+    });
+
+    it('should contain a data table with a grid', () => {
+        mountDefault({ grid: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--grid');
+    });
+
+    it('should contain a data table with a zebra grid', () => {
+        mountDefault({ zebra: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--zebra');
+    });
+
+    it('should contain a data table that collapsed on the medium breakpoint', () => {
+        mountDefault({ collapsedM: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-m');
+    });
+
+    it('should contain a data table that collapsed on the small breakpoint', () => {
+        mountDefault({ collapsedS: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-s');
+    });
+
+    it('should contain a data table that collapsed on the extra small breakpoint', () => {
+        mountDefault({ collapsedXS: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-xs');
+    });
+});
+
+const mountExpandable = ({
+    hover,
+    matrix,
+    grid,
+    zebra,
+    uigZebra,
+    collapsedM,
+    collapsedS,
+    collapsedXS,
+}: Partial<typeof dataTableDefaults>) =>
+    cy.mount(html`
+        <table
+            is="vl-data-table"
+            id="vl-data-table-with-expandable-details"
+            ?data-vl-hover=${hover}
+            ?data-vl-matrix=${matrix}
+            ?data-vl-grid=${grid}
+            ?data-vl-zebra=${zebra}
+            ?data-vl-uig-zebra=${uigZebra}
+            ?data-vl-collapsed-m=${collapsedM}
+            ?data-vl-collapsed-s=${collapsedS}
+            ?data-vl-collapsed-xs=${collapsedXS}
+        >
+            <caption>
+                Data table
+            </caption>
+            <thead>
+                <tr>
+                    <th>Entry Header 1</th>
+                    <th>Entry Header 2</th>
+                    <th>Entry Header 3</th>
+                    <th>Entry Header 4</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                </tr>
+                <tr data-details-id="details-row1">
+                    <td data-title="details-title 1">Title 1: generic details</td>
+                </tr>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2" colspan="2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                </tr>
+                <tr data-details-id="details-row2">
+                    <td data-title="details-title 2">Title 2: generic details</td>
+                </tr>
+                <tr id="multiple-cells">
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="details-title 3">Title 3: Zij die ter kaperen varen:</td>
+                    <td>*</td>
+                    <td>*</td>
+                    <td>*</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Jan</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Piet</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Joris</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Korneel</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+
+const shouldDetailsRowBeVisible = (isVisible: boolean, detailRowIndex = 0) => {
+    const haveStyle = !isVisible ? 'have.css' : 'not.have.css';
+    cy.get('[is="vl-data-table"]')
+        .should('have.class', 'vl-data-table')
+        .find('tbody')
+        .find('[data-details-id]')
+        .eq(detailRowIndex)
+        .should(haveStyle, 'display', 'none');
+};
+const toggleDetailsButton = () => {
+    cy.get('[is="vl-data-table"]').find('tbody > tr').first().find('td').last().find('button').click();
+};
+
+describe('story elements / data-table / vl-data-table - expandable', () => {
+    it('should mount', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        expect(customElements.get('vl-data-table')).to.not.be.undefined;
+    });
+
+    it('should be accessible', () => {
+        mountExpandable({});
+        cy.injectAxe();
+
+        cy.checkA11y('[is="vl-data-table"]');
+    });
+
+    it('should contain a data table with headers', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        cy.get('[is="vl-data-table"]')
+            .find('thead > tr')
+            .children()
+            .each((cell, index) => {
+                cy.wrap(cell).should('have.text', 'Entry Header ' + (index + 1));
+            });
+    });
+
+    it('should contain a data table with columns', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr:not([data-details-id])')
+            .each((row, rowIndex) => {
+                cy.wrap(row)
+                    .children()
+                    .each((cell, cellIndex) => {
+                        if (!cell.children('button').length) {
+                            cy.wrap(cell).should('contain.text', 'Entry line ' + (cellIndex + 1));
+                        } else {
+                            cy.wrap(cell).find('button').should('have.class', 'vl-button');
+                        }
+                    });
+                cy.wrap(row)
+                    .next()
+                    .find('td')
+                    .should('contain.text', 'Title ' + (rowIndex + 1));
+            });
+    });
+
+    it('should contain a data table with hover styling', () => {
+        mountExpandable({ hover: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--hover');
+    });
+
+    it('should contain a data table with a matrix', () => {
+        mountExpandable({ matrix: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--matrix');
+    });
+
+    it('should contain a data table with a grid', () => {
+        mountExpandable({ grid: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--grid');
+    });
+
+    it('should contain a data table with a zebra grid', () => {
+        mountExpandable({ zebra: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--zebra');
+    });
+
+    it('should set colspan for expandable row with one cell', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]').find('tbody > tr').first().find('td').last().find('button').click();
+        cy.get('[is="vl-data-table"]').find('tbody > tr').first().next().find('td').should('have.attr', 'colspan', '5');
+    });
+
+    it('should not set colspan for expandable row with multiple cells', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr#multiple-cells')
+            .first()
+            .find('td')
+            .last()
+            .find('button')
+            .click();
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr#multiple-cells')
+            .first()
+            .next()
+            .find('td')
+            .should('not.have.attr', 'colspan');
+    });
+
+    it('should expand all relevant detail rows when clicking the expand button', () => {
+        mountExpandable({});
+
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr[data-details-id="details-row3"]')
+            .should('have.css', 'display', 'none');
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr#multiple-cells')
+            .first()
+            .find('td')
+            .last()
+            .find('button')
+            .click();
+        cy.get('[is="vl-data-table"]')
+            .find('tbody > tr[data-details-id="details-row3"]')
+            .should('not.have.css', 'display', 'none');
+    });
+
+    it('should contain a data table that collapsed on the medium breakpoint', () => {
+        mountExpandable({ collapsedM: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-m');
+    });
+
+    it('should contain a data table that collapsed on the small breakpoint', () => {
+        mountExpandable({ collapsedS: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-s');
+    });
+
+    it('should contain a data table that collapsed on the extra small breakpoint', () => {
+        mountExpandable({ collapsedXS: true });
+
+        cy.get('[is="vl-data-table"]')
+            .should('have.class', 'vl-data-table')
+            .should('have.class', 'vl-data-table--collapsed-xs');
+    });
+
+    it('should toggle expanding a detail row when clicking the button', () => {
+        mountExpandable({});
+
+        shouldDetailsRowBeVisible(false);
+        toggleDetailsButton();
+        shouldDetailsRowBeVisible(true);
+        toggleDetailsButton();
+        shouldDetailsRowBeVisible(false);
+    });
+});
+
+const mountExpandableCustom = ({
+    hover,
+    matrix,
+    grid,
+    zebra,
+    uigZebra,
+    collapsedM,
+    collapsedS,
+    collapsedXS,
+}: Partial<typeof dataTableDefaults>) =>
+    cy.mount(html`
+        <table
+            is="vl-data-table"
+            id="vl-data-table-with-custom-expandable-details"
+            ?data-vl-hover=${hover}
+            ?data-vl-matrix=${matrix}
+            ?data-vl-grid=${grid}
+            ?data-vl-zebra=${zebra}
+            ?data-vl-uig-zebra=${uigZebra}
+            ?data-vl-collapsed-m=${collapsedM}
+            ?data-vl-collapsed-s=${collapsedS}
+            ?data-vl-collapsed-xs=${collapsedXS}
+        >
+            <caption>
+                Data table
+            </caption>
+            <thead>
+                <tr>
+                    <th>Entry Header 1</th>
+                    <th data-title="Entry Header 2" colspan="2">Entry line 2</th>
+                    <th>Entry Header 3</th>
+                    <th>Entry Header 4</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+            <tbody>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                    <td with-expand-details>
+                        <button
+                            is="vl-button"
+                            @click=${() => {
+                                const table = document.querySelector<VlDataTable & Element>(
+                                    '#vl-data-table-with-custom-expandable-details'
+                                );
+                                table?.toggleDetails('details-row1');
+                            }}
+                        >
+                            click to toggle details
+                        </button>
+                    </td>
+                </tr>
+                <tr data-details-id="details-row1">
+                    <td data-title="details-title 1" colspan="5">
+                        <div>
+                            <ul>
+                                <li>Extra Details 1</li>
+                                <li>Extra Details 1</li>
+                                <li>Extra Details 1</li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2" colspan="2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                </tr>
+                <tr data-details-id="details-row2">
+                    <td data-title="details-title 2" colspan="1">
+                        <div>
+                            <ul>
+                                <li>Extra Details 2</li>
+                                <li>Extra Details 2</li>
+                                <li>Extra Details 2</li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td data-title="Entry Header 1">Entry line 1</td>
+                    <td data-title="Entry Header 2">Entry line 2</td>
+                    <td data-title="Entry Header 3">Entry line 3</td>
+                    <td data-title="Entry Header 4">Entry line 4</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Jan</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Piet</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Joris</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+                <tr data-details-id="details-row3">
+                    <td data-title="naam">Korneel</td>
+                    <td data-title="familienaam">familienaam</td>
+                    <td data-title="telefoon">telefoon</td>
+                    <td data-title="adres">adres</td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+describe('story elements / data-table / vl-data-table - expandable with custom button', () => {
+    it('should mount', () => {
+        mountExpandableCustom({});
+
+        cy.get('[is="vl-data-table"]').should('have.class', 'vl-data-table');
+        expect(customElements.get('vl-data-table')).to.not.be.undefined;
+    });
+
+    it('should be accessible', () => {
+        mountExpandableCustom({});
+        cy.injectAxe();
+
+        cy.checkA11y('[is="vl-data-table"]');
+    });
+
+    it('should toggle expanding a detail row when clicking the button', () => {
+        mountExpandableCustom({});
+
+        shouldDetailsRowBeVisible(false);
+        toggleDetailsButton();
+        shouldDetailsRowBeVisible(true);
+        toggleDetailsButton();
+        shouldDetailsRowBeVisible(false);
+    });
+});


### PR DESCRIPTION
- Vroeger zetten we altijd een colspan op de cel in de uitklapbare rij. Nu doen we dit enkel wanneer er maar 1 cel is in de uitklapbare rij.
- Vroeger kon je enkel 1 detail-rij openen per data-rij. Nu kan je meerdere detail-rijen openen per data-rij.
- Storybook uitgebreid & testen gemigreerd naar component testen.

[jira](https://www.milieuinfo.be/jira/browse/UIG-2825)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC271)