### PR TITLE
fix: UIG-2987 - vl-upload-next - Dropzone import verbeterd

### DIFF
--- a/apps/storybook/docs/f_recepten/rollup-build.stories.mdx
+++ b/apps/storybook/docs/f_recepten/rollup-build.stories.mdx
@@ -1,0 +1,30 @@
+import {Meta} from '@storybook/addon-docs';
+
+<Meta title="Recepten/Rollup Beperkingen"/>
+
+# Rollup Beperkingen
+
+[Rollup](https://rollupjs.org/) is een module bundler die gebruikt kan worden om webcomponenten te bundelen. De te preferen bundler bij Departement Omgeving is [Webpack](https://webpack.js.org/).
+
+## CommonJS modules
+
+Projecten die opgebouwd zijn met `Rollup` kunnen problemen geven, bij het bundelen van third party libraries die CommonJS modules gebruiken. Dit komt omdat Rollup standaard ES modules verwacht en sommige libraries nog steeds CommonJS modules gebruiken. Dit kan opgelost worden door de `@rollup/plugin-commonjs` plugin te installeren en te configureren.
+
+## Imports
+
+Afhankelijk van de library kan je dit oplossen door de manier van import te veranderen.
+Voor sommige libraries zullen named imports niet werken. In dat geval moet je [namespace imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#forms_of_import_declarations) gebruiken.
+
+### Named imports
+> ipv deze code:
+```TypeScript
+import { Dropzone } from 'dropzone';
+```
+
+### Namespace imports
+> gebruik deze code:
+```TypeScript
+import * as Dropzone from 'dropzone';
+```
+
+

--- a/libs/form/src/utils/form.util.ts
+++ b/libs/form/src/utils/form.util.ts
@@ -1,5 +1,4 @@
 import { FormControl } from '../next/form-control';
-import { VlUploadComponent } from '../next/upload';
 
 /**
  * Haalt de form data op van een form element en zet deze om naar een object.
@@ -21,11 +20,7 @@ export const parseFormData = <T = { [key: string]: FormDataEntryValue[] | File |
     const allMultiFormControlKeys = multiFormControlNames
         ? multiFormControlNames
         : Array.from(formElement.querySelectorAll('*'))
-              .filter(
-                  (element) =>
-                      (element instanceof FormControl && element.hasAttribute('multiple')) ||
-                      element instanceof VlUploadComponent
-              )
+              .filter((element) => element instanceof FormControl && element.hasAttribute('multiple'))
               .map((el) => el.getAttribute('name'));
     // als de form data voor een bepaalde key meerdere waarden bevat, dan wordt deze key in de data map vervangen door een array van waarden
     return Array.from(data.keys()).reduce((result, key) => {


### PR DESCRIPTION
Vroeger gaf de manier van Dropzone importeren problemen tijdens compilatie voor web-dev-server (die intern rollup gebruikt). Nu is dit opgelost door op een andere manier Dropzone te importeren. In de `parseFormData()` helper-functie ook de VlUploadComponent dependency verwijderd.

[jira](https://www.milieuinfo.be/jira/browse/UIG-2987)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC326)