### PR TITLE
feat: UIG-2749 - vl-header - logout request

### DIFF
--- a/libs/sections/src/header/stories/vl-header.stories-arg.ts
+++ b/libs/sections/src/header/stories/vl-header.stories-arg.ts
@@ -1,31 +1,16 @@
 import { action } from '@storybook/addon-actions';
 import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
 import { ArgTypes } from '@storybook/web-components';
+import { headerDefaults } from '../vl-header.section';
 
-export const headerArgs = {
-    authenticatedUserUrl: '/sso/ingelogde_gebruiker',
-    skeleton: false,
-    development: false,
-    identifier: '',
-    loginRedirectUrl: '/',
-    loginUrl: '/sso/aanmelden',
-    logoutUrl: '/sso/afgemeld',
-    simple: false,
-    switchCapacityUrl: '/sso/wissel_organisatie',
-    applicationLinks: [],
+type HeaderArgs = typeof headerDefaults & { onReady: () => void };
+
+export const headerArgs: HeaderArgs = {
+    ...headerDefaults,
     onReady: action('ready'),
 };
 
-export const headerArgTypes: ArgTypes<typeof headerArgs> = {
-    skeleton: {
-        name: 'data-vl-skeleton',
-        description: 'Geeft aan of de header een skeleton mag tonen voordat het rendert.',
-        table: {
-            type: { summary: TYPES.BOOLEAN },
-            category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: headerArgs.skeleton },
-        },
-    },
+export const headerArgTypes: ArgTypes<HeaderArgs> = {
     authenticatedUserUrl: {
         name: 'data-vl-authenticated-user-url',
         description: 'De url die wordt opgeroepen om te zien of een gebruiker is ingelogd.',
@@ -92,6 +77,15 @@ export const headerArgTypes: ArgTypes<typeof headerArgs> = {
             defaultValue: { summary: headerArgs.simple },
         },
     },
+    skeleton: {
+        name: 'data-vl-skeleton',
+        description: 'Geeft aan of de header een skeleton moet tonen voordat het rendert.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.skeleton },
+        },
+    },
     switchCapacityUrl: {
         name: 'data-vl-switch-capacity-url',
         description:
@@ -100,6 +94,26 @@ export const headerArgTypes: ArgTypes<typeof headerArgs> = {
             type: { summary: TYPES.URL },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: headerArgs.switchCapacityUrl },
+        },
+    },
+    rejectLogout: {
+        name: 'data-vl-reject-logout',
+        description:
+            'Geeft aan of het logout request moet worden afgewezen.<br/>Een logout request door de gebruiker wordt nooit afgewezen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.rejectLogout },
+        },
+    },
+    logoutCallback: {
+        name: 'logoutCallback',
+        description: `De callback die aangeroepen wordt bij een logout request.<br/>De logout reason wordt meegegeven aan de callback, door een boolean promise terug te geven kan je het logout request accepteren of afwijzen.<br/>De mogelijke reasons zijn: 'inactivity' en 'expired'.<br/>Een logout request door de gebruiker wordt nooit afgewezen.`,
+        control: false,
+        table: {
+            type: { summary: '(reason: string) => Promise<boolean>' },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: headerArgs.logoutCallback },
         },
     },
     applicationLinks: {

--- a/libs/sections/src/header/stories/vl-header.stories-doc.mdx
+++ b/libs/sections/src/header/stories/vl-header.stories-doc.mdx
@@ -26,15 +26,16 @@ import { VlHeader } from '@domg-wc/sections';
 <ArgTypes of={VlHeaderStories.HeaderDefault} />
 
 
-## Extra info
+## Sessies
 
-Bij het aanpassen van volgende attributen wordt achterliggend de session.configure() methode van DV opnieuw aangeroepen:
+### Configuratie
+
+Bij het aanpassen van volgende attributen wordt achterliggend de `session.configure()` methode van DV opnieuw aangeroepen:
 
 -   `data-vl-login-url`
 -   `data-vl-login-redirect-url`
 -   `data-vl-logout-url`
 -   `data-vl-switch-capacity-url`
-
 
 Zie [Digitaal Vlaanderen - De endpoints overschrijven](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6336119448/Aanmelden+met+eenvoudig+of+gekoppeld+toegangsbeheer#De-endpoints-overschrijven) voor meer informatie.
 
@@ -51,7 +52,23 @@ export type ApplicationLink = {
     target?: string;
 };
 ```
+
 Zie [Digitaal Vlaanderen - Header applicatieve links](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6508874105/Aanmeldmenu#Applicatieve-links) voor meer informatie.
+
+### Logout request
+
+Bij het gebruik maken van sessies kan het logout request afgehandeld worden.<br/>
+Dit kan handig zijn als je wilt dat de gebruiker niet automatisch wordt uitgelogd bv. bij inactiviteit of als de sessie verlopen is.
+
+Door gebruik te maken van het `data-vl-reject-logout` attribuut worden alle logout requests afgewezen, behalve een logout request door de gebruiker.
+
+Met de `logoutCallback` property kan je een callback functie meegeven die wordt aangeroepen bij een logout request.<br/>
+De logout reason wordt meegegeven aan de callback, door een boolean promise terug te geven kan je de logout accepteren of afwijzen.<br/>
+De mogelijke reasons zijn: `inactivity` en `expired`.<br/>
+Een logout request door de gebruiker wordt nooit afgewezen.
+
+
+Zie [De aanvragen voor applicatie logout afhandelen via JavaScript](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6336119448/Aanmelden+met+eenvoudig+of+gekoppeld+toegangsbeheer#De-aanvragen-voor-applicatie-logout-afhandelen-via-JavaScript) voor meer informatie.
 
 ## Referenties
 

--- a/libs/sections/src/header/stories/vl-header.stories.ts
+++ b/libs/sections/src/header/stories/vl-header.stories.ts
@@ -31,6 +31,8 @@ export const HeaderDefault = story(
         skeleton,
         simple,
         switchCapacityUrl,
+        rejectLogout,
+        logoutCallback,
         applicationLinks,
         onReady,
     }) => html`
@@ -45,8 +47,10 @@ export const HeaderDefault = story(
                 ?data-vl-simple=${simple}
                 ?data-vl-skeleton=${skeleton}
                 data-vl-switch-capacity-url=${switchCapacityUrl}
+                ?data-vl-reject-logout=${rejectLogout}
+                .logoutCallback=${logoutCallback}
                 .applicationLinks=${applicationLinks}
-                @ready=${(event: CustomEvent) => onReady(event)}
+                @ready=${onReady}
             ></vl-header>
         </div>
     `

--- a/libs/sections/src/header/vl-header.section.cy.ts
+++ b/libs/sections/src/header/vl-header.section.cy.ts
@@ -4,163 +4,51 @@ import { VlHeader } from './index';
 
 registerWebComponents([VlHeader]);
 
-type MountDefaultProps = {
-    authenticatedUserUrl: string;
-    development: boolean;
-    identifier?: string;
-    loginRedirectUrl: string;
-    loginUrl: string;
-    logoutUrl: string;
-    simple: boolean;
-    skeleton?: boolean;
-    switchCapacityUrl: string;
-    onReady: (evt: CustomEvent) => void;
-};
-
-const mountDefault = ({ ...props }: MountDefaultProps) => {
-    return cy.mount(html`
-        <div is="vl-body">
-            <vl-header
-                data-vl-authenticated-user-url=${props.authenticatedUserUrl}
-                ?data-vl-development=${props.development}
-                data-vl-identifier=${props.identifier}
-                data-vl-login-redirect-url=${props.loginRedirectUrl}
-                data-vl-login-url=${props.loginUrl}
-                data-vl-logout-url=${props.logoutUrl}
-                ?data-vl-simple=${props.simple}
-                ?data-vl-skeleton=${props.skeleton}
-                data-vl-switch-capacity-url=${props.switchCapacityUrl}
-                @ready=${(evt: CustomEvent) => props.onReady(evt)}
-            ></vl-header>
-        </div>
-    `);
-};
-
-const props: MountDefaultProps = {
-    authenticatedUserUrl: '/sso/ingelogde_gebruiker',
-    development: true,
-    identifier: '59188ff6-662b-45b9-b23a-964ad48c2bfb',
-    loginRedirectUrl: '/',
-    loginUrl: '/sso/aanmelden',
-    logoutUrl: '/sso/afgemeld',
-    simple: false,
-    skeleton: false,
-    switchCapacityUrl: '/sso/wissel_organisatie',
-    onReady: () => console.log('ready'),
-};
-
-describe('vl-header component - default', () => {
+describe('component - vl-header', () => {
     beforeEach(() => {
-        mountDefault(props);
+        cy.mount(html`
+            <div is="vl-body">
+                <vl-header data-vl-development data-vl-identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"></vl-header>
+            </div>
+        `);
     });
 
     it('should mount', () => {
         cy.get('vl-header');
+        cy.get('#header__container');
     });
 
     it('should be accessible', () => {
-        cy.get('vl-header');
-
         cy.injectAxe();
+
+        cy.get('vl-header');
         cy.checkA11y('vl-header');
+        cy.checkA11y('#header__container');
     });
 
     it('should render with fixed height', () => {
-        cy.get('vl-header');
-
         cy.get('#header__container').should('have.css', 'min-height', '43px');
     });
-});
 
-describe('vl-header component - properties default ', () => {
-    it('should have default values properties', () => {
-        mountDefault(props);
-
-        cy.get('vl-header').should('have.attr', 'data-vl-authenticated-user-url', props.authenticatedUserUrl);
-        cy.get('vl-header').should('not.have.attr', 'data-vl-development', props.development);
-        cy.get('vl-header').should('have.attr', 'data-vl-identifier', props.identifier);
-        cy.get('vl-header').should('have.attr', 'data-vl-login-redirect-url', props.loginRedirectUrl);
-        cy.get('vl-header').should('have.attr', 'data-vl-login-url', props.loginUrl);
-        cy.get('vl-header').should('have.attr', 'data-vl-logout-url', props.logoutUrl);
-        cy.get('vl-header').should('not.have.attr', 'data-vl-simple', props.simple);
-        cy.get('vl-header').should('not.have.attr', 'data-vl-skeleton', props.skeleton);
-        cy.get('vl-header').should('have.attr', 'data-vl-switch-capacity-url', props.switchCapacityUrl);
-    });
-});
-
-describe('vl-header component - properties reflect ', () => {
-    it('should reflect the <authenticatedUser> attribute', () => {
-        mountDefault({ ...props, authenticatedUserUrl: '/sso/TEST_GEBRUIKER' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-authenticated-user-url', '/sso/TEST_GEBRUIKER');
-    });
-
-    it('should reflect the <development> attribute', () => {
-        mountDefault({ ...props, development: true });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-development', '');
-    });
-
-    it('should reflect the <identifier> attribute', () => {
-        mountDefault({ ...props, identifier: 'TEST_IDENTIFIER' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-identifier', 'TEST_IDENTIFIER');
-    });
-
-    it('should reflect the <loginRedirectUrl> attribute', () => {
-        mountDefault({ ...props, loginRedirectUrl: '/TEST_REDIRECT_URL' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-login-redirect-url', '/TEST_REDIRECT_URL');
-    });
-
-    it('should reflect the <loginUrl> attribute', () => {
-        mountDefault({ ...props, loginUrl: '/TEST_LOGIN_URL' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-login-url', '/TEST_LOGIN_URL');
-    });
-
-    it('should reflect the <logoutUrl> attribute', () => {
-        mountDefault({ ...props, logoutUrl: '/TEST_LOGOUT_URL' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-logout-url', '/TEST_LOGOUT_URL');
-    });
-
-    it('should reflect the <simple> attribute', () => {
-        mountDefault({ ...props, simple: true });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-simple');
-    });
-
-    it('should reflect the <skeleton> attribute', () => {
-        mountDefault({ ...props, skeleton: true });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-skeleton');
-    });
-
-    it('should reflect the <switchCapacityUrl> attribute', () => {
-        mountDefault({ ...props, switchCapacityUrl: '/TEST_SWITCH_URL' });
-
-        cy.get('vl-header').should('have.attr', 'data-vl-switch-capacity-url', '/TEST_SWITCH_URL');
-    });
-});
-
-describe('vl-header component - events', () => {
-    it('should emit ready event', () => {
-        mountDefault({ ...props, development: true });
-        cy.get('vl-header');
-
+    it('should dispatch ready event when ready', () => {
         // Mogelijke flaky test aangezien het event afgevuurd kan worden vooraleer de eventListener is toegevoegd.
         cy.createStubForEvent('vl-header', 'ready');
         cy.get('@ready').should('have.been.calledOnce');
     });
 });
 
-describe('vl-header component - with skeleton', () => {
+describe('component - vl-header - skeleton', () => {
     it('should render the skeleton container', () => {
-        mountDefault({ ...props, skeleton: true });
+        cy.mount(html`
+            <div is="vl-body">
+                <vl-header
+                    data-vl-development
+                    data-vl-identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
+                    data-vl-skeleton
+                ></vl-header>
+            </div>
+        `);
 
-        cy.get('vl-header').should('have.attr', 'data-vl-skeleton');
-
-        cy.get('#header__skeleton').should('exist');
+        cy.get('#header__skeleton').should('have.css', 'height', '43px');
     });
 });


### PR DESCRIPTION
Afhandelen van logout request toegevoegd
Storybook uitgebreid
Cypress testen herschreven

Ik heb 2 manieren voorzien om het logout request af te handelen:
- **data-vl-reject-logout attribuut**: dit zorgt ervoor dat alle logouts (behalve die door de gebruiker) afgewezen worden. Dit is voor Freek het gevraagde gedrag en dat kan hij nu heel simpel door een attribuut te plaatsen
- **logoutCallback property**: hiermee kan je het heft in eigen handen nemen en obv de logout reason zelf bepalen of je wilt uitloggen of niet. Dit is een asynchrone methode die een boolean terug verwacht zodat de afnemer een call naar hun backend kan doen om bv. te kijken of hun sessie nog geldig is. Ook hier worden logout requests door de gebruiker nooit afgewezen.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-2749)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC353)