### PR TITLE
feat: UIG-2999 - vl-popover - waarschuwing aangepast wanneer referentie-element niet wordt gevonden

### DIFF
--- a/libs/components/src/popover/vl-floating-ui.controller.ts
+++ b/libs/components/src/popover/vl-floating-ui.controller.ts
@@ -42,12 +42,7 @@ export default class FloatingController implements ReactiveController {
         const referenceId = `#${this.options.reference}`;
         const hostRootNode = this.host.getRootNode() as Element;
         const referenceElement = document.querySelector(referenceId) || hostRootNode.querySelector(referenceId);
-        if (referenceElement) {
-            return referenceElement as HTMLElement;
-        } else {
-            console.warn(this.host.tagName, ' could not find reference element with id: #', referenceId);
-            return null;
-        }
+        return referenceElement ? (referenceElement as HTMLElement) : null;
     }
 
     private getArrowElement(): HTMLElement {
@@ -71,6 +66,7 @@ export default class FloatingController implements ReactiveController {
 
     async updatePosition(): Promise<void> {
         if (!this.getReferenceElement) {
+            console.warn(this.host.tagName, ' could not find reference element with id: #', this.options?.reference);
             return;
         }
 
@@ -134,22 +130,28 @@ export default class FloatingController implements ReactiveController {
 
     private removeEventListeners(): void {
         const referenceElement = this.getReferenceElement();
-        referenceElement?.removeEventListener('keydown', this.handleKeyDown);
+
+        if (!referenceElement) {
+            console.warn(this.host.tagName, ' could not find reference element with id: #', this.options?.reference);
+            return;
+        }
+
+        referenceElement.removeEventListener('keydown', this.handleKeyDown);
 
         if (this.hasTrigger('click')) {
-            referenceElement?.removeEventListener('click', this.handleClick);
+            referenceElement.removeEventListener('click', this.handleClick);
             document.removeEventListener('click', this.handleClickOutside, true);
             this.host.removeEventListener('click', this.host.hide);
         }
 
         if (this.hasTrigger('hover')) {
-            referenceElement?.removeEventListener('mouseover', this.handleMouseOver);
-            referenceElement?.removeEventListener('mouseout', this.handleMouseOut);
+            referenceElement.removeEventListener('mouseover', this.handleMouseOver);
+            referenceElement.removeEventListener('mouseout', this.handleMouseOut);
         }
 
         if (this.hasTrigger('focus')) {
-            referenceElement?.removeEventListener('focusin', this.handleFocusIn, true);
-            referenceElement?.removeEventListener('focusout', this.handleFocusOut, true);
+            referenceElement.removeEventListener('focusin', this.handleFocusIn, true);
+            referenceElement.removeEventListener('focusout', this.handleFocusOut, true);
         }
 
         window.removeEventListener('resize', this.handleResize);

--- a/libs/components/src/popover/vl-popover.component.cy.ts
+++ b/libs/components/src/popover/vl-popover.component.cy.ts
@@ -2,7 +2,6 @@ import { registerWebComponents } from '@domg-wc/common-utilities';
 import { VlPopoverActionListComponent, VlPopoverComponent } from './index';
 import { html, nothing } from 'lit';
 import { VlPopoverActionComponent } from './vl-popover-action.component';
-import { action } from '@storybook/addon-actions';
 
 registerWebComponents([VlPopoverComponent, VlPopoverActionComponent, VlPopoverActionListComponent]);
 
@@ -35,12 +34,7 @@ const mountDefault = ({
             distance=${distance || nothing}
             content-padding=${contentPadding || nothing}
         >
-            <vl-popover-action-list
-                @click=${(event: CustomEvent) => {
-                    const actionElement = event.target as VlPopoverActionComponent;
-                    action('click')('vl-popover-action clicked > ' + actionElement.action);
-                }}
-            >
+            <vl-popover-action-list>
                 <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
                 <vl-popover-action icon="bell" .action=${'report'}>Rapportenoverzicht</vl-popover-action>
                 <vl-popover-action icon="pin" .action=${'locate'}>Vind locatie</vl-popover-action>

--- a/libs/components/src/popover/vl-popover.component.ts
+++ b/libs/components/src/popover/vl-popover.component.ts
@@ -12,12 +12,13 @@ import popoverUigStyle from './vl-popover.uig-css';
 
 @customElement('vl-popover')
 export class VlPopoverComponent extends BaseLitElement {
+    open = false;
+
     private popup!: FloatingController;
     private for = ''; // html id van het referentie-element
     private trigger = 'click';
     private placement: Placement = 'bottom';
     private distance = 10; // afstand van referentie-element in px
-    open = false;
     private hideArrow = false;
     private contentPadding: 'none' | 'small' | 'medium' | 'large' = 'small';
     private hideOnClick = false;
@@ -32,14 +33,14 @@ export class VlPopoverComponent extends BaseLitElement {
 
     static get properties(): PropertyDeclarations {
         return {
-            for: { type: String, attribute: 'for', reflect: true },
-            contentPadding: { type: String, attribute: 'content-padding', reflect: true },
+            for: { type: String, attribute: 'for' },
+            contentPadding: { type: String, attribute: 'content-padding' },
             open: { type: Boolean, attribute: 'open', reflect: true },
-            trigger: { type: String, attribute: 'trigger', reflect: true },
+            trigger: { type: String, attribute: 'trigger' },
             placement: { type: String, attribute: 'placement', reflect: true },
-            distance: { type: Number, attribute: 'distance', reflect: true },
-            hideArrow: { type: Boolean, attribute: 'hide-arrow', reflect: true },
-            hideOnClick: { type: Boolean, attribute: 'hide-on-click', reflect: true },
+            distance: { type: Number, attribute: 'distance' },
+            hideArrow: { type: Boolean, attribute: 'hide-arrow' },
+            hideOnClick: { type: Boolean, attribute: 'hide-on-click' },
         };
     }
 


### PR DESCRIPTION
Vroeger toonden we een waarschuwing wanneer we op basis van het referentie-element de popover tonen, renderen en event listeners toevoegen of verwijderen. Nu is dit aangepast zodat dit geen waarschuwing meer geeft als het referentie-element niet meer beschikbaar is, wanneer we de event listeners ervan willen verwijderen.

Ook andere kleine aanpassingen gemaakt:
- enkel properties reflecten die relevant zijn ipv allemaal
- volgorde properties aangepast (public boven, daarna private)
- Storybook dependency in component.cy test verwijderd

[jira](https://www.milieuinfo.be/jira/browse/UIG-2999)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC347)