### PR TITLE
feat: UIG-2830 - vl-tabs - weergave gedrag verbeterd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
@@ -54,7 +54,7 @@ const shouldSetTitleText = () => {
         .contains('School en studietoelagen');
 };
 
-describe('story vl-functional-header default', () => {
+describe('story - vl-functional-header', () => {
     it('should have default back text', () => {
         cy.visit(functionalHeaderUrl);
 
@@ -104,7 +104,7 @@ describe('story vl-functional-header default', () => {
     });
 });
 
-describe('story vl-functional-header actions', () => {
+describe('story - vl-functional-header - actions', () => {
     it('should have default back text', () => {
         cy.visit(functionalHeaderActionsUrl);
 
@@ -174,7 +174,7 @@ describe('story vl-functional-header actions', () => {
     });
 });
 
-describe('story vl-functional-header tabs', () => {
+describe('story - vl-functional-header - tabs', () => {
     it('should set title link', () => {
         cy.visit(`${functionalHeaderTabsUrl}&args=link:test`);
 
@@ -219,7 +219,7 @@ describe('story vl-functional-header tabs', () => {
         cy.visit(functionalHeaderTabsUrl);
 
         cy.createStubForEvent('vl-tabs', 'change');
-        cy.get('vl-tabs').shadow().find('button[data-vl-tabs-toggle]').click();
+        cy.get('vl-tabs').shadow().find('button[data-vl-tabs-toggle]').click({ force: true });
         cy.get('vl-tabs').shadow().find('a#trein').click();
         cy.get('@change').should('have.been.calledOnce');
     });
@@ -240,7 +240,7 @@ describe('story vl-functional-header tabs', () => {
     });
 });
 
-describe('story vl-functional-header breadcrumb', () => {
+describe('story - vl-functional-header - breadcrumb', () => {
     it('should set title link', () => {
         cy.visit(`${functionalHeaderBreadcrumbUrl}&args=link:test`);
 
@@ -288,7 +288,7 @@ describe('story vl-functional-header breadcrumb', () => {
     });
 });
 
-describe('story vl-functional-header slots', () => {
+describe('story - vl-functional-header - slots', () => {
     it('should set title slot', () => {
         cy.visit(functionalHeaderSlotsUrl);
 

--- a/libs/common/utilities/src/base/base.html.element.ts
+++ b/libs/common/utilities/src/base/base.html.element.ts
@@ -239,7 +239,7 @@ export class BaseHTMLElement extends HTMLElement {
      * @param {String} html - HTML literal
      * @return {HTMLTemplateElement}
      */
-    _template(html: any): any {
+    _template(html: string): DocumentFragment {
         const template = document.createElement('template');
         template.innerHTML = html;
         return template.content;

--- a/libs/common/utilities/src/models/vl.model.ts
+++ b/libs/common/utilities/src/models/vl.model.ts
@@ -70,7 +70,7 @@ interface SideNavigation {
 
 interface Tabs {
     currentTabIndexForCurrentTabsContainer: number;
-    dress(element: HTMLElement | undefined): void;
+    dress(element: HTMLElement | null): void;
 }
 
 interface Toaster {

--- a/libs/components/src/info-tile/vl-info-tile.component.ts
+++ b/libs/components/src/info-tile/vl-info-tile.component.ts
@@ -154,7 +154,7 @@ export class VlInfoTile extends BaseHTMLElement {
             <i class="vl-link__icon vl-link__icon--before vl-toggle__icon vl-vi vl-vi-arrow-right-fat" aria-hidden="true"></i>
           </button>
         `).firstElementChild;
-        button.appendChild(this._titleElement);
+        button?.appendChild(this._titleElement);
         this._headerWrapperElement.prepend(button);
     }
 

--- a/libs/components/src/tabs/stories/vl-tabs.stories-arg.ts
+++ b/libs/components/src/tabs/stories/vl-tabs.stories-arg.ts
@@ -1,6 +1,14 @@
-import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@domg-wc/common-storybook';
+import {
+    CATEGORIES,
+    CONTROLS,
+    defaultArgs,
+    defaultArgTypes,
+    getSelectControlOptions,
+    TYPES,
+} from '@domg-wc/common-storybook';
 import { action } from '@storybook/addon-actions';
 import { ArgTypes } from '@storybook/web-components';
+import { DISPLAY_STYLE } from '../vl-tabs.component';
 
 export const tabsArgs = {
     ...defaultArgs,
@@ -10,7 +18,7 @@ export const tabsArgs = {
     responsiveLabel: '',
     id: '',
     title: '',
-    tabListStyle: '',
+    displayStyle: 'default',
     observeTitle: false,
     onChangeActiveTab: action('change'),
 };
@@ -74,12 +82,16 @@ export const tabsArgTypes: ArgTypes<typeof tabsArgs> = {
             category: CATEGORIES.CHILD_ATTRIBUTES,
         },
     },
-    tabListStyle: {
-        name: 'data-vl-tab-list-style',
-        description: 'De stijl van de tab list.',
+    displayStyle: {
+        name: 'data-vl-display-style',
+        description:
+            'Geeft aan op welke manier de tabs getoond worden.<br>Standaard gedrag (`default`) is responsief; bij een breedte groter dan 768px is stijl de `tabs` stijl, anders is het de `collapsed` stijl.<br>Je kan ook expliciet de `tabs` of `collapsed` stijl kiezen die respectievelijk altijd de tabs of altijd de collapsed stijl toont.',
+        control: CONTROLS.SELECT,
+        options: Object.values(DISPLAY_STYLE),
         table: {
-            type: { summary: ['auto', 'collapsed', 'expanded'] },
+            type: { summary: getSelectControlOptions(Object.values(DISPLAY_STYLE)) },
             category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: tabsArgs.displayStyle },
         },
     },
     observeTitle: {

--- a/libs/components/src/tabs/stories/vl-tabs.stories-doc.mdx
+++ b/libs/components/src/tabs/stories/vl-tabs.stories-doc.mdx
@@ -7,7 +7,6 @@ import tabsStoryUtils from './vl-tabs.stories-util?raw';
 Gebruik de `tabs` component om gerelateerde informatie op te splitsen in kleinere stukken content.
 Op mobiel wordt de tab navigatie omgevormd tot een uitklapbaar menu.
 
-
 ## Voorbeeld
 
 ```js
@@ -19,7 +18,6 @@ import { VlTabsComponent } from '@domg-wc/components';
 ```
 
 <Canvas of={VlTabsStories.TabsDefault} />
-
 
 ## Configuratie
 
@@ -38,7 +36,6 @@ Zie de code onder de story voor het volledige voorbeeld.
     <summary>TypeScript code</summary>
     <Source code={tabsStoryUtils} language="ts" dark={true} />
 </details>
-
 
 ## Referenties
 

--- a/libs/components/src/tabs/stories/vl-tabs.stories.ts
+++ b/libs/components/src/tabs/stories/vl-tabs.stories.ts
@@ -20,10 +20,10 @@ export default {
 
 export const TabsDefault = story(
     tabsArgs,
-    ({ activeTab, alt, disableLinks, responsiveLabel, onChangeActiveTab, observeTitle, tabListStyle }) => html`
+    ({ activeTab, alt, disableLinks, responsiveLabel, onChangeActiveTab, observeTitle, displayStyle }) => html`
         <vl-tabs
             data-vl-active-tab=${activeTab}
-            data-vl-tab-list-style=${tabListStyle}
+            data-vl-display-style=${displayStyle}
             ?data-vl-alt=${alt}
             data-vl-responsive-label=${responsiveLabel}
             ?data-vl-disable-links=${disableLinks}
@@ -55,9 +55,10 @@ TabsDefault.args = {
 
 export const TabsWithoutActiveTab = story(
     tabsArgs,
-    ({ alt, disableLinks, responsiveLabel, onChangeActiveTab, observeTitle }) => html`
+    ({ alt, disableLinks, responsiveLabel, onChangeActiveTab, observeTitle, displayStyle }) => html`
         <vl-tabs
             ?data-vl-alt=${alt}
+            data-vl-display-style=${displayStyle}
             data-vl-responsive-label=${responsiveLabel}
             ?data-vl-disable-links=${disableLinks}
             @change=${(event: CustomEvent) => onChangeActiveTab(event.detail)}
@@ -87,12 +88,13 @@ TabsWithoutActiveTab.args = {
 
 export const TabsDynamic = story(
     tabsArgs,
-    ({ activeTab, alt, disableLinks, responsiveLabel, onChangeActiveTab }) => html`
+    ({ activeTab, alt, disableLinks, responsiveLabel, onChangeActiveTab, displayStyle }) => html`
         <div>
             <button is="vl-button" id="add-pane-button" @click=${addPane}>Pane toevoegen</button>
             <vl-tabs
                 id="tabs"
                 data-vl-active-tab=${activeTab}
+                data-vl-display-style=${displayStyle}
                 ?data-vl-alt=${alt}
                 data-vl-responsive-label=${responsiveLabel}
                 ?data-vl-disable-links=${disableLinks}

--- a/libs/components/src/tabs/vl-tabs.component.cy.ts
+++ b/libs/components/src/tabs/vl-tabs.component.cy.ts
@@ -3,7 +3,7 @@ import { registerWebComponents } from '@domg-wc/common-utilities';
 import { VlTabSectionComponent } from './vl-tab-section.component';
 import { VlTabsPaneComponent } from './vl-tabs-pane.component';
 import { VlTabComponent } from './vl-tab.component';
-import { VlTabsComponent } from './vl-tabs.component';
+import { DisplayStyle, VlTabsComponent } from './vl-tabs.component';
 import { VlIconElement } from '@domg-wc/elements';
 
 registerWebComponents([VlTabsComponent, VlTabComponent, VlTabsPaneComponent, VlTabSectionComponent, VlIconElement]);
@@ -36,7 +36,7 @@ type MountDefaultProps = {
     title?: string;
     responsiveLabel?: string;
     observeTitle?: boolean;
-    tabListStyle?: string;
+    displayStyle?: DisplayStyle;
     onChangeActiveTab: (activeTab: string) => void;
 };
 
@@ -51,7 +51,7 @@ const props: MountDefaultProps = {
     onChangeActiveTab: (activeTab) => {
         console.log(activeTab);
     },
-    tabListStyle: '',
+    displayStyle: 'default',
 };
 
 const mountDefault = ({
@@ -61,32 +61,34 @@ const mountDefault = ({
     disableLinks,
     onChangeActiveTab,
     observeTitle,
-    tabListStyle,
+    displayStyle,
 }: MountDefaultProps) => {
-    return cy.mount(html` <div><vl-tabs
-        data-vl-active-tab=${activeTab}
-        ?data-vl-alt=${alt}
-        data-vl-responsive-label=${responsiveLabel}
-        ?data-vl-disable-links=${disableLinks}
-        data-vl-tab-list-style=${tabListStyle}
-        @change=${(event: CustomEvent) => onChangeActiveTab(event.detail)}
-    >
-        <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein" ?data-vl-observe-title=${observeTitle}>
-            Nullam quis risus eget urna mollis ornare vel eu leo. Duis mollis, est non commodo luctus, nisi erat
-            porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Integer posuere erat a ante venenatis
-            dapibus posuere velit aliquet.
-        </vl-tabs-pane>
-        <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus" ?data-vl-observe-title=${observeTitle}>
-            Donec sed odio dui. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Etiam porta sem
-            malesuada magna mollis euismod. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit.
-        </vl-tabs-pane>
-        <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets" ?data-vl-observe-title=${observeTitle}>
-            Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean eu
-            leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis
-            in, egestas eget quam. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
-        </vl-tabs-pane>
-    </vl-tabs></div>`);
+    return cy.mount(html` <div>
+        <vl-tabs
+            data-vl-active-tab=${activeTab}
+            ?data-vl-alt=${alt}
+            data-vl-responsive-label=${responsiveLabel}
+            ?data-vl-disable-links=${disableLinks}
+            data-vl-display-style=${displayStyle}
+            @change=${(event: CustomEvent) => onChangeActiveTab(event.detail)}
+        >
+            <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein" ?data-vl-observe-title=${observeTitle}>
+                Nullam quis risus eget urna mollis ornare vel eu leo. Duis mollis, est non commodo luctus, nisi erat
+                porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Integer posuere erat a ante
+                venenatis dapibus posuere velit aliquet.
+            </vl-tabs-pane>
+            <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus" ?data-vl-observe-title=${observeTitle}>
+                Donec sed odio dui. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Etiam porta sem
+                malesuada magna mollis euismod. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem
+                ipsum dolor sit amet, consectetur adipiscing elit.
+            </vl-tabs-pane>
+            <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets" ?data-vl-observe-title=${observeTitle}>
+                Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean
+                eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac
+                facilisis in, egestas eget quam. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+            </vl-tabs-pane>
+        </vl-tabs>
+    </div>`);
 };
 
 describe('component vl-tabs', () => {
@@ -124,10 +126,11 @@ describe('component vl-tabs - accessibility', () => {
 });
 
 describe('component vl-tabs - attributes', () => {
-    it('should render the expanded view for containers with width > 767', () => {
+    it('should render tabs view for containers with width > 767', () => {
         mountDefault({ ...props });
-        document.querySelector('div')?.setAttribute('style', 'width:768px');
-        cy.get('vl-tabs').should('not.have.attr', 'data-vl-collapsed');
+        cy.viewport(1920, 1080);
+
+        cy.get('vl-tabs').find('vl-tabs-pane');
         cy.get('vl-tabs')
             .shadow()
             .find('div#tabs > div#tabs-wrapper > ul#tab-list > li')
@@ -136,10 +139,10 @@ describe('component vl-tabs - attributes', () => {
             });
     });
 
-    it('should render the collapsed view for containers with width <= 767', () => {
+    it('should render collapsed view for containers with width <= 767', () => {
         mountDefault({ ...props });
-        document.querySelector('div')?.setAttribute('style', 'width:767px');
-        cy.get('vl-tabs').should('have.attr', 'data-vl-collapsed');
+        cy.viewport(767, 500);
+
         cy.get('vl-tabs')
             .shadow()
             .find('div#tabs > div#tabs-wrapper > ul#tab-list > li')
@@ -148,10 +151,10 @@ describe('component vl-tabs - attributes', () => {
             });
     });
 
-    it('should render the collapsed view for containers with width > 767 when data-vl-tab-list-style is set to collapsed', () => {
-        mountDefault({ ...props, tabListStyle: 'collapsed' });
-        document.querySelector('div')?.setAttribute('style', 'width:768px');
-        cy.get('vl-tabs').should('have.attr', 'data-vl-collapsed');
+    it('should render the collapsed view for containers with width > 767 with collapsed display style', () => {
+        mountDefault({ ...props, displayStyle: 'collapsed' });
+        cy.viewport(1920, 1080);
+
         cy.get('vl-tabs')
             .shadow()
             .find('div#tabs > div#tabs-wrapper > ul#tab-list > li')
@@ -160,10 +163,10 @@ describe('component vl-tabs - attributes', () => {
             });
     });
 
-    it('should render the expanded view for containers with width <= 767 when data-vl-tab-list-style is set to expanded', () => {
-        mountDefault({ ...props, tabListStyle: 'expanded' });
-        document.querySelector('div')?.setAttribute('style', 'width:767px');
-        cy.get('vl-tabs').should('not.have.attr', 'data-vl-collapsed');
+    it('should render tabs view for containers with width <= 767 with tabs display style', () => {
+        mountDefault({ ...props, displayStyle: 'tabs' });
+        cy.viewport(767, 500);
+
         cy.get('vl-tabs')
             .shadow()
             .find('div#tabs > div#tabs-wrapper > ul#tab-list > li')
@@ -171,6 +174,7 @@ describe('component vl-tabs - attributes', () => {
                 expect($el.css('display')).to.eq('inline-block');
             });
     });
+
     it('should not have an <activeTab> selected', () => {
         mountDefault({ ...props, activeTab: '' });
 
@@ -207,8 +211,6 @@ describe('component vl-tabs - attributes', () => {
 
         cy.get('vl-tabs').should('have.attr', 'data-vl-disable-links');
     });
-
-
 });
 
 describe('component vl-tabs-pane - functionality on larger devices', () => {

--- a/libs/components/src/tabs/vl-tabs.uig-css.ts
+++ b/libs/components/src/tabs/vl-tabs.uig-css.ts
@@ -142,7 +142,7 @@ const styles: CSSResult = css`
         border: 0;
         border-bottom: none;
     }
-    .vl-tabs:not(.vl-tabs--overflow) {
+    :host([data-vl-display-style='tabs']) .vl-tabs:not(.vl-tabs--overflow) {
         display: block;
         position: relative;
         left: unset;
@@ -153,27 +153,26 @@ const styles: CSSResult = css`
         border-bottom: 1px #cbd2da solid;
         line-height: unset;
     }
-    [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab {
+    :host([data-vl-display-style='tabs']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab {
         display: inline-block;
         position: relative;
         margin: 0 1.3rem;
-        padding: 0;
         border-bottom: 3px solid transparent;
     }
-    .vl-tabs__toggle {
+    :host([data-vl-display-style='tabs']) .vl-tabs__toggle {
         display: none;
     }
-    [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:first-of-type {
+    :host([data-vl-display-style='tabs']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:first-of-type {
         width: unset;
     }
-    [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab--active {
+    :host([data-vl-display-style='tabs']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab--active {
         border-bottom: 3px solid;
     }
-    [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:hover,
+    :host([data-vl-display-style='tabs']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:hover,
     .vl-tab:focus {
         border-bottom-color: var(--vl-theme-fg-color);
     }
-    :host([data-vl-collapsed]) .vl-tabs:not(.vl-tabs--overflow) {
+    :host([data-vl-display-style='collapsed']) .vl-tabs:not(.vl-tabs--overflow) {
         display: none;
         position: relative;
         left: -1.5rem;
@@ -184,16 +183,16 @@ const styles: CSSResult = css`
         border-bottom: 1px #f7f9fc solid;
         line-height: 1.33;
     }
-    :host([data-vl-collapsed]) .vl-tabs:not(.vl-tabs--overflow)[data-vl-show='true'] {
+    :host([data-vl-display-style='collapsed']) .vl-tabs:not(.vl-tabs--overflow)[data-vl-show='true'] {
         display: block;
     }
-    :host([data-vl-collapsed]) .vl-tabs__toggle {
+    :host([data-vl-display-style='collapsed']) .vl-tabs__toggle {
         display: block;
     }
-    :host([data-vl-collapsed]) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:first-of-type {
+    :host([data-vl-display-style='collapsed']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab:first-of-type {
         width: calc(100% - 4.2rem);
     }
-    :host([data-vl-collapsed]) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab {
+    :host([data-vl-display-style='collapsed']) [data-vl-tabs] .vl-tabs:not(.vl-tabs--overflow) .vl-tab {
         display: block;
         top: 0;
         padding: 0.7rem 1.5rem;


### PR DESCRIPTION
Bij een recente wijziging was het standaard gedrag dat de weergave van de tabs afhing van de grootte van de container, in plaats van de grootte van het scherm. Nu is responsief standaard gedrag hersteld en is enkel de mogelijkheid behouden voor de afnemer om te kiezen voor welke weergave ze expliciet willen instellen onafhankelijk van de schermgrootte. Cypress testen, typing & storybook verbeterd.

[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC273)
[jira](https://www.milieuinfo.be/jira/browse/UIG-2830)