### PR TITLE
feat: UIG-3018 - form-control - null als default value ingesteld waar relvant

### DIFF
--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -70,3 +70,11 @@ Cypress.Commands.add('runTestFor', <T>(selector: string, test: (component: T) =>
         test(component);
     });
 });
+
+Cypress.Commands.add('runTest', { prevSubject: true }, <T>(prevSubject, test: (component: T) => void) => {
+    const el = prevSubject as JQuery<HTMLElement>;
+    const component = el.get(0) as T;
+
+    test(component);
+    return cy.wrap(component);
+});

--- a/cypress/types.d.ts
+++ b/cypress/types.d.ts
@@ -16,8 +16,9 @@ declare global {
                 value: string;
                 pseudo?: string;
                 not?: boolean;
-            }): Chainable<any>;
+            }): Chainable<Subject>;
             runTestFor<T>(selector: string, test: (component: T) => void): Chainable<Subject>;
+            runTest<T = HTMLElement>(test: (component: T) => void): Chainable<Subject>;
         }
     }
 }

--- a/libs/form/src/next/checkbox/stories/vl-checkbox.stories.ts
+++ b/libs/form/src/next/checkbox/stories/vl-checkbox.stories.ts
@@ -6,6 +6,7 @@ import { story } from '@domg-wc/common-storybook';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import { VlCheckboxComponent } from '../vl-checkbox.component';
+import { nothing } from 'lit';
 
 registerWebComponents([VlCheckboxComponent]);
 
