### PR TITLE
feat: UIG-2899 - vl-datepicker-next - mask validatie toegevoegd

### DIFF
--- a/apps/playground-lit/src/app/app.element.ts
+++ b/apps/playground-lit/src/app/app.element.ts
@@ -502,7 +502,6 @@ export class AppElement extends LitElement {
                             <vl-datepicker-next
                                 id="geboortedatum"
                                 name="geboortedatum"
-                                pattern="^(0?[1-9]|[12][0-9]|3[01])\\.(0?[1-9]|1[012])\\.([0-9]{4})$"
                                 block
                                 value=${this.birthdate}
                                 ?required=${this.birthdateRequired}

--- a/libs/form/src/models/cleave.model.ts
+++ b/libs/form/src/models/cleave.model.ts
@@ -14,6 +14,12 @@ export interface MaskOptions {
     numeralDecimalMark?: string;
     date?: boolean;
     datePattern?: string[];
+    dateMin?: string;
+    dateMax?: string;
+    time?: boolean;
+    timePattern?: string[];
+    timeFormat?: string;
+    onValueChanged?: (event: { target: { value: string; rawValue: string } }) => void;
     regex?: RegExp;
     customTransformFn?: (value: string) => string;
 }

--- a/libs/form/src/next/datepicker/masks.ts
+++ b/libs/form/src/next/datepicker/masks.ts
@@ -1,0 +1,73 @@
+import flatpickr from 'flatpickr';
+import { MaskOptions } from '../../models/cleave.model';
+
+export const createDateMask = (format: string, minDate?: string, maxDate?: string): MaskOptions | null => {
+    if (!format) return null;
+    let maskOptions: MaskOptions | null = null;
+    const delimiters = format.split(/[dmyY]/).filter((delimiter) => delimiter);
+    const datePattern = format.split(/[.*+-/_:]/);
+    // indien pattern niet ondersteund wordt, genereren we geen mask
+    if (datePattern.filter((char) => !['d', 'm', 'Y', 'y'].includes(char)).length) return null;
+    // 4 cijfers voor volledig jaar, anders 2
+    const length = datePattern.reduce((acc, char) => {
+        // 4 cijfers voor een volledig jaar
+        if (char === 'Y') return acc + 4;
+        // 2 cijfers voor een maand, dag of kort jaar
+        return acc + 2;
+    }, 0);
+    maskOptions = {
+        date: true,
+        datePattern: datePattern,
+        delimiters: delimiters,
+        regex: new RegExp(`^[0-9]{${length}}$`),
+    };
+    if (minDate) {
+        const minimumDate = flatpickr?.parseDate(minDate, format);
+        maskOptions = {
+            ...maskOptions,
+            // formatteren naar verwacht formaat voor cleave.js
+            dateMin: minimumDate ? flatpickr?.formatDate(minimumDate, 'Y-M-D') : undefined,
+        };
+    }
+    if (maxDate) {
+        const maximumDate = flatpickr?.parseDate(maxDate, format);
+        maskOptions = {
+            ...maskOptions,
+            // formatteren naar verwacht formaat voor cleave.js
+            dateMax: maximumDate ? flatpickr?.formatDate(maximumDate, 'Y-M-D') : undefined,
+        };
+    }
+    return maskOptions;
+};
+
+export const createTimeMask = (format: string): MaskOptions | null => {
+    if (!format) return null;
+    const delimiters = format.split(/[HhiS]/).filter((delimiter) => delimiter);
+    let isMilitaryFormat = true;
+    const timePattern = format.split(/[.*+-/_:]/).map((char) => {
+        // conversie van flatpickr naar cleave.js format
+        switch (char) {
+            case 'H':
+                return 'h';
+            case 'h':
+                isMilitaryFormat = false;
+                return 'h';
+            case 'i':
+                return 'm';
+            case 'S':
+                return 's';
+            default:
+                return char;
+        }
+    });
+    // indien pattern niet ondersteund wordt, genereren we geen mask
+    if (timePattern.filter((char) => !['h', 'm', 's'].includes(char)).length) return null;
+    return {
+        time: true,
+        timePattern: timePattern,
+        timeFormat: isMilitaryFormat ? '24' : '12',
+        delimiters: delimiters,
+        // timePattern.length * 2
+        regex: new RegExp(`^[0-9]{${timePattern.length * 2}}$`),
+    };
+};

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -75,7 +75,7 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
     format: {
         name: 'format',
         description:
-            "Het formaat van de datum/tijd waarde, standaard 'd.m.Y' (-> 31.12.2019). Bv. 'l d M Y' geeft dinsdag 03 jan 2023.",
+            'Het formaat van de datum/tijd waarde. Voor een datum is het standaard formaat `d.m.Y` (-> 31.12.2019).<br>Voor tijd, is `H:i` het standaard formaat (-> 23:59).',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
@@ -131,13 +131,34 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
             defaultValue: { summary: datepickerArgs.amPm },
         },
     },
