### PR TITLE
fix: UIG-2888 - vl-cascader-item - typfout in render methode rechtgezet

### DIFF
--- a/libs/components/src/next/cascader/vl-cascader-item.component.ts
+++ b/libs/components/src/next/cascader/vl-cascader-item.component.ts
@@ -59,9 +59,10 @@ export class VlCascaderItemComponent extends BaseLitElement {
         }
         return cascaderRef && templateResultForNode
             ? html`${templateResultForNode} ${html`<slot name="content"></<slot>`}`
-            : html`${
-                  !hasLabelSlot ? defaultItemActionTemplate(this.item) : html`<slot name="label"></slot>`
-              }<slot name="content"></<slot>`;
+            : html`
+                  ${!hasLabelSlot ? defaultItemActionTemplate(this.item) : html`<slot name="label"></slot>`}
+                  <slot name="content"></slot>
+              `;
     }
 }
 


### PR DESCRIPTION
[jira](https://www.milieuinfo.be/jira/browse/UIG-2888)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC276)