### PR TITLE
feat: UIG-2958 - Cypress videos uitgezet

### DIFF
--- a/apps/playground-lit-e2e/cypress.config.ts
+++ b/apps/playground-lit-e2e/cypress.config.ts
@@ -4,8 +4,6 @@ export default defineConfig({
     fileServerFolder: '.',
     fixturesFolder: './src/fixtures',
     modifyObstructiveCode: false,
-    video: true,
-    videosFolder: '../../dist/cypress/apps/playground-lit-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/playground-lit-e2e/screenshots',
     chromeWebSecurity: false,
     retries: 3,

--- a/apps/storybook-e2e/cypress.config.ts
+++ b/apps/storybook-e2e/cypress.config.ts
@@ -5,8 +5,6 @@ export default defineConfig({
     fileServerFolder: '.',
     fixturesFolder: './src/fixtures',
     modifyObstructiveCode: false,
-    video: true,
-    videosFolder: '../../dist/cypress/apps/storybook-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/storybook-e2e/screenshots',
     chromeWebSecurity: false,
     retries: 3,

--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -81,10 +81,9 @@ unit-wct-component-integrator-tests:
         git config --global init.defaultBranch develop
     - checkout
     - script: bash ./resources/ci/scripts/unit-wct-component-integrator-tests-docker.sh
-    - script: *dist-artifact
   artifacts:
     - name: dist-unit-wct-component-integrator-tests
-      location: dist-artifact
+      location: dist
       pattern: '**/*.*'
 
 e2e-tests-storybook:
@@ -97,12 +96,10 @@ e2e-tests-storybook:
         git config --global init.defaultBranch develop
     - checkout
     - script: bash ./resources/ci/scripts/e2e-tests-storybook-docker.sh
-    - script: *dist-artifact
   artifacts:
     - name: dist-e2e-tests-storybook
-      location: dist-artifact
+      location: dist
       pattern: '**/*.*'
-      shared: true
 
 release-and-publish:
   requirements: *requirements

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'cypress';
 import path from 'path';
 
 export default defineConfig({
-    videosFolder: './dist/cypress/videos',
     screenshotsFolder: './dist/cypress/screenshots',
     retries: 3,
     component: {

--- a/resources/ci/scripts/e2e-tests-storybook.sh
+++ b/resources/ci/scripts/e2e-tests-storybook.sh
@@ -19,5 +19,9 @@ if [ $? -eq 0 ]
 fi
 set -e
 
+echo "create dist folder with emtpy text file"
+mkdir dist
+touch dist/empty.txt
+
 echo "run the e2e tests"
 npm run storybook:ci-test


### PR DESCRIPTION
Cypress videos uitgezet
dist folder met lege file toegevoegd in storybook-e2e build script zodat er altijd een artifact gemaakt kan worden 
dist-artifact script verwijderd uit build test steps

[Jira](https://www.milieuinfo.be/jira/browse/UIG-2958)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC301-2)