### PR TITLE
fix: UIG-3021 - vl-textarea-rich-next - tinymce editor afbraak verbeterd

### DIFF
--- a/libs/form/src/next/textarea-rich/vl-textarea-rich.component.ts
+++ b/libs/form/src/next/textarea-rich/vl-textarea-rich.component.ts
@@ -90,6 +90,7 @@ export class VlTextareaRichComponent extends VlTextareaComponent {
     disconnectedCallback() {
         super.disconnectedCallback();
 
+        this.editor?.mode?.set('readonly');
         this.editor?.destroy();
     }
 


### PR DESCRIPTION
Vroeger gaf afbraak van de tinymce editor in FireFox de foutmelding "Node cannot be null or undefined" en kon de tinymce instantie ook niet meer opnieuw geïnitialiseerd worden. Nu komt deze fout niet meer voor nadat we de editor eerst op readonly zetten.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3021)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC376)