### PR TITLE
fix: UIG-3007 - vl-upload - Dropzone initialisatie aangepast

### DIFF
--- a/libs/form/src/dropzone-types.d.ts
+++ b/libs/form/src/dropzone-types.d.ts
@@ -1,0 +1,374 @@
+export interface DropzoneResizeInfo {
+    srcX?: number;
+    srcY?: number;
+    trgX?: number;
+    trgY?: number;
+    srcWidth?: number;
+    srcHeight?: number;
+    trgWidth?: number;
+    trgHeight?: number;
+}
+
+export interface DropzoneFileUpload {
+    progress: number;
+    total: number;
+    bytesSent: number;
+    uuid: string;
+    totalChunkCount?: number;
+}
+
+export interface DropzoneFile extends File {
+    dataURL?: string;
+    previewElement: HTMLElement;
+    previewTemplate: HTMLElement;
+    previewsContainer: HTMLElement;
+    status: string;
+    accepted: boolean;
+    xhr?: XMLHttpRequest;
+    upload?: DropzoneFileUpload;
+}
+
+export interface DropzoneMockFile {
+    name: string;
+    size: number;
+    [index: string]: any;
+}
+
+export interface DropzoneDictFileSizeUnits {
+    tb?: string;
+    gb?: string;
+    mb?: string;
+    kb?: string;
+    b?: string;
+}
+
+export interface DropzoneOptions {
+    url?: ((files: readonly DropzoneFile[]) => string) | string | undefined;
+    method?: ((files: readonly DropzoneFile[]) => string) | string | undefined;
+    withCredentials?: boolean | undefined;
+    timeout?: number | undefined;
+    parallelUploads?: number | undefined;
+    uploadMultiple?: boolean | undefined;
+    chunking?: boolean | undefined;
+    forceChunking?: boolean | undefined;
+    chunkSize?: number | undefined;
+    parallelChunkUploads?: boolean | undefined;
+    retryChunks?: boolean | undefined;
+    retryChunksLimit?: number | undefined;
+    maxFilesize?: number | undefined;
+    paramName?: string | undefined;
+    createImageThumbnails?: boolean | undefined;
+    maxThumbnailFilesize?: number | undefined;
+    thumbnailWidth?: number | undefined;
+    thumbnailHeight?: number | undefined;
+    thumbnailMethod?: 'contain' | 'crop' | undefined;
+    resizeWidth?: number | undefined;
+    resizeHeight?: number | undefined;
+    resizeMimeType?: string | undefined;
+    resizeQuality?: number | undefined;
+    resizeMethod?: 'contain' | 'crop' | undefined;
+    filesizeBase?: number | undefined;
+    maxFiles?: number | undefined;
+    params?: {} | undefined;
+    headers?: { [key: string]: string } | undefined;
+    clickable?: boolean | string | HTMLElement | Array<string | HTMLElement> | undefined;
+    ignoreHiddenFiles?: boolean | undefined;
+    acceptedFiles?: string | undefined;
+    renameFilename?(name: string): string;
+    autoProcessQueue?: boolean | undefined;
+    autoQueue?: boolean | undefined;
+    addRemoveLinks?: boolean | undefined;
+    previewsContainer?: boolean | string | HTMLElement | undefined;
+    hiddenInputContainer?: HTMLElement | undefined;
+    capture?: string | undefined;
+
+    dictDefaultMessage?: string | undefined;
+    dictFallbackMessage?: string | undefined;
+    dictFallbackText?: string | undefined;
+    dictFileTooBig?: string | undefined;
+    dictInvalidFileType?: string | undefined;
+    dictResponseError?: string | undefined;
+    dictCancelUpload?: string | undefined;
+    dictCancelUploadConfirmation?: string | undefined;
+    dictRemoveFile?: string | undefined;
+    dictRemoveFileConfirmation?: string | undefined;
+    dictMaxFilesExceeded?: string | undefined;
+    dictFileSizeUnits?: DropzoneDictFileSizeUnits | undefined;
+    dictUploadCanceled?: string | undefined;
+
+    accept?(file: DropzoneFile, done: (error?: string | Error) => void): void;
+    chunksUploaded?(file: DropzoneFile, done: (error?: string | Error) => void): void;
+    init?(this: Dropzone): void;
+    forceFallback?: boolean | undefined;
+    fallback?(): void;
+    resize?(file: DropzoneFile, width?: number, height?: number, resizeMethod?: string): DropzoneResizeInfo;
+
+    drop?(e: DragEvent): void;
+    dragstart?(e: DragEvent): void;
+    dragend?(e: DragEvent): void;
+    dragenter?(e: DragEvent): void;
+    dragover?(e: DragEvent): void;
+    dragleave?(e: DragEvent): void;
+    paste?(e: DragEvent): void;
+
+    reset?(): void;
+
+    addedfile?(file: DropzoneFile): void;
+    addedfiles?(files: DropzoneFile[]): void;
+    removedfile?(file: DropzoneFile): void;
+    thumbnail?(file: DropzoneFile, dataUrl: string): void;
+
+    error?(file: DropzoneFile, message: string | Error, xhr: XMLHttpRequest): void;
+    errormultiple?(files: DropzoneFile[], message: string | Error, xhr: XMLHttpRequest): void;
+
+    processing?(file: DropzoneFile): void;
+    processingmultiple?(files: DropzoneFile[]): void;
+
+    uploadprogress?(file: DropzoneFile, progress: number, bytesSent: number): void;
+    totaluploadprogress?(totalProgress: number, totalBytes: number, totalBytesSent: number): void;
+
+    sending?(file: DropzoneFile, xhr: XMLHttpRequest, formData: FormData): void;
+    sendingmultiple?(files: DropzoneFile[], xhr: XMLHttpRequest, formData: FormData): void;
+
+    success?(file: DropzoneFile): void;
+    successmultiple?(files: DropzoneFile[], responseText: string): void;
+
+    canceled?(file: DropzoneFile): void;
+    canceledmultiple?(file: DropzoneFile[]): void;
+
+    complete?(file: DropzoneFile): void;
+    completemultiple?(file: DropzoneFile[]): void;
+
+    maxfilesexceeded?(file: DropzoneFile): void;
+    maxfilesreached?(files: DropzoneFile[]): void;
+    queuecomplete?(): void;
+
+    transformFile?(file: DropzoneFile, done: (file: string | Blob) => void): void;
+
+    previewTemplate?: string | undefined;
+}
+
+export interface DropzoneListener {
+    element: HTMLElement;
+    events: {
+        [key: string]: (e: Event) => any;
+    };
+}
+
+export class Dropzone {
+    constructor(container: string | HTMLElement, options?: DropzoneOptions);
+
+    static autoDiscover: boolean;
+    static blacklistedBrowsers: RegExp[];
+    static confirm: (question: string, accepted: () => void, rejected?: () => void) => void;
+    static createElement(string: string): HTMLElement;
+    static dataURItoBlob(dataURI: string): Blob;
+    static discover(): Dropzone[];
+    static elementInside(element: HTMLElement, container: HTMLElement): boolean;
+    static forElement(element: string | HTMLElement): Dropzone;
+    static getElement(element: string | HTMLElement, name?: string): HTMLElement;
+    static getElements(elements: string | HTMLElement | Array<string | HTMLElement>): HTMLElement[];
+    static instances: Dropzone[];
+    static isBrowserSupported(): boolean;
+    static isValidFile(file: File, acceptedFiles: string): boolean;
+    static options: { [key: string]: DropzoneOptions | false };
+    static optionsForElement(element: HTMLElement): DropzoneOptions | undefined;
+    static version: string;
+
+    static ADDED: string;
+    static QUEUED: string;
+    static ACCEPTED: string;
+    static UPLOADING: string;
+    static PROCESSING: string;
+    static CANCELED: string;
+    static ERROR: string;
+    static SUCCESS: string;
+
+    element: HTMLElement;
+    files: DropzoneFile[];
+    hiddenFileInput?: HTMLInputElement | undefined;
+    listeners: DropzoneListener[];
+    defaultOptions: DropzoneOptions;
+    options: DropzoneOptions;
+    previewsContainer: HTMLElement;
+    version: string;
+
+    enable(): void;
+
+    disable(): void;
+
+    destroy(): Dropzone;
+
+    addFile(file: DropzoneFile): void;
+
+    removeFile(file: DropzoneFile): void;
+
+    removeAllFiles(cancelIfNecessary?: boolean): void;
+
+    resizeImage(
+        file: DropzoneFile,
+        width?: number,
+        height?: number,
+        resizeMethod?: string,
+        callback?: (...args: any[]) => void
+    ): void;
+
+    processQueue(): void;
+
+    cancelUpload(file: DropzoneFile): void;
+
+    createThumbnail(
+        file: DropzoneFile,
+        width?: number,
+        height?: number,
+        resizeMethod?: string,
+        fixOrientation?: boolean,
+        callback?: (...args: any[]) => void
+    ): any;
+
+    displayExistingFile(
+        mockFile: DropzoneMockFile,
+        imageUrl: string,
+        callback?: () => void,
+        crossOrigin?: 'anonymous' | 'use-credentials',
+        resizeThumbnail?: boolean
+    ): any;
+
+    createThumbnailFromUrl(
+        file: DropzoneFile,
+        width?: number,
+        height?: number,
+        resizeMethod?: string,
+        fixOrientation?: boolean,
+        callback?: (...args: any[]) => void,
+        crossOrigin?: string
+    ): any;
+
+    processFiles(files: DropzoneFile[]): void;
+
+    processFile(file: DropzoneFile): void;
+
+    uploadFile(file: DropzoneFile): void;
+
+    uploadFiles(files: DropzoneFile[]): void;
+
+    getAcceptedFiles(): DropzoneFile[];
+
+    getActiveFiles(): DropzoneFile[];
+
+    getAddedFiles(): DropzoneFile[];
+
+    getRejectedFiles(): DropzoneFile[];
+
+    getQueuedFiles(): DropzoneFile[];
+
+    getUploadingFiles(): DropzoneFile[];
+
+    accept(file: DropzoneFile, done: (error?: string | Error) => void): void;
+
+    getFilesWithStatus(status: string): DropzoneFile[];
+
+    enqueueFile(file: DropzoneFile): void;
+
+    enqueueFiles(file: DropzoneFile[]): void;
+
+    createThumbnail(file: DropzoneFile, callback?: (...args: any[]) => void): any;
+
+    createThumbnailFromUrl(file: DropzoneFile, url: string, callback?: (...args: any[]) => void): any;
+
+    on(eventName: string, callback: (...args: any[]) => void): Dropzone;
+
+    off(): Dropzone;
+    off(eventName: string, callback?: (...args: any[]) => void): Dropzone;
+
+    emit(eventName: string, ...args: any[]): Dropzone;
+
+    on(eventName: 'drop', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'dragstart', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'dragend', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'dragenter', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'dragover', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'dragleave', callback: (e: DragEvent) => any): Dropzone;
+    on(eventName: 'paste', callback: (e: DragEvent) => any): Dropzone;
+
+    on(eventName: 'reset'): Dropzone;
+
+    on(eventName: 'addedfile', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'addedfiles', callback: (files: DropzoneFile[]) => any): Dropzone;
+    on(eventName: 'removedfile', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'thumbnail', callback: (file: DropzoneFile, dataUrl: string) => any): Dropzone;
+
+    on(eventName: 'error', callback: (file: DropzoneFile, message: string | Error) => any): Dropzone;
+    on(eventName: 'errormultiple', callback: (files: DropzoneFile[], message: string | Error) => any): Dropzone;
+
+    on(eventName: 'processing', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'processingmultiple', callback: (files: DropzoneFile[]) => any): Dropzone;
+
+    on(
+        eventName: 'uploadprogress',
+        callback: (file: DropzoneFile, progress: number, bytesSent: number) => any
+    ): Dropzone;
+    on(
+        eventName: 'totaluploadprogress',
+        callback: (totalProgress: number, totalBytes: number, totalBytesSent: number) => any
+    ): Dropzone;
+
+    on(eventName: 'sending', callback: (file: DropzoneFile, xhr: XMLHttpRequest, formData: FormData) => any): Dropzone;
+    on(
+        eventName: 'sendingmultiple',
+        callback: (files: DropzoneFile[], xhr: XMLHttpRequest, formData: FormData) => any
+    ): Dropzone;
+
+    on(eventName: 'success', callback: (file: DropzoneFile, response: Object | string) => any): Dropzone;
+    on(eventName: 'successmultiple', callback: (files: DropzoneFile[]) => any): Dropzone;
+
+    on(eventName: 'canceled', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'canceledmultiple', callback: (file: DropzoneFile[]) => any): Dropzone;
+
+    on(eventName: 'complete', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'completemultiple', callback: (file: DropzoneFile[]) => any): Dropzone;
+
+    on(eventName: 'maxfilesexceeded', callback: (file: DropzoneFile) => any): Dropzone;
+    on(eventName: 'maxfilesreached', callback: (files: DropzoneFile[]) => any): Dropzone;
+    on(eventName: 'queuecomplete'): Dropzone;
+
+    emit(eventName: 'drop', e: DragEvent): Dropzone;
+    emit(eventName: 'dragstart', e: DragEvent): Dropzone;
+    emit(eventName: 'dragend', e: DragEvent): Dropzone;
+    emit(eventName: 'dragenter', e: DragEvent): Dropzone;
+    emit(eventName: 'dragover', e: DragEvent): Dropzone;
+    emit(eventName: 'dragleave', e: DragEvent): Dropzone;
+    emit(eventName: 'paste', e: DragEvent): Dropzone;
+
+    emit(eventName: 'reset'): Dropzone;
+
+    emit(eventName: 'addedfile', file: DropzoneFile): Dropzone;
+    emit(eventName: 'addedfiles', files: DropzoneFile[]): Dropzone;
+    emit(eventName: 'removedfile', file: DropzoneFile): Dropzone;
+    emit(eventName: 'thumbnail', file: DropzoneFile, dataUrl: string): Dropzone;
+
+    emit(eventName: 'error', file: DropzoneFile, message: string | Error): Dropzone;
+    emit(eventName: 'errormultiple', files: DropzoneFile[], message: string | Error): Dropzone;
+
+    emit(eventName: 'processing', file: DropzoneFile): Dropzone;
+    emit(eventName: 'processingmultiple', files: DropzoneFile[]): Dropzone;
+
+    emit(eventName: 'uploadprogress', file: DropzoneFile, progress: number, bytesSent: number): Dropzone;
+    emit(eventName: 'totaluploadprogress', totalProgress: number, totalBytes: number, totalBytesSent: number): Dropzone;
+
+    emit(eventName: 'sending', file: DropzoneFile, xhr: XMLHttpRequest, formData: FormData): Dropzone;
+    emit(eventName: 'sendingmultiple', files: DropzoneFile[], xhr: XMLHttpRequest, formData: FormData): Dropzone;
+
+    emit(eventName: 'success', file: DropzoneFile, response: object | string): Dropzone;
+    emit(eventName: 'successmultiple', files: DropzoneFile[]): Dropzone;
+
+    emit(eventName: 'canceled', file: DropzoneFile): Dropzone;
+    emit(eventName: 'canceledmultiple', file: DropzoneFile[]): Dropzone;
+
+    emit(eventName: 'complete', file: DropzoneFile): Dropzone;
+    emit(eventName: 'completemultiple', file: DropzoneFile[]): Dropzone;
+
+    emit(eventName: 'maxfilesexceeded', file: DropzoneFile): Dropzone;
+    emit(eventName: 'maxfilesreached', files: DropzoneFile[]): Dropzone;
+    emit(eventName: 'queuecomplete'): Dropzone;
+}

