### PR TITLE
fix: UIG-2905 - vl-map-legend - verwijder dubbele custom items

### DIFF
--- a/libs/map/src/components/legend/vl-map-legend.ts
+++ b/libs/map/src/components/legend/vl-map-legend.ts
@@ -254,16 +254,13 @@ export class VlMapLegend extends BaseLitElement {
                     this.items.push(customItem);
                 } else {
                     const layer = customItem.name;
+                    const defaultItemForLayer = defaultItems.find((item) => item.name === layer);
 
-                    const defaultItemsForLayer = defaultItems
-                        .filter((item) => item.name === layer)
-                        .map((defaultItem) => {
-                            if (defaultItem.type === 'styled') {
-                                defaultItem.iconText = customItem.iconText;
-                            }
-                            return defaultItem;
-                        });
-                    this.items = this.items.concat(...defaultItemsForLayer);
+                    if (defaultItemForLayer && defaultItemForLayer.type === 'styled') {
+                        defaultItemForLayer.iconText = customItem.iconText;
+                    }
+
+                    this.items.push(defaultItemForLayer);
                 }
             });
         } else {
@@ -290,6 +287,8 @@ export class VlMapLegend extends BaseLitElement {
                       <span class="uig-map-legend-text uig-map-legend-title">Legende: </span>
                   </div>`}
             ${this.items.map((item) => {
+                if (!item) return '';
+
                 switch (item.type) {
                     case 'custom':
                         return html` ${item.styleElement} `;


### PR DESCRIPTION
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC290)
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2905)