### PR TITLE
fix: UIG-2897 - side-navigation - proza messages

### DIFF
--- a/apps/storybook/docs/d_richtlijnen/a_accessibility/1_accessibility.stories.mdx
+++ b/apps/storybook/docs/d_richtlijnen/a_accessibility/1_accessibility.stories.mdx
@@ -4,9 +4,9 @@ import {Meta} from '@storybook/addon-docs';
 
 # Accessibility
 
-## Gekende Beperkingen
+## Gekende beperkingen
 
-### focus op niet-tekstuele inputs
+### Focus op niet-tekstuele inputs
 
 Op Safari is het niet mogelijk om met standaard instellingen, focus te leggen op een niet-tekstuele input zoals buttons, checkboxes of radios. [Dit is een probleem gemeld bij Safari.](https://bugs.webkit.org/show_bug.cgi?id=22261) (maar is gemarkeerd als WONTFIX)
 

--- a/libs/elements/src/side-navigation/stories/vl-side-navigation.stories-doc.mdx
+++ b/libs/elements/src/side-navigation/stories/vl-side-navigation.stories-doc.mdx
@@ -53,6 +53,14 @@ Dit gebeurt op de volgende manier (we gebruiken content 1 als voorbeeld):
 2. Plaats op het VlSideNavigationToggle element het attribuut `data-vl-child="content-1"`
 3. Plaats op de child links het attribuut `data-vl-parent="content-1"`
 
+## Gekende beperkingen
+
+### Proza messages
+
+Door de complexiteit van de side-navigation kan het zijn dat er problemen optreden met het renderen van Proza messages.<br/>
+Proza messages renderen regelmatig niet tot er een resize van de window optreedt.<br/>
+Om dit op te lossen kan je gebruik maken van het `data-vl-side-navigation-id` attribuut, aan dit attribuut geef je een unieke string mee.<br/>
+Deze manier van werken is een tijdelijke quick-fix, in de nieuwe versie van de side-navigation gaat dit probleem niet voorkomen.
 
 ## Referenties
 


### PR DESCRIPTION
data-vl-side-navigation-id attribuut toegevoegd als fix voor proza messages die niet renderen 
Storybook uitgebreid

[Jira](https://www.milieuinfo.be/jira/browse/UIG-2897)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC308)