--- a/libs/form/src/external-types.d.ts
+++ b/libs/form/src/external-types.d.ts
@@ -1,1 +1,2 @@
 declare module 'cleave.js';
+declare module 'dropzone';

--- a/libs/form/src/next/upload/vl-upload.component.ts
+++ b/libs/form/src/next/upload/vl-upload.component.ts
@@ -1,13 +1,14 @@
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { iconStyle, linkStyle, uploadStyle } from '@domg/govflanders-style/component';
 import { classMap } from 'lit/directives/class-map.js';
-import * as Dropzone from 'dropzone';
+import Dropzone from 'dropzone';
 import { Validator } from '@open-wc/form-control';
 import { FormValue } from '@open-wc/form-control/src/types';
 import { accessibilityStyle, baseStyle, resetStyle } from '@domg/govflanders-style/common';
 import { findNodesForSlot, webComponent } from '@domg-wc/common-utilities';
 import { FormControl, formControlDefaults } from '../form-control/form-control';
 import uploadUigStyle from './vl-upload.uig-css';
+import { Dropzone as DropzoneInstance, DropzoneFile } from '@domg-wc/form/dropzone-types';
 
 /**
  * valideert of dropzone bij 1 van de bestanden een error heeft
@@ -63,10 +64,9 @@ export class VlUploadComponent extends FormControl {
     private multiple = false;
 
     // Variables
-    private dropzoneInstance: Dropzone | undefined | null;
+    private dropzoneInstance: DropzoneInstance | undefined | null;
 
     static formControlValidators = [...FormControl.formControlValidators, dropzoneValidator];
-
     static get styles(): CSSResult[] {
         return [resetStyle, baseStyle, linkStyle, uploadStyle, uploadUigStyle, iconStyle, accessibilityStyle];
     }
@@ -133,7 +133,7 @@ export class VlUploadComponent extends FormControl {
             }
             // drag & drop aan of uit zetten
             if (this.dropzoneInstance) {
-                const dropzoneInstance = this.dropzoneInstance as Dropzone & {
+                const dropzoneInstance = this.dropzoneInstance as DropzoneInstance & {
                     setupEventListeners: () => void;
                     removeEventListeners: () => void;
                 };
@@ -261,7 +261,7 @@ export class VlUploadComponent extends FormControl {
         this.dropzoneInstance?.off(event, callback);
     }
 
-    getFiles(): Dropzone.DropzoneFile[] {
+    getFiles(): DropzoneFile[] {
         return this.dropzoneInstance?.getAcceptedFiles() || [];
     }
 
@@ -273,7 +273,7 @@ export class VlUploadComponent extends FormControl {
             if (this.autoProcess) {
                 this.dropzoneInstance.options.autoProcessQueue = false;
             }
-            this.dropzoneInstance.addFile(<Dropzone.DropzoneFile>file);
+            this.dropzoneInstance.addFile(<DropzoneFile>file);
             this.dropzoneInstance.emit('complete', file);
             if (this.autoProcess) {
                 this.dropzoneInstance.options.autoProcessQueue = true;
@@ -357,7 +357,7 @@ export class VlUploadComponent extends FormControl {
             : this.getInput()?.removeAttribute(attribute);
     }
 
-    private async updateFileList(dropzone: Dropzone, file?: Dropzone.DropzoneFile) {
+    private async updateFileList(dropzone: DropzoneInstance, file?: DropzoneFile) {
         const fileList = this.shadowRoot?.querySelector(`.vl-upload__files`);
 
         if (dropzone.files.length) {
@@ -417,8 +417,12 @@ export class VlUploadComponent extends FormControl {
         };
 
         if (dropzoneContainer) {
-            // @ts-ignore omdat Dropzone.default niet herkend wordt door typescript
-            this.dropzoneInstance = new Dropzone.default(dropzoneContainer, dropzoneOptions);
+            // afhankelijk van de configuratie van build tools, kan Dropzone geinitialiseerd worden als named of als default export
+            try {
+                this.dropzoneInstance = new Dropzone(dropzoneContainer, dropzoneOptions);
+            } catch (error) {
+                this.dropzoneInstance = new Dropzone.default(dropzoneContainer, dropzoneOptions);
+            }
         }
     }
 
@@ -472,7 +476,7 @@ export class VlUploadComponent extends FormControl {
         this.dropzoneInstance.off('drop', this.handleDragLeave);
     }
 
-    private updateValue(detail: { type: string; file?: Dropzone.DropzoneFile; value: FormValue }) {
+    private updateValue(detail: { type: string; file?: DropzoneFile; value: FormValue }) {
         this.value = this.collectFormData();
         this.dispatchEvent(
             new CustomEvent('vl-input', {
@@ -498,17 +502,17 @@ export class VlUploadComponent extends FormControl {
             : '';
     }
 
-    private handleAddedFile = async (file: Dropzone.DropzoneFile): Promise<void> => {
+    private handleAddedFile = async (file: DropzoneFile): Promise<void> => {
         await this.updateFileList(this.dropzoneInstance!, file);
         this.updateValue({ type: 'addedfile', file: file, value: this.value });
     };
 
-    private handleRemovedFile = async (file: Dropzone.DropzoneFile): Promise<void> => {
+    private handleRemovedFile = async (file: DropzoneFile): Promise<void> => {
         await this.updateFileList(this.dropzoneInstance!);
         this.updateValue({ type: 'removedfile', file: file, value: this.value });
     };
 
-    private handleError = (file: Dropzone.DropzoneFile, errorMessage: string) => {
+    private handleError = (file: DropzoneFile, errorMessage: string) => {
         this.dispatchEvent(
             new CustomEvent('vl-error', {
                 composed: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
                 "@swc/cli": "0.3.10",
                 "@swc/core": "1.4.6",
                 "@swc/jest": "0.2.36",
-                "@types/dropzone": "5.7.8",
                 "@types/jest": "29.5.12",
                 "@types/node": "20.11.26",
                 "@types/prettier": "2.7.3",
@@ -10401,15 +10400,6 @@
             "integrity": "sha512-w5jZ0ee+HaPOaX25X2/2oGR/7rgAQSYII7X7pp0m9KgBfMP7uKfMfTvcpl5Dj+eDBbpxKGiqE+flqDr6XTd2RA==",
             "dev": true
         },
-        "node_modules/@types/dropzone": {
-            "version": "5.7.8",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@types/dropzone/-/dropzone-5.7.8.tgz",
-            "integrity": "sha512-+L0/KRMuB8cIiCe5AfF448nGMpY+gHiSakqsqT3plEIfgqSV+gcVs1AkngM9zZG8hi6lgMxy4iYEuGXXmqjYvg==",
-            "dev": true,
-            "dependencies": {
-                "@types/jquery": "*"
-            }
-        },
         "node_modules/@types/ejs": {
             "version": "3.1.5",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@types/ejs/-/ejs-3.1.5.tgz",
@@ -10582,15 +10572,6 @@
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
             "dev": true
-        },
-        "node_modules/@types/jquery": {
-            "version": "3.5.29",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@types/jquery/-/jquery-3.5.29.tgz",
-            "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
-            "dev": true,
-            "dependencies": {
-                "@types/sizzle": "*"
-            }
         },
         "node_modules/@types/jsdom": {
             "version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
         "@swc/cli": "0.3.10",
         "@swc/core": "1.4.6",
         "@swc/jest": "0.2.36",
-        "@types/dropzone": "5.7.8",
         "@types/jest": "29.5.12",
         "@types/node": "20.11.26",
         "@types/prettier": "2.7.3",


### PR DESCRIPTION
Afhankelijk van de configuratie van het build systeem waarin onze library wordt gebruikt, kan het zijn dat de Dropzone instance niet correct wordt geïnitialiseerd. Als dit het geval is, zullen we de Dropzone instance initialiseren met de Dropzone.default export.
@types/dropzone verwijderd en zelf Dropzone klasses toegevoegd.

[jira](https://www.milieuinfo.be/jira/browse/UIG-3007)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC349)