@@ -120,7 +121,7 @@ export const CheckboxReadonly = story(
         >
             ${unsafeHTML(contentSlot)}
         </vl-checkbox-next>
-        <input type="hidden" name=${name} value=${checked ? value || 'on' : ''} />
+        <input type="hidden" name=${name} value=${checked ? value || 'on' : nothing} />
     `
 );
 CheckboxReadonly.storyName = 'vl-checkbox-next - readonly';

--- a/libs/form/src/next/checkbox/vl-checkbox.component.ts
+++ b/libs/form/src/next/checkbox/vl-checkbox.component.ts
@@ -10,7 +10,7 @@ import { webComponent } from '@domg-wc/common-utilities';
 export const checkboxDefaults = {
     ...formControlDefaults,
     block: false as boolean,
-    value: '' as string,
+    value: null as string | null,
     checked: false as boolean,
     isSwitch: false as boolean,
 } as const;
@@ -24,7 +24,7 @@ export class VlCheckboxComponent extends FormControl {
     private isSwitch = checkboxDefaults.isSwitch;
 
     // Variables
-    private initialValue = '';
+    private initialValue: string | null = null;
     private initialCheckedValue = false;
 
     static get styles(): (CSSResult | CSSResult[])[] {
@@ -53,8 +53,8 @@ export class VlCheckboxComponent extends FormControl {
         super.updated(changedProperties);
 
         if (changedProperties.has('checked') || changedProperties.has('value')) {
-            const value = this.checked ? this.value || 'on' : '';
-            const detail: { checked: boolean; value?: string } = { checked: this.checked };
+            const value = this.checked ? this.value || 'on' : null;
+            const detail: { checked: boolean; value?: string | null } = { checked: this.checked };
 
             if (this.checked) {
                 detail.value = value;

--- a/libs/form/src/next/radio-group/vl-radio-group.component.cy.ts
+++ b/libs/form/src/next/radio-group/vl-radio-group.component.cy.ts
@@ -223,6 +223,44 @@ describe('component - vl-radio-group-next - in form', () => {
         cy.get('vl-radio-group-next').find('vl-radio-next[value="lucht"]').should('not.have.attr', 'checked');
     });
 
+    it('should reset to null when the form is reset with no value', () => {
+        cy.mount(html`
+            <form>
+                <vl-radio-group-next id="land-zee" name="land-zee" required>
+                    <vl-radio-next value="land">Land</vl-radio-next>
+                    <vl-radio-next value="zee">Zee</vl-radio-next>
+                    <vl-radio-next value="lucht">Lucht</vl-radio-next>
+                </vl-radio-group-next>
+                <button class="vl-button" type="reset">Reset</button>
+            </form>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-radio-group-next').runTest((radioGroup) => {
+            // @ts-ignore test private property
+            expect(radioGroup.value).to.be.null;
+        });
+
+        clickRadioWithValue('zee');
+
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="zee"]').should('have.attr', 'checked');
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="land"]').should('not.have.attr', 'checked');
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="lucht"]').should('not.have.attr', 'checked');
+        cy.checkA11y('vl-radio-group-next');
+
+        cy.get('button[type="reset"]').click();
+
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="land"]').should('not.have.attr', 'checked');
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="zee"]').should('not.have.attr', 'checked');
+        cy.get('vl-radio-group-next').find('vl-radio-next[value="lucht"]').should('not.have.attr', 'checked');
+        cy.checkA11y('vl-radio-group-next');
+
+        cy.get('vl-radio-group-next').runTest((radioGroup) => {
+            // @ts-ignore test private property
+            expect(radioGroup.value).to.be.null;
+        });
+    });
+
     it('should reset the value when the form is reset', () => {
         cy.mount(html`
             <form>

--- a/libs/form/src/next/radio-group/vl-radio-group.component.ts
+++ b/libs/form/src/next/radio-group/vl-radio-group.component.ts
@@ -10,17 +10,17 @@ import { webComponent } from '@domg-wc/common-utilities';
 export const radioGroupDefaults = {
     ...formControlDefaults,
     readonly: false as boolean,
-    value: '' as string,
+    value: null as string | null,
 };
 
 @webComponent('vl-radio-group-next')
 export class VlRadioGroupComponent extends FormControl {
     // Attributes
     private readonly = radioGroupDefaults.readonly;
-    private value = radioGroupDefaults.value;
+    private value: string | null = radioGroupDefaults.value;
 
     // Variables
-    private initialValue = '';
+    private initialValue: string | null = null;
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [resetStyle, baseStyle, vlElementsStyle, radioStyle, radioUigStyle];
@@ -167,7 +167,7 @@ export class VlRadioGroupComponent extends FormControl {
                 radio.removeAttribute('checked');
             } else {
                 if (!radio.hasAttribute('checked')) radio.setAttribute('checked', '');
-                this.value = value ? value : '';
+                this.value = value;
                 this.setValue(value);
             }
         });

--- a/libs/form/src/next/radio-group/vl-radio.component.ts
+++ b/libs/form/src/next/radio-group/vl-radio.component.ts
@@ -10,7 +10,7 @@ import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
 export const radioDefaults = {
     id: 'radio' as string,
     name: '' as string,
-    value: '' as string,
+    value: null as string | null,
     label: '' as string,
     block: false as boolean,
     readonly: false as boolean,

--- a/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
@@ -371,7 +371,7 @@ describe('component - vl-select-rich-next - single', () => {
         cy.get('@vl-select')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
-            .should('deep.equal', { value: '' });
+            .should('deep.equal', { value: null });
         cy.checkA11y('vl-select-rich-next');
     });
 
@@ -515,7 +515,7 @@ describe('component - vl-select-rich-next - single', () => {
 
         cy.checkA11y('vl-select-rich-next');
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich-next', (component) => {
-            expect(component.getSelected()).to.be.empty;
+            expect(component.getSelected()).to.be.null;
         });
         cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich-next')
@@ -544,7 +544,7 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-pill__close')
             .click();
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich-next', (component) => {
-            expect(component.getSelected()).to.be.empty;
+            expect(component.getSelected()).to.be.null;
         });
         cy.checkA11y('vl-select-rich-next');
     });

--- a/libs/form/src/next/select-rich/vl-select-rich.component.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.ts
@@ -56,7 +56,7 @@ export class VlSelectRichComponent extends FormControl {
     private searchPlaceholder = selectRichDefaults.searchPlaceholder;
 
     // State
-    private value: FormValue = '';
+    private value: FormValue = null;
 
     // Variables
     private choices: Choices | null = null;
@@ -114,7 +114,7 @@ export class VlSelectRichComponent extends FormControl {
 
             // Fix voor required validator
             if (!this.value) {
-                this.setValue('');
+                this.setValue(null);
             }
 
             // Fix voor Choices.js search event dat niet afgevuurd wordt als de search value verwijderd wordt.
@@ -207,8 +207,8 @@ export class VlSelectRichComponent extends FormControl {
         this.options = [...this.initialOptions];
     }
 
-    getSelected(): string | string[] {
-        return this.multiple ? this.getSelectedValues() : this.getSelectedValues()[0] || '';
+    getSelected(): string | string[] | null {
+        return this.multiple ? this.getSelectedValues() : this.getSelectedValues()[0] || null;
     }
 
     private getSelectedValues(): string[] {
@@ -221,7 +221,7 @@ export class VlSelectRichComponent extends FormControl {
         );
     }
 
-    private collectFormData(): FormData | string {
+    private collectFormData(): FormData | FormValue {
         const name = this.name || this.id;
         const selectedValues = this.getSelectedValues();
         return selectedValues?.length
@@ -229,7 +229,7 @@ export class VlSelectRichComponent extends FormControl {
                   currentIndex ? formData.append(name, string) : formData.set(name, string);
                   return formData;
               }, new FormData())
-            : '';
+            : null;
     }
 
     private getChoicesElement(): HTMLElement | null {

--- a/libs/form/src/next/select/vl-select.component.cy.ts
+++ b/libs/form/src/next/select/vl-select.component.cy.ts
@@ -155,7 +155,7 @@ describe('component - vl-select-next', () => {
         cy.get('@vl-select')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
-            .should('deep.equal', { value: '' });
+            .should('deep.equal', { value: null });
         cy.checkA11y('vl-select-next');
     });
 

--- a/libs/form/src/next/select/vl-select.component.ts
+++ b/libs/form/src/next/select/vl-select.component.ts
@@ -37,7 +37,7 @@ export class VlSelectComponent extends FormControl {
     private notDeletable = selectDefaults.notDeletable;
 
     // State
-    private value = '';
+    private value: string | null = null;
 
     // Variables
     private initialOptions = [] as SelectOption[];
@@ -63,7 +63,7 @@ export class VlSelectComponent extends FormControl {
         super.connectedCallback();
 
         const selectedOption = this.getSelectedOption();
-        this.value = selectedOption?.value || '';
+        this.value = selectedOption?.value ?? null;
         this.initialOptions = JSON.parse(JSON.stringify(this.options));
     }
 
@@ -72,7 +72,7 @@ export class VlSelectComponent extends FormControl {
 
         if (changedProperties.has('options')) {
             const selectedOption = this.getSelectedOption();
-            this.value = selectedOption?.value || '';
+            this.value = selectedOption?.value ?? null;
         }
 
         if (changedProperties.has('value')) {
@@ -96,7 +96,7 @@ export class VlSelectComponent extends FormControl {
             'vl-select--success': this.success,
             'vl-select--block': this.block,
         };
-        const hasValue = this.value !== '';
+        const hasValue = this.value !== null;
         const hasGroups = this.options.some((option) => option.group);
 
         return html`
@@ -176,7 +176,7 @@ export class VlSelectComponent extends FormControl {
     }
 
     private clearValue() {
-        this.value = '';
+        this.value = null;
     }
 
     private getSelectedOption(): SelectOption | undefined {

--- a/libs/form/src/next/upload/vl-upload.component.cy.ts
+++ b/libs/form/src/next/upload/vl-upload.component.cy.ts
@@ -217,12 +217,7 @@ describe('component - vl-upload-next', () => {
                 force: true,
             });
         // voor elk individueel bestand wordt er een vl-input event getriggerd van type `addedfile`
-        cy.get('@vl-input')
-            .its('callCount')
-            .should('eq', 4) // 4 addedFile events
-            .then((ddd) => {
-                console.log(ddd);
-            });
+        cy.get('@vl-input').its('callCount').should('eq', 4); // 4 addedFile events
     });
 
     it('should not upload by default when selecting a file to upload', () => {

--- a/libs/form/src/next/upload/vl-upload.component.ts
+++ b/libs/form/src/next/upload/vl-upload.component.ts
@@ -60,7 +60,7 @@ export class VlUploadComponent extends FormControl {
     private url = uploadDefaults.url;
 
     // State
-    private value: FormValue = '';
+    private value: FormValue = null;
     private multiple = false;
 
     // Variables
@@ -101,7 +101,7 @@ export class VlUploadComponent extends FormControl {
         super.updated(changedProperties);
 
         if (changedProperties.has('value')) {
-            this.setValue(this.value ?? '');
+            this.setValue(this.value);
         }
 
         if (changedProperties.has('disabled')) {
@@ -492,14 +492,14 @@ export class VlUploadComponent extends FormControl {
      * functie om FormData object te verzamelen op basis van de lijst met huidige bestanden
      * @private
      */
-    private collectFormData(): FormData | string {
+    private collectFormData(): FormData | FormValue {
         const name = this.name || this.id;
         return this.getFiles()?.length
             ? this.getFiles().reduce((formData: FormData, file, currentIndex) => {
                   currentIndex ? formData.append(name, file, file.name) : formData.set(name, file, file.name);
                   return formData;
               }, new FormData())
-            : '';
+            : null;
     }
 
     private handleAddedFile = async (file: DropzoneFile): Promise<void> => {

--- a/libs/form/src/utils/form.util.ts
+++ b/libs/form/src/utils/form.util.ts
@@ -4,8 +4,11 @@ import { FormControl } from '../next/form-control';
  * Haalt de form data op van een form element en zet deze om naar een object.
  * Als een form control meerdere waarden kan hebben, dan wordt deze omgezet naar een array van waarden.
  * @param formElement
- * // multiFormControlNames: een array van form control names waarvoor een array van waarden moet worden aangemaakt
- * // optioneel, als deze parameter niet wordt meegegeven, dan wordt er gezocht naar alle form controls die meerdere waarden kunnen hebben
+ * multiFormControlNames: een array van form control names waarvoor een array van waarden moet worden aangemaakt
+ * optioneel, als deze parameter niet wordt meegegeven, dan wordt er gezocht naar alle form controls die meerdere waarden kunnen hebben
+ * meer specifiek, form controls waarvan:
+ *  - het name attribuut meerdere keren voorkomt
+ *  - het multiple attribuut aanwezig is
  * @param multiFormControlNames
  */
 export const parseFormData = <T = { [key: string]: FormDataEntryValue[] | File | string }>(
@@ -16,24 +19,26 @@ export const parseFormData = <T = { [key: string]: FormDataEntryValue[] | File |
         return;
     }
     const data = new FormData(formElement);
+    const isValidFormInterface = (element: Element) =>
+        element instanceof FormControl ||
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLSelectElement ||
+        element instanceof HTMLTextAreaElement;
     // alle form controls die een array van waarden moeten geven
-    const allMultiFormControlKeys = multiFormControlNames
+    // Form controls met dezelfde name attribuut worden samengevoegd in een array
+    const duplicateNames = Array.from(data.keys()).filter((key) => data.getAll(key).length > 1);
+    const multipleFormControlKeys = Array.from(formElement.querySelectorAll('*'))
+        .filter((element) => isValidFormInterface(element) && element.hasAttribute('multiple'))
+        .map((el) => el.getAttribute('name'));
+    const multipleValueFormControls = multiFormControlNames
         ? multiFormControlNames
-        : Array.from(formElement.querySelectorAll('*'))
-              .filter((element) => element instanceof FormControl && element.hasAttribute('multiple'))
-              .map((el) => el.getAttribute('name'));
+        : Array.from(new Set([...duplicateNames, ...multipleFormControlKeys]));
     // als de form data voor een bepaalde key meerdere waarden bevat, dan wordt deze key in de data map vervangen door een array van waarden
-    return Array.from(data.keys()).reduce((result, key) => {
-        if (allMultiFormControlKeys.includes(key)) {
-            const allValuesForKey = data.getAll(key);
-            if (allValuesForKey.length === 1 && allValuesForKey[0] === '') {
-                // native FormData.getAll() geeft een array terug met een lege string als de key niet gevonden wordt
-                // in dit geval moet de key in de data map vervangen worden door een lege array
-                return { ...result, [key]: [] };
-            }
-            return { ...result, [key]: allValuesForKey };
-        } else {
-            return { ...result, [key]: data.get(key) };
-        }
-    }, {});
+    return Array.from(data.keys()).reduce(
+        (result, key) => ({
+            ...result,
+            [key]: multipleValueFormControls.includes(key) ? data.getAll(key) : data.get(key),
+        }),
+        {}
+    );
 };

--- a/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
+++ b/libs/integration/src/form/demo/vl-form-demo.component.cy.ts
@@ -112,21 +112,48 @@ describe('integration - form demo', () => {
         fillInForm();
         getResetButton().click('bottomLeft'); // Hack om click te triggeren op de button, anders werd de click getriggered op de vl-button-next tag.
         getNaamInput().find('input').should('have.value', '');
+        getNaamInput({ shadow: false }).runTest((component) => {
+            // @ts-ignore access private property
+            expect(component.value).to.be.empty;
+        });
         getRrnInput().find('input#rrn').should('have.value', '');
+        getRrnInput({ shadow: false }).runTest((component) => {
+            // @ts-ignore access private property
+            expect(component.value).to.be.empty;
+        });
         getGeboortedatumDatepicker().find('input#geboortedatum').should('have.value', '');
         getGeboortePlaatsSelectRich().find('select').find('option[value="hasselt"]').should('not.exist');
         getHobbiesSelectRich().find('select').find('option[value="padel"]').should('not.exist');
         getHobbiesSelectRich().find('select').find('option[value="dans"]').should('not.exist');
+        getHobbiesSelectRich({ shadow: false }).runTest((component) => {
+            // @ts-ignore access private property
+            expect(component.value).to.be.null;
+        });
         getKinderenSelect().find('select').find('option[value="0"]').should('not.have.attr', 'selected');
         getInteressesTextarea().find('textarea').should('have.value', '');
         getLeeftijdInput().find('input').should('have.value', '');
+        getLeeftijdInput({ shadow: false }).runTest((component) => {
+            // @ts-ignore access private property
+            expect(component.value).to.be.empty;
+        });
         getContactMethodeRadioGroup({ shadow: false })
             .find('vl-radio-next')
             .shadow()
             .find('input[value="telefoon"]')
             .should('not.be.checked');
-        getFotosUpload().find('input[type="file"]').should('have.value', '');
+        getContactMethodeRadioGroup({ shadow: false }).runTest((radioGroup) => {
+            // @ts-ignore access private property
+            expect(radioGroup.value).to.be.null;
+        });
+        getFotosUpload({ shadow: false }).runTest((upload) => {
+            // @ts-ignore access private property
+            expect(upload.value).to.be.null;
+        });
         getWaarheidsGetrouwCheckbox().find('input').should('not.be.checked');
+        getWaarheidsGetrouwCheckbox({ shadow: false }).runTest((component) => {
+            // @ts-ignore access private property
+            expect(component.value).to.be.null;
+        });
     });
 
     it('should submit form', () => {
@@ -196,15 +223,8 @@ describe('integration - form demo', () => {
         const submittedFormData = {
             naam: '',
             rrn: '',
-            geboortedatum: '',
-            geboorteplaats: '',
-            hobbies: [],
-            kinderen: '',
             interesses: '',
             leeftijd: '',
-            contactmethode: '',
-            foto: [],
-            waarheidsgetrouw: '',
         };
 
         cy.mount(html`<vl-form-demo></vl-form-demo>`);


### PR DESCRIPTION
Vroeger stelde wij voor alle values standaard een lege string in, nu stellen we waar voor form controls zonder tekstinvoer null in, gelijkaardig aan native gedrag.
Storybook & cypress testen verbeterd.
FormData helper functie bijgewerkt.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3018)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC365)