### PR TITLE
fix: UIG-3008 - storybook - list style verwijderd in canvas tab

### DIFF
--- a/apps/storybook/.storybook/styles.css
+++ b/apps/storybook/.storybook/styles.css
@@ -3,18 +3,18 @@ ol, ul {
 }
 
 ol {
-    list-style-type: decimal !important; 
+    list-style-type: decimal !important;
 }
 
 strong {
     font-weight: bold !important;
 }
 
-.sb-story {
+.sb-story, #storybook-root {
     ol, ul {
         list-style: none !important;
     }
-    
+
     strong {
         font-weight: 500 !important;
     }


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3008)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC371)