### PR TITLE
feat: UIG-2797 - vl-modal - uitlijning van de knoppen verbeterd

### DIFF
--- a/libs/components/src/modal/vl-modal.uig-css.ts
+++ b/libs/components/src/modal/vl-modal.uig-css.ts
@@ -8,5 +8,9 @@ const styles: CSSResult = css`
     .vl-modal-dialog__close {
         cursor: pointer;
     }
+
+    ::slotted(button) {
+        margin-right: 1.4rem;
+    }
 `;
 export default styles;


### PR DESCRIPTION
De oorzaak is dat de knoppen wel degelijk in een 'vl-action-group' zitten, maar doordat de custom knop(pen) in een slot gestoken wordt werkt de css van de action-group niet. Als je knoppen in het slot zelf in een action-group steekt werkt het ook niet, want de 'Annuleer' link staat rechts van de laatste knop in het slot, die dan ook geen rechter margin heeft.

Als oplossing heb ik slotted buttons een rechter margin gegeven. Dat werkt voor meerdere knoppen als je dit doet:
```
<button is="vl-button" slot="button">Knop 1</button>
<button is="vl-button" slot="button">Knop 2</button>
```
maar niet als je dit doet - maar dan moet je maar zelf je uitlijning correct doen
```
<div slot="button">
  <button is="vl-button">Knop 1</button>
  <button is="vl-button">Knop 2</button>
</div>
```

Ik zou hier niet meer tijd in steken om te testen of te documenteren. Is een component die herschreven moet worden: vl-modal.lib.js moet weg, styling moet bij ons komen.