### PR TITLE
fix: UIG-2959 - vl-cascader - null check toegevoegd bij het instellen van children

### DIFF
--- a/libs/components/src/next/cascader/vl-cascader.component.ts
+++ b/libs/components/src/next/cascader/vl-cascader.component.ts
@@ -274,7 +274,9 @@ export class VlCascaderComponent extends BaseLitElement {
         const nodesForThisLevel: CascaderItem[] = [];
         nodes.forEach((node) => {
             const children = this.traverseTreeAndMapItems(node);
-            node.item.children = children;
+            if (node.item) {
+                node.item.children = children;
+            }
             node.cascaderRef = this;
             nodesForThisLevel.push({
                 ...node.item,


### PR DESCRIPTION
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC302)
[jira](https://www.milieuinfo.be/jira/browse/UIG-2959)