### PR TITLE
fix: UIG-2982 - vl-data-table - responsive layout regressie gestroomlijnd

### DIFF
--- a/libs/elements/src/data-table/stories/vl-data-table.stories-arg.ts
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories-arg.ts
@@ -10,7 +10,7 @@ export const dataTableArgTypes: ArgTypes<typeof dataTableArgs> = {
     hover: {
         name: 'data-vl-hover',
         description:
-            'Attribuut wordt gebruikt om een rij te highlighten waneer de gebruiker erover hovert met muiscursor.',
+            'Attribuut wordt gebruikt om een rij te highlighten wanneer de gebruiker erover hovert met muiscursor.',
         table: {
             category: CATEGORIES.ATTRIBUTES,
             type: { summary: TYPES.BOOLEAN },
@@ -39,7 +39,7 @@ export const dataTableArgTypes: ArgTypes<typeof dataTableArgs> = {
     zebra: {
         name: 'data-vl-zebra',
         description:
-            'Variant waarin de rijen afwisslend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. ' +
+            'Variant waarin de rijen afwisselend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. ' +
             'Deze zebra werkt niet voor tabellen met detail rijen, gebruik hiervoor data-vl-uig-zebra.',
         table: {
             category: CATEGORIES.ATTRIBUTES,
@@ -50,7 +50,7 @@ export const dataTableArgTypes: ArgTypes<typeof dataTableArgs> = {
     uigZebra: {
         name: 'data-vl-uig-zebra',
         description:
-            'Variant waarin de rijen afwisslend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. Deze zebra werkt voor tabellen met en zonder detail rijen.',
+            'Variant waarin de rijen afwisselend een andere achtergrondkleur krijgen. Dit maakt de tabel makkelijker leesbaar. Deze zebra werkt voor tabellen met en zonder detail rijen.',
         table: {
             category: CATEGORIES.ATTRIBUTES,
             type: { summary: TYPES.BOOLEAN },

--- a/libs/elements/src/data-table/stories/vl-data-table.stories-doc.mdx
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories-doc.mdx
@@ -3,7 +3,7 @@ import * as VlDataTableStories from './vl-data-table.stories';
 
 # Data Table
 
-Gebruik het `data-table` component om op een gestructureerde manier (grote hoeveelheden) relationele data te tonen.
+Gebruik de `data-table` component om op een gestructureerde manier (grote hoeveelheden) relationele data te tonen.
 
 ## Voorbeeld
 

--- a/libs/elements/src/data-table/stories/vl-data-table.stories.ts
+++ b/libs/elements/src/data-table/stories/vl-data-table.stories.ts
@@ -9,6 +9,7 @@ import { VlDataTable } from '../vl-data-table.element';
 export default {
     title: 'Elements/data-table',
     tags: ['autodocs'],
+    args: dataTableArgs,
     argTypes: dataTableArgTypes,
     parameters: {
         docs: { page: dataTableDoc },
@@ -65,7 +66,6 @@ export const DataTableDefault = story(
     `
 );
 DataTableDefault.storyName = 'vl-data-table - default';
-DataTableDefault.args = dataTableArgs;
 
 export const DataTableJoinedRowTitles = story(
     dataTableArgs,
@@ -134,7 +134,6 @@ export const DataTableJoinedRowTitles = story(
     `
 );
 DataTableJoinedRowTitles.storyName = 'vl-data-table - joined row titles';
-DataTableJoinedRowTitles.args = dataTableArgs;
 
 export const DataTableExpandable = story(
     dataTableArgs,

--- a/libs/elements/src/data-table/vl-data-table.component.cy.ts
+++ b/libs/elements/src/data-table/vl-data-table.component.cy.ts
@@ -1,5 +1,4 @@
 import { html } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import { dataTableDefaults, VlDataTable } from '../data-table/vl-data-table.element';
 

--- a/libs/elements/src/data-table/vl-data-table.uig-css.ts
+++ b/libs/elements/src/data-table/vl-data-table.uig-css.ts
@@ -21,38 +21,5 @@ const styles: CSSResult = css`
         background: #cbd2d9;
         color: var(--vl-theme-fg-color-70);
     }
-
-    tr[data-details-id] {
-        display: table-row;
-    }
-
-    @media screen and (max-width: 500px) {
-        .vl-data-table--collapsed-m td,
-        .vl-data-table--collapsed-s td,
-        .vl-data-table--collapsed-xs td {
-            padding-left: 1rem;
-            padding-top: 3.6rem;
-        }
-        .vl-data-table--collapsed-m td::before,
-        .vl-data-table--collapsed-s td::before,
-        .vl-data-table--collapsed-xs td::before {
-            width: 90%;
-            padding-right: 0;
-        }
-
-        .vl-data-table--collapsed-xs tr[data-details-id] {
-            display: block;
-        }
-    }
-    @media screen and (max-width: 767px) {
-        .vl-data-table--collapsed-s tr[data-details-id] {
-            display: block;
-        }
-    }
-    @media screen and (max-width: 1023px) {
-        .vl-data-table--collapsed-m tr[data-details-id] {
-            display: block;
-        }
-    }
 `;
 export default styles;


### PR DESCRIPTION
Vroeger gebruikte DV o.a. relative positioning om responsiveness in de data-table te bekomen en aan onze kant patchen wij CSS om dynamische functionaliteit te kunnen toevoegen. Na de upgrade naar recentste DV styling wordt er nu gebruikt gemaakt van flexbox. Nu nemen we die over en is het ook niet langer nodig om de CSS te patchen aan onze kant.

[jira](https://www.milieuinfo.be/jira/browse/UIG-2982)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC314)