+    disableMaskValidation: {
+        name: 'disable-mask-validation',
+        description: 'Schakelt de automatische mask validatie uit.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: datepickerArgs.disableMaskValidation },
+        },
+    },
     pattern: {
         name: 'pattern',
-        description: 'Het patroon dat je moet volgen bij het ingeven van een waarde.',
+        description:
+            'Het patroon dat je moet volgen bij het ingeven van een waarde.<br>Dit kan gebruikt worden voor eenvoudige validatie.<br>Gebruik de `regex` property voor complexe validatie.',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: datepickerArgs.pattern },
+        },
+    },
+    regex: {
+        name: 'regex',
+        description:
+            'Het patroon dat je moet volgen bij het ingeven van een waarde.<br>Dit kan gebruikt worden voor complexe validatie.',
+        control: false,
+        table: {
+            type: { summary: TYPES.REGEX },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: datepickerArgs.regex },
         },
     },
     onVlInput: {

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -39,6 +39,20 @@ In onderstaand voorbeeld wordt de datumnotatie expliciet ingesteld op `d/m/Y`.
 <vl-datepicker-next format="d/m/Y"></vl-datepicker-next>
 ```
 
+## Validatie
+
+### Mask Validatie
+
+- Er wordt automatisch mask validatie toegevoegd aan de datepicker met type `date` (standaard) of type `time`.
+- De mask wordt opgebouwd op basis van het `format` attribuut.
+- Je kan automatische mask validatie uitschakelen met het `disable-mask-validation` attribuut.
+- De `patternMismatch` ValidityState key wordt gebruikt voor de mask validatie error.
+
+### Pattern Validatie
+
+- Als de mask validatie is uitgeschakeld, kan je met het `pattern` attribuut een regex patroon instellen. Je kan ook de `regex` property gebruiken voor complexere validatie.
+- De `patternMismatch` ValidityState key wordt gebruikt voor de pattern validatie error.
+
 ## Conversie
 
 Wanneer je een ander formaat wil gebruiken dan het formaat dat aan de gebruiker wordt getoond, moet je deze zelf omzetten.<br/>
@@ -52,7 +66,10 @@ function convertDate(date: Date, format: string) {
 }
 ```
 
-Meer documentatie over `flatpickr`-formaten kan je terugvinden in de [Flatpickr documentatie](https://flatpickr.js.org/formatting/).
+## Gekende Beperkingen
+
+- De datepicker is niet toegankelijk voor gebruikers die enkel met het toetsenbord navigeren. Ze kunnen wel manueel een datum invullen.
+- Voor datepicker met type `datetime` & `range` is er geen automatische mask validatie voorzien gezien `cleave.js` hiervoor geen ondersteuning biedt.
 
 ## Referenties
 

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories.ts
@@ -44,6 +44,7 @@ export const DatepickerDefault = story(
         autocomplete,
         label,
         pattern,
+        regex,
         name,
         onVlInput,
         onVlReset,
@@ -72,6 +73,7 @@ export const DatepickerDefault = story(
                     max-time=${maxTime}
                     am-pm=${amPm}
                     pattern=${pattern}
+                    .regex=${regex}
                     @vl-input=${onVlInput}
                     @vl-reset=${onVlReset}
                     @vl-valid=${onVlValid}

--- a/libs/form/src/next/datepicker/validators.ts
+++ b/libs/form/src/next/datepicker/validators.ts
@@ -1,0 +1,31 @@
+import { Validator } from '@open-wc/form-control';
+import { CleaveInstance, MaskOptions } from '../../models/cleave.model';
+
+export const maskValidator: Validator = {
+    key: 'patternMismatch',
+    message: 'Value does not meet the given pattern.',
+    isValid(
+        instance: HTMLElement & {
+            disableMaskValidation: boolean;
+            pattern: string;
+            regex: RegExp;
+            maskOptions: MaskOptions;
+            cleaveInstance: CleaveInstance;
+        },
+        value: string
+    ): boolean {
+        const { disableMaskValidation, cleaveInstance } = instance;
+        const regex = instance.regex || instance.pattern;
+        if (!value || (!regex && (!cleaveInstance || disableMaskValidation))) {
+            return true;
+        }
+        if (cleaveInstance && !disableMaskValidation && instance.maskOptions?.regex) {
+            const rawValue = cleaveInstance.getRawValue();
+            const regExp = new RegExp(instance.maskOptions.regex);
+            return regExp.test(rawValue);
+        } else {
+            const regExp = new RegExp(regex);
+            return regExp.test(value);
+        }
+    },
+};

--- a/libs/form/src/next/datepicker/vl-datepicker.component.ts
+++ b/libs/form/src/next/datepicker/vl-datepicker.component.ts
@@ -7,7 +7,6 @@ import {
     inputGroupStyle,
     tooltipStyle,
 } from '@domg/govflanders-style/component';
-import { patternValidator } from '@open-wc/form-control';
 import datepickerUigStyle from './vl-datepicker.uig-css';
 import { CSSResult, html, nothing, TemplateResult } from 'lit';
 import { Options } from 'flatpickr/dist/types/options';
@@ -19,9 +18,12 @@ import { registerWebComponents, webComponent } from '@domg-wc/common-utilities';
 import { VlButtonInputAddon, VlIconElement } from '@domg-wc/elements';
 import { live } from 'lit/directives/live.js';
 import { FormControl, formControlDefaults } from '../form-control/form-control';
+import { maskValidator } from './validators';
+import { CleaveInstance, MaskOptions } from '../../models/cleave.model';
+import Cleave from 'cleave.js';
+import { createDateMask, createTimeMask } from './masks';
 
 export const DATEPICKER_TYPES = ['date', 'range', 'time', 'date-time'] as const;
-
 export const datepickerDefaults = {
     ...formControlDefaults,
     block: false as boolean,
@@ -30,14 +32,18 @@ export const datepickerDefaults = {
     placeholder: '' as string,
     autocomplete: '' as string,
     type: 'date' as (typeof DATEPICKER_TYPES)[number],
-    format: 'd.m.Y' as string,
+    format: '' as string,
     amPm: false as boolean,
     minDate: '' as string,
     maxDate: '' as string,
     minTime: '' as string,
     maxTime: '' as string,
+    disableMaskValidation: false as boolean,
     pattern: '' as string,
+    regex: null as RegExp | null,
 } as const;
+
+const dateRangeSeparator = ' tot en met ';
 
 @webComponent('vl-datepicker-next')
 export class VlDatepickerComponent extends FormControl {
@@ -54,17 +60,20 @@ export class VlDatepickerComponent extends FormControl {
     private maxDate = datepickerDefaults.maxDate;
     private minTime = datepickerDefaults.minTime;
     private maxTime = datepickerDefaults.maxTime;
-    private pattern = datepickerDefaults.pattern;
+    private disableMaskValidation = datepickerDefaults.disableMaskValidation; // Wordt enkel gebruikt in de mask validator
+    private pattern = datepickerDefaults.pattern; // Wordt enkel gebruikt in de mask validator
 
     // Variables
-    private instance: Instance | null = null;
     private initialValue = '';
+    private flatpickrInstance: Instance | null = null;
+    private maskOptions: MaskOptions | null = null; // Wordt enkel gebruikt in de mask validator
+    private cleaveInstance: CleaveInstance | null = null;
 
     static {
         registerWebComponents([VlButtonInputAddon, VlIconElement]);
     }
 
-    static formControlValidators = [...FormControl.formControlValidators, patternValidator];
+    static formControlValidators = [...FormControl.formControlValidators, maskValidator];
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [
@@ -94,7 +103,9 @@ export class VlDatepickerComponent extends FormControl {
             maxDate: { type: String, attribute: 'max-date' },
             minTime: { type: String, attribute: 'min-time' },
             maxTime: { type: String, attribute: 'max-time' },
+            rawValue: { type: Boolean, attribute: 'raw-value' },
             pattern: { type: String },
+            disableMaskValidation: { type: Boolean, attribute: 'disable-mask-validation' },
         };
     }
 
@@ -102,8 +113,8 @@ export class VlDatepickerComponent extends FormControl {
         super.connectedCallback();
 
         if (Dutch?.nl) {
-            Dutch.nl.rangeSeparator = ' tot en met ';
-            flatpickr.l10ns.default.rangeSeparator = ' tot en met ';
+            Dutch.nl.rangeSeparator = dateRangeSeparator;
+            flatpickr.l10ns.default.rangeSeparator = dateRangeSeparator;
         }
 
         if (!this.initialValue) {
@@ -114,6 +125,29 @@ export class VlDatepickerComponent extends FormControl {
     firstUpdated(changedProperties: Map<string, unknown>) {
         super.firstUpdated(changedProperties);
 
+        // passen formaat aan indien niet opgegeven
+        if (changedProperties.has('type') && !this.format) {
+            const timeFormat = 'H:i';
+            const dateFormat = 'd.m.Y';
+            switch (this.type) {
+                case 'date':
+                    this.format = dateFormat;
+                    break;
+                case 'time':
+                    this.format = timeFormat;
+                    break;
+                case 'date-time':
+                    this.format = `${dateFormat} ${timeFormat}`;
+                    break;
+                default:
+                    this.format = dateFormat;
+            }
+        }
+
+        this.maskOptions = this.composeMaskForFormat(this.format, this.type);
+        if (this.maskOptions && !this.disableMaskValidation) {
+            this.cleaveInstance = new Cleave(this.validationTarget!, this.maskOptions);
+        }
         this.initializeComponent();
     }
 
@@ -121,7 +155,11 @@ export class VlDatepickerComponent extends FormControl {
         super.updated(changedProperties);
 
         const options = this.getDynamicOptions();
-        this.updateOptionsForInstance(options);
+        const dynamicAttributes = ['disabled', 'readonly', 'minDate', 'maxDate', 'minTime', 'maxTime'];
+
+        if (dynamicAttributes.some((prop) => changedProperties.has(prop))) {
+            this.updateOptionsForInstance(options);
+        }
 
         if (changedProperties.has('value')) {
             this.updateValue(this.value);
@@ -139,7 +177,7 @@ export class VlDatepickerComponent extends FormControl {
     disconnectedCallback() {
         super.disconnectedCallback();
 
-        this.instance?.destroy();
+        this.flatpickrInstance?.destroy();
     }
 
     render(): TemplateResult {
@@ -176,7 +214,7 @@ export class VlDatepickerComponent extends FormControl {
                     placeholder=${this.placeholder || nothing}
                     autocomplete=${this.autocomplete || nothing}
                     pattern=${this.pattern || nothing}
-                    @input=${this.onInput}
+                    @input=${!this.cleaveInstance ? this.onInput : nothing}
                 />
                 <button
                     id="toggle-calendar"
@@ -199,12 +237,16 @@ export class VlDatepickerComponent extends FormControl {
     resetFormControl() {
         super.resetFormControl();
 
-        this.instance?.clear();
+        this.flatpickrInstance?.clear();
         this.value = this.initialValue;
-        if (this.initialValue) this.instance?.setDate(this.initialValue, true, this.format);
+        if (this.initialValue) this.flatpickrInstance?.setDate(this.initialValue, true, this.format);
     }
 
-    private parseDate(dateString: 'today' | string | undefined): string | undefined {
+    getRawValue(): string | undefined {
+        return this.cleaveInstance?.getRawValue();
+    }
+
+    private parseTodayDate(dateString: 'today' | string | undefined): string | undefined {
         const formatDate = (date: Date) => flatpickr.formatDate(date, this.format);
         if (dateString === 'today') {
             return formatDate(new Date());
@@ -214,47 +256,35 @@ export class VlDatepickerComponent extends FormControl {
     }
 
     private getDynamicOptions(): Options {
-        // minTime en maxTime gebruiken om defaultHour en defaultMinute te bepalen
-        let defaultHour: number | undefined;
-        let defaultMinute: number | undefined;
-        if (this.minTime) {
-            defaultHour = Number(this.minTime.split(':')[0]);
-            defaultMinute = Number(this.minTime.split(':')[1]);
-        } else if (this.maxTime) {
-            defaultHour = Number(this.maxTime.split(':')[0]);
-            defaultMinute = Number(this.maxTime.split(':')[1]);
-        }
-
-        const defaultDate = this.parseDate(this.initialValue);
+        const minimumDateTime = flatpickr.parseDate(this.minTime, this.format);
         return {
             allowInput: !(this.disabled || this.readonly),
-            dateFormat: this.format,
-            defaultHour: defaultHour,
-            defaultMinute: defaultMinute,
             maxDate: this.maxDate,
             minDate: this.minDate,
-            defaultDate: defaultDate,
-            enableTime: this.type === 'time' || this.type === 'date-time',
-            noCalendar: this.type === 'time',
-            time_24hr: !this.amPm,
             minTime: this.minTime,
             maxTime: this.maxTime,
-            mode: this.type !== 'range' ? 'single' : 'range',
+            defaultHour: minimumDateTime?.getHours() ?? 12,
+            defaultMinute: minimumDateTime?.getMinutes() ?? 0,
         };
     }
 
     private getOptions(): Options {
         const datepickerButton = this.shadowRoot?.querySelector('button');
         const datepicker = this.shadowRoot?.querySelector('#datepicker-wrapper') as HTMLInputElement;
-
+        const defaultDate = this.parseTodayDate(this.initialValue);
         const staticOptions = {
-            autoFillDefaultTime: true,
+            dateFormat: this.format,
             locale: Dutch.nl,
             clickOpens: false,
             onChange: this.handleDateChange,
             positionElement: datepickerButton,
             static: true,
             appendTo: datepicker,
+            defaultDate: defaultDate,
+            enableTime: this.type === 'time' || this.type === 'date-time',
+            noCalendar: this.type === 'time',
+            time_24hr: !this.amPm,
+            mode: this.type !== 'range' ? 'single' : 'range',
         };
 
         const options = {
@@ -280,39 +310,36 @@ export class VlDatepickerComponent extends FormControl {
         Object.keys(options)
             .map((key) => key as keyof Options)
             .forEach((key) => {
-                this.instance?.set(key, options[key as keyof Options]);
+                this.flatpickrInstance?.set(key, options[key as keyof Options]);
             });
     }
 
     private initializeComponent() {
-        if (this.getDatePicker() && !this.instance) {
-            this.instance = flatpickr(this.getDatePicker()!, this.getOptions()) as unknown as Instance;
+        if (this.getDatePicker() && !this.flatpickrInstance) {
+            this.flatpickrInstance = flatpickr(this.getDatePicker()!, this.getOptions()) as unknown as Instance;
             this.getDatePicker()?.classList.add('static');
         }
     }
 
     private toggleCalendar = () => {
-        this.instance?.toggle();
+        this.flatpickrInstance?.toggle();
     };
 
     private onInput = (event: Event & { target: HTMLInputElement }) => {
-        const dateString = event.target.value;
-        if (this.pattern) {
-            if (!dateString.match(this.pattern)) {
-                this.value = dateString;
-                return;
-            }
-        }
+        this.handleValueChanged(event.target?.value ?? '');
+    };
+
+    private handleValueChanged(dateString: string) {
         let parsedDate;
         try {
             parsedDate = flatpickr.parseDate(dateString, this.format);
         } finally {
             this.value = dateString;
             if (parsedDate instanceof Date && !isNaN(parsedDate as unknown as number)) {
-                this.instance?.setDate(dateString, false, this.format);
+                this.flatpickrInstance?.setDate(dateString, false, this.format);
             }
         }
-    };
+    }
 
     private handleDateChange = (dates: Date[]) => {
         const format = (date: Date) => flatpickr.formatDate(new Date(date), this.format);
@@ -325,11 +352,38 @@ export class VlDatepickerComponent extends FormControl {
 
     private updateValue = (value: string) => {
         const detail = { value: this.value };
-
+        // indien de waarde getypt wordt, updaten we de flatpickr instance zodat deze de nieuwe waarde toont
+        if (this.value !== this.flatpickrInstance?.input.value) {
+            this.flatpickrInstance?.setDate(this.value, false, this.format);
+        }
         this.setValue(value);
         this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
         this.dispatchEventIfValid(detail);
     };
+
+    private composeMaskForFormat(format: string, type: string): MaskOptions | null {
+        if (!format) return null;
+        let maskOptions: MaskOptions | null = null;
+        switch (type) {
+            case 'date':
+                maskOptions = createDateMask(format, this.minDate, this.maxDate);
+                break;
+            case 'time':
+                maskOptions = createTimeMask(format);
+                break;
+            default:
+                break;
+        }
+        return maskOptions
+            ? {
+                  ...maskOptions,
+                  // als we een cleave mask gebruiken, willen we de transformed value verkrijgen
+                  onValueChanged: ({ target: { value } }: { target: { value: string } }) => {
+                      this.handleValueChanged(value ?? '');
+                  },
+              }
+            : null;
+    }
 }
 
 declare global {

--- a/libs/form/src/next/input-field-masked/masks.ts
+++ b/libs/form/src/next/input-field-masked/masks.ts
@@ -1,4 +1,4 @@
-import { MaskOptions } from './vl-input-field-masked.model';
+import { MaskOptions } from '../../models/cleave.model';
 
 // Deze maskers zijn gebaseerd op de maskers van Cleave.js, uitgebreid met de properties 'customTransformFn' en 'regex'.
 // De 'customTransformFn' wordt gebruikt om features die Cleave.js niet ondersteunt toe te voegen, bv. het verwijderen van niet hexadecimale karakters.

--- a/libs/form/src/next/input-field-masked/validators.ts
+++ b/libs/form/src/next/input-field-masked/validators.ts
@@ -1,5 +1,5 @@
 import { Validator } from '@open-wc/form-control';
-import { CleaveInstance, MaskOptions } from './vl-input-field-masked.model';
+import { CleaveInstance, MaskOptions } from '../../models/cleave.model';
 
 export const maskValidator: Validator = {
     key: 'patternMismatch',

--- a/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
+++ b/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
@@ -306,7 +306,7 @@ const fillInForm = () => {
     getHobbiesSelect().find('.vl-select__list').find('.vl-select__item').contains('Padel').click();
     getHobbiesSelect().find('.vl-select__list').find('.vl-select__item').contains('Dans').click();
     // Sluit de hobby dropdown
-    cy.get('body').click(0, 0);
+    cy.get('body').click(0, 0, { force: true });
     getInteressesTextarea().find('textarea').click().type('Vanalles en nog wat');
     getLeeftijdInput().find('input').click().type('32');
     getContactMethodeRadioGroup({ shadow: false })
@@ -316,14 +316,14 @@ const fillInForm = () => {
         // Force true omdat anders Cypress klaagt dat de radio gecovered is door zijn parent tag, wat een zeer vreemde error is.
         // Zoek een andere manier moest deze test flaky zijn hierdoor.
         .check({ force: true });
-    getFotosUpload().find('input[type="file"]').selectFile('src/fixtures/upload/cat.jpeg', { force: true });
+    getFotosUpload().find('input[type="file"]').selectFile('cypress/fixtures/upload/cat.jpeg', { force: true });
     // Force true omdat anders Cypress klaagt dat de radio gecovered is door zijn parent tag, wat een zeer vreemde error is.
     // Zoek een andere manier moest deze test flaky zijn hierdoor.
     getWaarheidsGetrouwCheckbox().find('input').check({ force: true });
 };
 
 const setupMockedUploadFormData = (submittedFormData: unknown & { foto: File[] | null }) => {
-    cy.readFile('src/fixtures/upload/cat.jpeg', 'base64').then((fileContent) => {
+    cy.readFile('cypress/fixtures/upload/cat.jpeg', 'base64').then((fileContent) => {
         const blob = Cypress.Blob.base64StringToBlob(fileContent);
         const lastModified = new Date().getTime();
         const fileToAdd = new File([blob], 'cat.jpeg', {

--- a/libs/integration/src/form/demo/vl-form-demo.component.ts
+++ b/libs/integration/src/form/demo/vl-form-demo.component.ts
@@ -123,13 +123,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-label-next for="geboortedatum" label="Geboortedatum *" block></vl-form-label-next>
                     </div>
                     <div class="vl-form-col--8-12">
-                        <vl-datepicker-next
-                            id="geboortedatum"
-                            name="geboortedatum"
-                            pattern="^(0?[1-9]|[12][0-9]|3[01])\\.(0?[1-9]|1[012])\\.([0-9]{4})$"
-                            block
-                            required
-                        >
+                        <vl-datepicker-next id="geboortedatum" name="geboortedatum" block required>
                         </vl-datepicker-next>
                         <vl-error-message-next for="geboortedatum" state="valueMissing">
                             Gelieve een geboortedatum in te vullen.


### PR DESCRIPTION
Vroeger moest je als afnemer zelf een regex patroon meegeven om ervoor te zorgen dat een datum instellen in het tekst veld gevalideerd kon worden, nu wordt voor de meest gebruikte formaten automatisch een mask ingesteld met bijhorende regex patroon.

[jira](https://www.milieuinfo.be/jira/browse/UIG-2899)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC304)