### PR TITLE
feat: UIG-2846 - vl-datepicker-next - standaard waarde veranderd naar ISO-8601 formaat

### DIFF
--- a/apps/playground-lit/src/app/app.element.ts
+++ b/apps/playground-lit/src/app/app.element.ts
@@ -552,7 +552,7 @@ export class AppElement extends LitElement {
                                 <button
                                     class="vl-button vl-button--secondary"
                                     type="button"
-                                    @click=${() => (this.birthdate = '31.12.1976')}
+                                    @click=${() => (this.birthdate = '1976-12-31')}
                                 >
                                     Select '31.12.1976'
                                 </button>

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -32,20 +32,36 @@ import { VlDatepickerComponent } from '@domg-wc/form/next/datepicker';
 ## Formaat
 
 Je kan het `format` attribuut gebruiken om de datumnotatie te wijzigen. Het default formaat is `d.m.Y`.<br/>
-In onderstaand voorbeeld wordt de datumnotatie expliciet ingesteld op `d/m/Y`.
-> `format="d/m/Y"` zal de datum tonen als `31/12/2023`
 
+In het onderstaande voorbeeld wordt de datumnotatie expliciet ingesteld op `d/m/Y`.
+
+> `format="d/m/Y"` zal de gekozen datum weergeven als `31/12/2023`
 ```html
 <vl-datepicker-next format="d/m/Y"></vl-datepicker-next>
+```
+
+## Waarde
+
+Je kan de datum instellen met het `value` attribuut. De waarde moet conform het [ISO-formaat](https://en.wikipedia.org/wiki/ISO_8601) zijn.
+
+De uitgelezen waarde volgt eveneens het [ISO-formaat](https://en.wikipedia.org/wiki/ISO_8601). Per type datepicker wordt de waarde standaard als volgt weergegeven:
+- `date`: `2023-12-31`
+- `time`: `23:59`
+- `date-time`: `2023-12-31T23:59`
+- `range`: `2023-12-31/2023-12-31`
+
+> `value="2023-12-31"` zal de ingestelde datum weergeven als `31.12.2023`
+```html
+<vl-datepicker-next value="2023-12-31"></vl-datepicker-next>
 ```
 
 ## Validatie
 
 ### Mask Validatie
 
-- Er wordt automatisch mask validatie toegevoegd aan de datepicker met type `date` (standaard) of type `time`.
+- Er wordt standaard mask validatie toegevoegd aan de datepicker met type `date` (standaard) of type `time`.
 - De mask wordt opgebouwd op basis van het `format` attribuut.
-- Je kan automatische mask validatie uitschakelen met het `disable-mask-validation` attribuut.
+- Je kan standaard mask validatie uitschakelen met het `disable-mask-validation` attribuut.
 - De `patternMismatch` ValidityState key wordt gebruikt voor de mask validatie error.
 
 ### Pattern Validatie
@@ -53,23 +69,10 @@ In onderstaand voorbeeld wordt de datumnotatie expliciet ingesteld op `d/m/Y`.
 - Als de mask validatie is uitgeschakeld, kan je met het `pattern` attribuut een regex patroon instellen. Je kan ook de `regex` property gebruiken voor complexere validatie.
 - De `patternMismatch` ValidityState key wordt gebruikt voor de pattern validatie error.
 
-## Conversie
-
-Wanneer je een ander formaat wil gebruiken dan het formaat dat aan de gebruiker wordt getoond, moet je deze zelf omzetten.<br/>
-Hiervoor kan je gebruik maken van de `flatpickr`-functie `formatDate`.
-
-```ts
-import flatpickr from 'flatpickr';
-
-function convertDate(date: Date, format: string) {
-  return flatpickr.formatDate(date, format);
-}
-```
-
 ## Gekende Beperkingen
 
 - De datepicker is niet toegankelijk voor gebruikers die enkel met het toetsenbord navigeren. Ze kunnen wel manueel een datum invullen.
-- Voor datepicker met type `datetime` & `range` is er geen automatische mask validatie voorzien gezien `cleave.js` hiervoor geen ondersteuning biedt.
+- Voor datepicker met type `date-time` & `range` is er geen standaard mask validatie voorzien gezien `cleave.js` hiervoor geen ondersteuning biedt.
 
 ## Referenties
 

--- a/libs/form/src/next/datepicker/validators.ts
+++ b/libs/form/src/next/datepicker/validators.ts
@@ -11,10 +11,11 @@ export const maskValidator: Validator = {
             regex: RegExp;
             maskOptions: MaskOptions;
             cleaveInstance: CleaveInstance;
+            inputValue: string;
         },
         value: string
     ): boolean {
-        const { disableMaskValidation, cleaveInstance } = instance;
+        const { disableMaskValidation, cleaveInstance, inputValue } = instance;
         const regex = instance.regex || instance.pattern;
         if (!value || (!regex && (!cleaveInstance || disableMaskValidation))) {
             return true;
@@ -25,7 +26,8 @@ export const maskValidator: Validator = {
             return regExp.test(rawValue);
         } else {
             const regExp = new RegExp(regex);
-            return regExp.test(value);
+            // we testen de inputValue gezien dit de waarde is die de gebruiker ingeeft
+            return regExp.test(inputValue);
         }
     },
 };

--- a/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
@@ -109,26 +109,67 @@ describe('component - vl-datepicker-next', () => {
     });
 
     it('should set date in format', () => {
-        const format = 'Y-m-d';
+        const format = 'd-m-Y';
         cy.mount(html`<vl-datepicker-next format=${format}></vl-datepicker-next>`);
 
-        const testDate = createDateString({ selectedDay: 15, format: format });
+        const testDate = createDateString({ day: 15, format: format });
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
-        cy.get('vl-datepicker-next').should('have.value', testDate);
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', testDate);
+        cy.get('vl-datepicker-next').should('have.value', createIsoDateString({ day: 15 }));
     });
 
-    it('should set prefilled date', () => {
-        const date = '01.11.2021';
-        cy.mount(html`<vl-datepicker-next value=${date} label="startdatum"></vl-datepicker-next>`);
+    it('should set initial date', () => {
+        const date = '2021-11-01';
+        cy.mount(html`<vl-datepicker-next value=${date} label="date"></vl-datepicker-next>`);
         cy.injectAxe();
 
-        cy.get('vl-datepicker-next').should('have.value', date);
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '01.11.2021');
+        cy.get('vl-datepicker-next').should('have.value', '2021-11-01');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set initial time', () => {
+        const value = '09:06';
+        cy.mount(html`<vl-datepicker-next value=${value} type="time" label="time"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '09:06');
+        cy.get('vl-datepicker-next').should('have.value', '09:06');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set initial date-time', () => {
+        const date = '2024-04-17T09:06:35';
+        cy.mount(html`<vl-datepicker-next value=${date} type="date-time" label="date-time"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '17.04.2024 09:06');
+        cy.get('vl-datepicker-next').should('have.value', '2024-04-17T09:06');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it('should set initial date in long ISO format', () => {
+        const date = '2024-04-17T09:06:35';
+        cy.mount(html`<vl-datepicker-next value=${date} label="date"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '17.04.2024');
+        cy.get('vl-datepicker-next').should('have.value', '2024-04-17');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
+    it("should set today's date", () => {
+        cy.mount(html`<vl-datepicker-next value="today" label="startdatum"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', createDateString({}));
+        cy.get('vl-datepicker-next').should('have.value', createIsoDateString({}));
         cy.checkA11y('vl-datepicker-next');
     });
 
     it('should set min date', () => {
-        const minDate = createDateString({ selectedDay: 15 });
+        const minDate = createDateString({ day: 15 });
         cy.mount(html`<vl-datepicker-next min-date=${minDate}></vl-datepicker-next>`);
 
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
@@ -141,7 +182,7 @@ describe('component - vl-datepicker-next', () => {
     });
 
     it('should set max date', () => {
-        const maxDate = createDateString({ selectedDay: 20 });
+        const maxDate = createDateString({ day: 20 });
         cy.mount(html`<vl-datepicker-next max-date=${maxDate}></vl-datepicker-next>`);
 
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
@@ -245,16 +286,45 @@ describe('component - vl-datepicker-next', () => {
         cy.mount(html`<vl-datepicker-next type="range"></vl-datepicker-next>`);
         cy.injectAxe();
 
-        const startDate = createDateString({ selectedDay: 15 });
-        const endDate = createDateString({ selectedDay: 25 });
+        const startDate = createDateString({ day: 15 });
+        const endDate = createDateString({ day: 25 });
 
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
         cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('25').click();
 
-        cy.get('vl-datepicker-next').should('have.value', `${startDate} tot en met ${endDate}`);
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('input.vl-input-field')
+            .should('have.value', `${startDate} tot en met ${endDate}`);
+
+        cy.get('vl-datepicker-next').should(
+            'have.value',
+            `${createIsoDateString({ day: 15 })}/${createIsoDateString({ day: 25 })}`
+        );
     });
 
+    it('should set range by manual input', () => {
+        cy.mount(html`<vl-datepicker-next type="range"></vl-datepicker-next>`);
+        cy.injectAxe();
+
+        const startDate = createDateString({ day: 15 });
+        const endDate = createDateString({ day: 25 });
+
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').type(`${startDate} tot en met ${endDate}`);
+
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('input.vl-input-field')
+            .should('have.value', `${startDate} tot en met ${endDate}`);
+
+        cy.get('vl-datepicker-next').should(
+            'have.value',
+            `${createIsoDateString({ day: 15 })}/${createIsoDateString({ day: 25 })}`
+        );
+    });
+
+    // deze test slaagt in Electron/Firefox, maar niet in Chromium browsers gezien verschil in event werking
     it('should dispatch vl-input event on input', () => {
         cy.mount(html`<vl-datepicker-next></vl-datepicker-next>`);
         cy.createStubForEvent('vl-datepicker-next', 'vl-input');
@@ -264,9 +334,10 @@ describe('component - vl-datepicker-next', () => {
         cy.get('@vl-input')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
-            .should('deep.equal', { value: createDateString({ selectedDay: 15 }) });
+            .should('deep.equal', { value: createIsoDateString({ day: 15 }) });
     });
 
+    // deze test slaagt in Electron/Firefox, maar niet in Chromium browsers gezien verschil in event werking
     it('should dispatch vl-valid event on valid input', () => {
         cy.mount(html`<vl-datepicker-next required></vl-datepicker-next>`);
         cy.createStubForEvent('vl-datepicker-next', 'vl-valid');
@@ -276,13 +347,14 @@ describe('component - vl-datepicker-next', () => {
         cy.get('@vl-valid')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
-            .should('deep.equal', { value: createDateString({ selectedDay: 15 }) });
+            .should('deep.equal', { value: createIsoDateString({ day: 15 }) });
     });
 });
 
 describe('component - vl-datepicker-next - in form', () => {
     it('should reset datepicker with initial value', () => {
-        const initialValue = '02.12.2023';
+        const initialValue = createIsoDateString({ day: 2, month: 12, year: 2021 });
+
         mountDatepickerInForm({ ...datepickerDefaults, value: initialValue, block: true });
         cy.get('form').then((form$) => {
             form$.on('submit', (e) => {
@@ -293,13 +365,17 @@ describe('component - vl-datepicker-next - in form', () => {
 
         cy.get('vl-datepicker-next').shadow();
         cy.get('vl-datepicker-next').should('have.value', initialValue);
+        cy.get('vl-datepicker-next').shadow().find('input').should('have.value', '02.12.2021');
         cy.checkA11y('vl-datepicker-next');
 
-        cy.get('vl-datepicker-next').invoke('attr', 'value', '21.12.2023');
-        cy.get('vl-datepicker-next').should('have.value', '21.12.2023');
+        const value = createIsoDateString({ day: 21, month: 12, year: 2023 });
+        cy.get('vl-datepicker-next').invoke('attr', 'value', value);
+        cy.get('vl-datepicker-next').should('have.value', value);
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '21.12.2023');
 
         cy.get('button[type="reset"]').click();
         cy.get('vl-datepicker-next').should('have.value', initialValue);
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '02.12.2021');
         cy.checkA11y('vl-datepicker-next');
     });
 
@@ -320,7 +396,11 @@ describe('component - vl-datepicker-next - in form', () => {
 
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
-        cy.get('vl-datepicker-next').should('have.value', createDateString({ selectedDay: 15 }));
+        cy.get('vl-datepicker-next').should('have.value', createIsoDateString({ day: 15 }));
+        cy.get('vl-datepicker-next')
+            .shadow()
+            .find('input')
+            .should('have.value', createDateString({ day: 15 }));
 
         cy.get('button[type="submit"]').click();
         cy.get('vl-datepicker-next').shadow().find('input').should('not.have.class', 'vl-input-field--error');
@@ -400,6 +480,24 @@ describe('component - vl-datepicker-next - in form', () => {
         cy.checkA11y('vl-datepicker-next');
     });
 
+    it('should disable automatic mask validation with invalid initial value', () => {
+        mountDatepickerInForm({ ...datepickerDefaults, disableMaskValidation: true, value: 'hello' });
+        cy.get('form').then((form$) => {
+            form$.on('submit', (e) => {
+                e.preventDefault();
+            });
+        });
+        cy.injectAxe();
+
+        cy.get('vl-datepicker-next').shadow().find('input').should('not.have.class', 'vl-input-field--error');
+        cy.get('vl-datepicker-next').should('have.value', 'hello');
+        cy.get('button[type="submit"]').click({ force: true });
+
+        cy.get('vl-error-message-next[state="valueMissing"]').should('not.be.visible');
+        cy.get('vl-error-message-next[state="patternMismatch"]').should('not.be.visible');
+        cy.checkA11y('vl-datepicker-next');
+    });
+
     it('should validate pattern with disabled automatic mask validation', () => {
         mountDatepickerInForm({
             ...datepickerDefaults,
@@ -415,6 +513,7 @@ describe('component - vl-datepicker-next - in form', () => {
 
         cy.get('vl-datepicker-next').shadow().find('input').should('not.have.class', 'vl-input-field--error');
         cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').type('1512202');
+        // cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').type('1');
         cy.get('button[type="submit"]').click({ force: true });
 
         cy.get('vl-error-message-next[state="valueMissing"]').should('not.be.visible');
@@ -487,6 +586,7 @@ describe('component - vl-datepicker-next - in form', () => {
         cy.get('button[type="reset"]').click();
 
         cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').type('999');
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '09:09:09');
         cy.get('vl-datepicker-next').should('have.value', '09:09:09');
         cy.get('button[type="submit"]').click();
         cy.get('vl-error-message-next[state="patternMismatch"]').should('not.be.visible');
@@ -527,33 +627,69 @@ describe('component - vl-datepicker-next - in form', () => {
  * @param format
  */
 const createDateString = ({
-    selectedYear,
-    selectedDay,
-    selectedMonth,
+    year,
+    day,
+    month,
     format,
+    date = new Date(),
 }: {
-    selectedYear?: number;
-    selectedMonth?: number;
-    selectedDay?: number;
-    format?: 'Y-m-d' | 'd-m-Y' | 'd/m/Y';
+    year?: number;
+    month?: number;
+    day?: number;
+    format?: 'Y-m-d' | 'd-m-Y' | 'd/m/Y' | 'Z';
+    date?: Date;
 }) => {
-    const date = new Date();
-    const year = selectedYear ? selectedYear : date.getFullYear();
-    const month = selectedMonth ? selectedMonth : date.getMonth() + 1;
-    const day = selectedDay ? selectedDay : date.getDate();
+    const selectedYear = year ? year : date.getFullYear();
+    const selectedMonth = month ? month : date.getMonth() + 1;
+    const selectedDay = day ? day : date.getDate();
     // als de dag kleiner is dan 10, voeg een 0 toe voor de dag
-    const dayString = day < 10 ? `0${day}` : `${day}`;
-    const monthString = month < 10 ? `0${month}` : `${month}`;
-
+    const dayString = selectedDay < 10 ? `0${selectedDay}` : `${selectedDay}`;
+    const monthString = selectedMonth < 10 ? `0${selectedMonth}` : `${selectedMonth}`;
     switch (format) {
         case 'Y-m-d':
-            return `${year}-${monthString}-${dayString}`;
+            return `${selectedYear}-${monthString}-${dayString}`;
         case 'd-m-Y':
-            return `${dayString}-${monthString}-${year}`;
+            return `${dayString}-${monthString}-${selectedYear}`;
         case 'd/m/Y':
-            return `${dayString}/${monthString}/${year}`;
+            return `${dayString}/${monthString}/${selectedYear}`;
         default:
-            return `${dayString}.${monthString}.${year}`;
+            return `${dayString}.${monthString}.${selectedYear}`;
+    }
+};
+
+const createIsoDateString = ({
+    year = 0,
+    month = 0,
+    day = 0,
+    hours = 0,
+    minutes = 0,
+    seconds = 0,
+    offset = true,
+    type = 'date',
+}: {
+    year?: number;
+    month?: number;
+    day?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+    offset?: boolean;
+    type?: 'date' | 'time' | 'date-time' | 'range';
+}) => {
+    const timezoneOffset = new Date().getTimezoneOffset() * 60000; //offset in milliseconds
+    const localTodayDate = new Date(new Date().setHours(hours, minutes, seconds, 0) - (offset ? timezoneOffset : 0));
+    if (day) localTodayDate.setDate(day);
+    if (month) localTodayDate.setMonth(month - 1);
+    if (year) localTodayDate.setFullYear(year);
+    switch (type) {
+        case 'date':
+            return localTodayDate.toISOString().substring(0, 10);
+        case 'date-time':
+            return localTodayDate.toISOString().substring(0, 16);
+        case 'time':
+            return localTodayDate.toTimeString().substring(0, 5);
+        case 'range':
+            return `${localTodayDate.toISOString()} tot en met ${localTodayDate.toISOString()}`;
     }
 };
 

--- a/libs/form/src/next/datepicker/vl-datepicker.component.ts
+++ b/libs/form/src/next/datepicker/vl-datepicker.component.ts
@@ -47,6 +47,9 @@ const dateRangeSeparator = ' tot en met ';
 
 @webComponent('vl-datepicker-next')
 export class VlDatepickerComponent extends FormControl {
+    // Properties
+    regex = datepickerDefaults.regex; // Wordt enkel gebruikt in de pattern validator
+
     // Attributes
     private block = datepickerDefaults.block;
     private readonly = datepickerDefaults.readonly;
@@ -68,6 +71,7 @@ export class VlDatepickerComponent extends FormControl {
     private flatpickrInstance: Instance | null = null;
     private maskOptions: MaskOptions | null = null; // Wordt enkel gebruikt in de mask validator
     private cleaveInstance: CleaveInstance | null = null;
+    private inputValue: string | undefined = ''; // Houdt de waarde van het getoonde inputveld bij
 
     static {
         registerWebComponents([VlButtonInputAddon, VlIconElement]);
@@ -93,7 +97,7 @@ export class VlDatepickerComponent extends FormControl {
         return {
             block: { type: Boolean },
             readonly: { type: Boolean },
-            value: { type: String, reflect: true },
+            value: { type: String }, // Bevat de waarde van het component
             placeholder: { type: String },
             autocomplete: { type: String },
             type: { type: String },
@@ -104,6 +108,7 @@ export class VlDatepickerComponent extends FormControl {
             minTime: { type: String, attribute: 'min-time' },
             maxTime: { type: String, attribute: 'max-time' },
             rawValue: { type: Boolean, attribute: 'raw-value' },
+            inputValue: { type: String, state: true }, // Houdt de waarde van het getoonde inputveld bij
             pattern: { type: String },
             disableMaskValidation: { type: Boolean, attribute: 'disable-mask-validation' },
         };
@@ -117,7 +122,7 @@ export class VlDatepickerComponent extends FormControl {
             flatpickr.l10ns.default.rangeSeparator = dateRangeSeparator;
         }
 
-        if (!this.initialValue) {
+        if (!this.initialValue && typeof this.value === 'string' && this.type !== 'range') {
             this.initialValue = this.value;
         }
     }
@@ -148,7 +153,9 @@ export class VlDatepickerComponent extends FormControl {
         if (this.maskOptions && !this.disableMaskValidation) {
             this.cleaveInstance = new Cleave(this.validationTarget!, this.maskOptions);
         }
+
         this.initializeComponent();
+        this.setInitialValue();
     }
 
     updated(changedProperties: Map<string, unknown>) {
@@ -162,7 +169,29 @@ export class VlDatepickerComponent extends FormControl {
         }
 
         if (changedProperties.has('value')) {
-            this.updateValue(this.value);
+            // alleen als de inputValue niet aangepast is, updaten we deze met de nieuwe waarde
+            // dit gebeurt typisch wanneer de waarde van buitenaf aangepast wordt
+            if (!changedProperties.has('inputValue') && typeof this.value === 'string') {
+                switch (this.type) {
+                    case 'date-time':
+                    case 'date': {
+                        const date = flatpickr.parseDate(this.value, 'Z');
+                        if (date) this.inputValue = flatpickr.formatDate(date, this.format);
+                        break;
+                    }
+                    case 'time': {
+                        const date = flatpickr.parseDate(this.value, this.format);
+                        if (date) this.inputValue = flatpickr.formatDate(date, this.format);
+                        break;
+                    }
+                    default:
+                        this.inputValue = this.value;
+                }
+            }
+        }
+
+        if (changedProperties.has('inputValue')) {
+            this.updateFormControlValue(this.inputValue ?? '');
         }
 
         if (changedProperties.has('block')) {
@@ -210,7 +239,7 @@ export class VlDatepickerComponent extends FormControl {
                     ?disabled=${this.disabled}
                     ?error=${this.error}
                     ?readonly=${this.readonly}
-                    .value=${live(this.value)}
+                    .value=${live(this.inputValue)}
                     placeholder=${this.placeholder || nothing}
                     autocomplete=${this.autocomplete || nothing}
                     pattern=${this.pattern || nothing}
@@ -237,21 +266,42 @@ export class VlDatepickerComponent extends FormControl {
     resetFormControl() {
         super.resetFormControl();
 
-        this.flatpickrInstance?.clear();
-        this.value = this.initialValue;
-        if (this.initialValue) this.flatpickrInstance?.setDate(this.initialValue, true, this.format);
+        this.setInitialValue();
     }
 
     getRawValue(): string | undefined {
         return this.cleaveInstance?.getRawValue();
     }
 
+    getDates(): Date[] | undefined {
+        return this.flatpickrInstance?.selectedDates;
+    }
+
+    private setInitialValue() {
+        const initialDate = this.flatpickrInstance?.parseDate(this.initialValue, 'Z');
+        this.value = this.initialValue;
+
+        if (initialDate instanceof Date && !isNaN(initialDate as unknown as number) && this.type !== 'range') {
+            this.flatpickrInstance?.setDate(initialDate, true);
+            this.inputValue = flatpickr.formatDate(initialDate, this.format);
+        } else if (this.type === 'time' && this.initialValue) {
+            this.inputValue = this.initialValue;
+        } else {
+            this.flatpickrInstance?.clear();
+            this.inputValue = '';
+        }
+    }
+
     private parseTodayDate(dateString: 'today' | string | undefined): string | undefined {
         const formatDate = (date: Date) => flatpickr.formatDate(date, this.format);
+
         if (dateString === 'today') {
             return formatDate(new Date());
+        } else if (dateString) {
+            const parsedDate = flatpickr.parseDate(dateString, 'Z');
+            return parsedDate ? formatDate(parsedDate) : undefined;
         } else {
-            return dateString;
+            return undefined;
         }
     }
 
@@ -271,12 +321,12 @@ export class VlDatepickerComponent extends FormControl {
     private getOptions(): Options {
         const datepickerButton = this.shadowRoot?.querySelector('button');
         const datepicker = this.shadowRoot?.querySelector('#datepicker-wrapper') as HTMLInputElement;
-        const defaultDate = this.parseTodayDate(this.initialValue);
+        const defaultDate = this.type !== 'range' && this.parseTodayDate(this.initialValue);
         const staticOptions = {
             dateFormat: this.format,
             locale: Dutch.nl,
             clickOpens: false,
-            onChange: this.handleDateChange,
+            onChange: this.handleDatePickerChange,
             positionElement: datepickerButton,
             static: true,
             appendTo: datepicker,
@@ -326,37 +376,88 @@ export class VlDatepickerComponent extends FormControl {
     };
 
     private onInput = (event: Event & { target: HTMLInputElement }) => {
-        this.handleValueChanged(event.target?.value ?? '');
+        this.handleInputValueChanged(event.target?.value ?? '');
     };
 
-    private handleValueChanged(dateString: string) {
-        let parsedDate;
+    private getISODateString(date?: Date, date2?: Date): string {
+        if (!date) return '';
+        switch (this.type) {
+            case 'time':
+                return flatpickr.formatDate(date, this.format?.includes('S') ? 'H:i:S' : 'H:i');
+            case 'date-time':
+                return flatpickr.formatDate(date, 'Y-m-dTH:i');
+            case 'range':
+                return `${flatpickr.formatDate(date, 'Y-m-d')}${
+                    date2 ? '/' + flatpickr.formatDate(date2, 'Y-m-d') : ''
+                }`;
+            case 'date':
+            default:
+                return flatpickr.formatDate(date, 'Y-m-d');
+        }
+    }
+
+    // functie die de start- en einddatum zal extraheren uit de geformatteerde invoerwaarde met scheidingsteken (tot en met)
+    private getDatesFromInputValue(inputValue: string): Date[] | undefined {
+        const rangeSeparator = Dutch?.nl?.rangeSeparator;
+        const dateStrings = (rangeSeparator && inputValue.split(rangeSeparator)) || [];
+        const dates = dateStrings?.map((dateString) => flatpickr.parseDate(dateString, this.format));
+        return dates.length && dates.every((date) => date instanceof Date) ? (dates as Date[]) : undefined;
+    }
+
+    private handleInputValueChanged(dateString: string, isValidDateString = true) {
+        let parsedDate, isValidFormat;
+        // we verwachten een fout die opgeworpen wordt wanneer de waarde niet conform het formaat is
+        // daarom gebruiken we een try-catch
         try {
-            parsedDate = flatpickr.parseDate(dateString, this.format);
+            // indien een RegExp opgegeven is, controleren we of de waarde conform het formaat is
+            const patternRegExp = this.pattern ? new RegExp(this.pattern) : undefined;
+            const regex = this.regex || patternRegExp;
+            isValidFormat = regex ? regex.test(dateString) : true;
+            if (isValidFormat) parsedDate = flatpickr.parseDate(dateString, this.format);
+        } catch (error) {
+            // we vangen de error op, maar behandelen we die niet en gaan verder met de default waarde
         } finally {
-            this.value = dateString;
+            if (isValidDateString && isValidFormat && parsedDate && this.type !== 'range') {
+                this.value = this.getISODateString(parsedDate);
+            } else if (this.type === 'range') {
+                const dates = this.getDatesFromInputValue(dateString);
+                if (dates?.length) {
+                    this.value = this.getISODateString(dates[0], dates[1]);
+                } else {
+                    this.value = dateString;
+                }
+                this.inputValue = dateString;
+            } else {
+                // indien de waarde niet conform het verwachte formaat is of niet kon geconverteerd worden
+                // stellen we de value gelijk aan de inputValue
+                this.inputValue = dateString;
+                this.value = dateString;
+            }
             if (parsedDate instanceof Date && !isNaN(parsedDate as unknown as number)) {
                 this.flatpickrInstance?.setDate(dateString, false, this.format);
             }
         }
     }
 
-    private handleDateChange = (dates: Date[]) => {
-        const format = (date: Date) => flatpickr.formatDate(new Date(date), this.format);
-        if (dates.length !== 2) {
-            this.value = format(dates[0]);
-        } else {
-            this.value = `${format(dates[0])}${Dutch?.nl?.rangeSeparator}${format(dates[1])}`;
+    private handleDatePickerChange = (dates: Date[]) => {
+        const format = (date: Date) => flatpickr.formatDate(date, this.format);
+        if (dates.length === 1) {
+            this.inputValue = format(dates[0]);
+            this.value = this.getISODateString(dates[0]);
+        } else if (dates.length === 2) {
+            this.value = this.getISODateString(dates[0], dates[1]);
+            this.inputValue = `${format(dates[0])}${Dutch?.nl?.rangeSeparator}${format(dates[1])}`;
         }
     };
 
-    private updateValue = (value: string) => {
+    private updateFormControlValue = (inputValue: string) => {
         const detail = { value: this.value };
+        const date = this.flatpickrInstance?.parseDate(inputValue, this.format);
         // indien de waarde getypt wordt, updaten we de flatpickr instance zodat deze de nieuwe waarde toont
-        if (this.value !== this.flatpickrInstance?.input.value) {
-            this.flatpickrInstance?.setDate(this.value, false, this.format);
+        if (this.inputValue !== this.flatpickrInstance?.input.value && date) {
+            this.flatpickrInstance?.setDate(date, false, this.format);
         }
-        this.setValue(value);
+        this.setValue(this.value ?? '');
         this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
         this.dispatchEventIfValid(detail);
     };
@@ -378,8 +479,15 @@ export class VlDatepickerComponent extends FormControl {
             ? {
                   ...maskOptions,
                   // als we een cleave mask gebruiken, willen we de transformed value verkrijgen
-                  onValueChanged: ({ target: { value } }: { target: { value: string } }) => {
-                      this.handleValueChanged(value ?? '');
+                  onValueChanged: ({
+                      target: { value, rawValue },
+                  }: {
+                      target: { value: string; rawValue: string };
+                  }) => {
+                      // flatpickr gaat soms een string parsen naar een Date, ook al is de string niet conform het verwachte formaat
+                      // daarom voegen we hier nog een extra check toe om te voorkomen dat we een ongeldige datum in de flatpickr instance instellen
+                      const isValidDateString = maskOptions?.regex?.test(rawValue);
+                      this.handleInputValueChanged(value ?? '', isValidDateString);
                   },
               }
             : null;

--- a/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
+++ b/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
@@ -133,7 +133,7 @@ describe('integration - form demo', () => {
         const submittedFormData = {
             naam: 'Kristof Spaas',
             rrn: '12.34.56-789.12',
-            geboortedatum: '26.09.1991',
+            geboortedatum: '1991-09-26',
             geboorteplaats: 'hasselt',
             hobbies: ['padel', 'dans'],
             kinderen: '0',
@@ -164,7 +164,7 @@ describe('integration - form demo', () => {
         const submittedFormData = {
             naam: 'Kristof Spaas',
             rrn: '12345678912',
-            geboortedatum: '26.09.1991',
+            geboortedatum: '1991-09-26',
             geboorteplaats: 'hasselt',
             hobbies: ['padel', 'dans'],
             kinderen: '0',


### PR DESCRIPTION
Vroeger was de waarde die je instelde en de waarde die je eruit terugkreeg in hetzelfde formaat als de gebruiker ziet. Nu volgt die waarde altijd het ISO-8601 formaat, maar de waarde die de gebruiker ziet blijft conform het gekozen formaat.
Storybook & cypress testen uitgebreid en verbeterd.

[jira](https://www.milieuinfo.be/jira/browse/UIG-2846)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC329)