### PR TITLE
fix: UIG-3014 - vl-modal - allow-overflow attribute werking rechtgezet

### DIFF
--- a/libs/components/src/modal/vl-modal.uig-css.ts
+++ b/libs/components/src/modal/vl-modal.uig-css.ts
@@ -1,7 +1,8 @@
 import { css, CSSResult } from 'lit';
 
 const styles: CSSResult = css`
-    :host([data-vl-allow-overflow]) dialog {
+    :host([data-vl-allow-overflow]) dialog,
+    :host([data-vl-allow-overflow]) dialog .vl-modal-dialog__wrapper {
         overflow: visible;
     }
 


### PR DESCRIPTION
[jira](https://www.milieuinfo.be/jira/browse/UIG-3014)
[bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC358)