### PR TITLE
fix: UIG-3024 - vl-side-sheet - werking open-attribuut gestroomlijnd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/side-sheet/vl-side-sheet.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/side-sheet/vl-side-sheet.stories.cy.ts
@@ -1,189 +1,20 @@
-import { transformStringToArgument } from '../../../support/utils';
+const sideSheetDefaultUrl =
+    'http://localhost:8080/iframe.html?id=components-side-sheet--side-sheet-default&viewMode=story';
+const sideSheetToggleUrl =
+    'http://localhost:8080/iframe.html?id=components-side-sheet--side-sheet-toggle&viewMode=story';
 
-const sideSheetUrl = 'http://localhost:8080/iframe.html?id=components-side-sheet--side-sheet-default&viewMode=story';
+describe('story - vl-side-sheet - default', () => {
+    it('should render', () => {
+        cy.visit(sideSheetDefaultUrl);
 
-const shouldClickToggleButton = () => {
-    cy.get('vl-side-sheet').shadow().find('vl-toggle-button').shadow().find('button').click({ force: true });
-};
-
-const shouldBeOpen = () => {
-    cy.get('vl-side-sheet').should('have.attr', 'data-vl-open');
-    cy.get('vl-side-sheet')
-        .shadow()
-        .find('div#vl-side-sheet')
-        .shouldHaveComputedStyle({ style: 'display', value: 'block' });
-};
-
-const shouldBeClosed = () => {
-    cy.get('vl-side-sheet').should('not.have.attr', 'data-vl-open');
-    cy.get('vl-side-sheet')
-        .shadow()
-        .find('div#vl-side-sheet')
-        .shouldHaveComputedStyle({ style: 'display', value: 'none' });
-};
-
-const shouldHaveIcon = (iconName: string) => {
-    cy.get('vl-side-sheet')
-        .shadow()
-        .find('vl-toggle-button')
-        .shadow()
-        .find('button')
-        .find('span[is=vl-icon]')
-        .should('have.class', `vl-vi-${iconName}`);
-};
-
-describe('story - vl-side-sheet default', () => {
-    it('should be accessible', () => {
-        cy.visitWithA11y(sideSheetUrl);
-
-        cy.get('vl-side-sheet');
-        cy.checkA11y('vl-side-sheet');
+        cy.get('vl-side-sheet').shadow().find('#vl-side-sheet');
     });
+});
 
-    it('should open and close the side-sheet', () => {
-        cy.visit(`${sideSheetUrl}`);
+describe('story - vl-side-sheet - toggle', () => {
+    it('should render', () => {
+        cy.visit(sideSheetToggleUrl);
 
-        shouldBeClosed();
-        shouldClickToggleButton();
-        shouldBeOpen();
-        shouldClickToggleButton();
-        shouldBeClosed();
-    });
-
-    it('should contain the expected data', () => {
-        cy.visit(`${sideSheetUrl}`);
-
-        cy.get('vl-side-sheet')
-            .shadow()
-            .find('slot')
-            .within((slot) => {
-                const slotContent = (slot[0] as any).assignedNodes();
-                expect(slotContent[1].innerHTML).to.contain('Lorem ipsum dolor sit amet,');
-            });
-    });
-
-    it('should not contain toggle text by default', () => {
-        cy.visit(sideSheetUrl);
-
-        cy.get('vl-side-sheet')
-            .shadow()
-            .find('vl-toggle-button')
-            .find('span#vl-side-sheet-toggle-text')
-            .should('not.contain.text');
-    });
-
-    it('should contain toggle text if set', () => {
-        const toggleText = 'text on toggle button';
-        cy.visit(`${sideSheetUrl.concat(`&args=toggleText:${transformStringToArgument(toggleText)}`)}`);
-
-        cy.get('vl-side-sheet')
-            .shadow()
-            .find('vl-toggle-button')
-            .find('span#vl-side-sheet-toggle-text')
-            .contains(toggleText);
-    });
-
-    it('should not be absolutely positioned by default', () => {
-        cy.visit(sideSheetUrl);
-
-        cy.get('vl-side-sheet')
-            .shouldHaveComputedStyle({ style: 'position', value: 'absolute', not: true })
-            .should('not.have.class', 'vl-side-sheet--absolute');
-    });
-
-    it('should be absolutely positioned', () => {
-        cy.visit(`${sideSheetUrl.concat('&args=absolute:true')}`);
-
-        cy.get('vl-side-sheet')
-            .shouldHaveComputedStyle({ style: 'position', value: 'absolute' })
-            .should('have.class', 'vl-side-sheet--absolute');
-    });
-
-    it('should not contain a tooltip by default', () => {
-        cy.visit(sideSheetUrl);
-
-        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('not.have.attr', 'title');
-    });
-
-    it('should contain a custom tooltip', () => {
-        const toolTipText = 'text on native tooltip';
-        cy.visit(`${sideSheetUrl.concat(`&args=tooltipText:${transformStringToArgument(toolTipText)}`)}`);
-
-        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('have.attr', 'title', toolTipText);
-    });
-
-    it('should be right by default & change default icon direction when opening or closing', () => {
-        cy.visit(`${sideSheetUrl}`);
-
-        cy.get('vl-side-sheet').shouldHaveComputedStyle({ style: 'right', value: '0px' });
-        shouldHaveIcon('nav-left');
-        shouldClickToggleButton();
-        shouldHaveIcon('nav-right');
-        shouldClickToggleButton();
-        shouldHaveIcon('nav-left');
-    });
-
-    it('should be left & change icon direction when opening or closing', () => {
-        cy.visit(`${sideSheetUrl.concat(`&args=left:true`)}`);
-
-        cy.get('vl-side-sheet').shouldHaveComputedStyle({ style: 'left', value: '0px' });
-        shouldHaveIcon('nav-right');
-        shouldClickToggleButton();
-        shouldHaveIcon('nav-left');
-        shouldClickToggleButton();
-        shouldHaveIcon('nav-right');
-    });
-
-    it('should have a custom icon & remain the same when opening or closing', () => {
-        const customIcon = 'list-add';
-        cy.visit(`${sideSheetUrl.concat(`&args=customIcon:${customIcon}`)}`);
-
-        shouldHaveIcon(customIcon);
-        shouldClickToggleButton();
-        shouldHaveIcon(customIcon);
-        shouldClickToggleButton();
-        shouldHaveIcon(customIcon);
-    });
-
-    it('should hide toggle button', () => {
-        cy.visit(`${sideSheetUrl}&args=hideToggleButton:true`);
-
-        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('have.class', 'vl-u-visually-hidden');
-    });
-
-    it('should open and close the side-sheet when toggle button is hidden', () => {
-        cy.visit(`${sideSheetUrl}&args=hideToggleButton:true`);
-
-        shouldBeClosed();
-        shouldClickToggleButton();
-        shouldBeOpen();
-        shouldClickToggleButton();
-        shouldBeClosed();
-    });
-
-    it('should place icon before the text by default', () => {
-        cy.visit(`${sideSheetUrl}&args=toggleText:toggle-side-sheet`);
-
-        cy.get('vl-side-sheet')
-            .shadow()
-            .find('vl-toggle-button')
-            .shadow()
-            .find('button.vl-button')
-            .children()
-            .first()
-            .should('have.class', 'vl-icon');
-    });
-
-    it('should place icon behind the text ', () => {
-        cy.visit(`${sideSheetUrl}&args=iconPlacement:after;toggleText:toggle-side-sheet`);
-
-        cy.get('vl-side-sheet')
-            .shadow()
-            .find('vl-toggle-button')
-            .shadow()
-            .find('button.vl-button')
-            .children()
-            .last()
-            .should('have.class', 'vl-icon');
+        cy.get('vl-side-sheet').shadow().find('#vl-side-sheet');
     });
 });

--- a/apps/storybook-e2e/src/e2e/map/map-side-sheet/vl-map-side-sheet.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/map-side-sheet/vl-map-side-sheet.stories.cy.ts
@@ -1,0 +1,10 @@
+const mapSideSheetDefaultUrl =
+    'http://localhost:8080/iframe.html?id=map-side-sheet--map-side-sheet-default&viewMode=story';
+
+describe('story - vl-map-side-sheet - default', () => {
+    it('should render', () => {
+        cy.visit(mapSideSheetDefaultUrl);
+
+        cy.get('vl-map-side-sheet').shadow().find('#vl-side-sheet');
+    });
+});

--- a/libs/components/src/side-sheet/stories/vl-side-sheet.stories-arg.ts
+++ b/libs/components/src/side-sheet/stories/vl-side-sheet.stories-arg.ts
@@ -10,6 +10,7 @@ export const sideSheetArgs = {
     iconPlacement: 'before',
     left: false,
     right: false,
+    open: false,
     toggleText: '',
     tooltipText: '',
 };
@@ -46,6 +47,14 @@ export const sideSheetArgTypes: ArgTypes<typeof sideSheetArgs> = {
         table: {
             type: { summary: TYPES.BOOLEAN },
             defaultValue: { summary: sideSheetArgs.absolute },
+        },
+    },
+    open: {
+        name: 'data-vl-open',
+        description: 'Duidt aan dat de side-sheet open is.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: sideSheetArgs.open },
         },
     },
     toggleText: {

--- a/libs/components/src/side-sheet/stories/vl-side-sheet.stories.ts
+++ b/libs/components/src/side-sheet/stories/vl-side-sheet.stories.ts
@@ -31,6 +31,7 @@ export const SideSheetDefault = story(
         customIcon,
         hideToggleButton,
         iconPlacement,
+        open,
     }) => html`
         <vl-side-sheet
             ?data-vl-enable-swipe=${enableSwipe}
@@ -42,6 +43,7 @@ export const SideSheetDefault = story(
             data-vl-custom-icon=${customIcon}
             data-vl-icon-placement=${iconPlacement}
             ?data-vl-hide-toggle-button=${hideToggleButton}
+            ?data-vl-open=${open}
         >
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum urna ante. Integer eu sem
@@ -94,7 +96,18 @@ SideSheetDefault.storyName = 'vl-side-sheet - default';
 
 export const SideSheetToggle = story(
     sideSheetArgs,
-    ({ enableSwipe, absolute, left, toggleText, tooltipText, right, customIcon, hideToggleButton, iconPlacement }) => {
+    ({
+        enableSwipe,
+        absolute,
+        left,
+        toggleText,
+        tooltipText,
+        right,
+        customIcon,
+        hideToggleButton,
+        iconPlacement,
+        open,
+    }) => {
         const { toggleSideSheet, openSideSheet, closeSideSheet } = sideSheetToggleImplementation();
         return html`
             <style>
@@ -147,6 +160,7 @@ export const SideSheetToggle = story(
                 data-vl-custom-icon=${customIcon}
                 data-vl-icon-placement=${iconPlacement}
                 ?data-vl-hide-toggle-button=${hideToggleButton}
+                ?data-vl-open=${open}
             >
                 <button
                     is="vl-button"

--- a/libs/components/src/side-sheet/vl-side-sheet.component.cy.ts
+++ b/libs/components/src/side-sheet/vl-side-sheet.component.cy.ts
@@ -1,0 +1,286 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlSideSheet } from './vl-side-sheet.component';
+
+registerWebComponents([VlSideSheet]);
+
+describe('vl-spotlight', () => {
+    it('should be accessible', () => {
+        mountDefault({});
+        cy.injectAxe();
+
+        cy.get('vl-side-sheet');
+        cy.checkA11y('vl-side-sheet');
+    });
+
+    it('should open and close the side-sheet', () => {
+        mountDefault({});
+
+        shouldBeClosed();
+        shouldClickToggleButton();
+        shouldBeOpen();
+        shouldClickToggleButton();
+        shouldBeClosed();
+    });
+
+    it('should open and close the side-sheet using open attribute', () => {
+        mountDefault({});
+
+        shouldBeClosed();
+        cy.get('vl-side-sheet').invoke('attr', 'data-vl-open', 'true');
+        shouldBeOpen();
+        cy.get('vl-side-sheet').invoke('removeAttr', 'data-vl-open');
+        shouldBeClosed();
+    });
+
+    it('should contain the expected data', () => {
+        mountDefault({});
+
+        cy.get('vl-side-sheet')
+            .shadow()
+            .find('slot')
+            .within((slot) => {
+                const slotContent = (slot[0] as any).assignedNodes();
+                expect(slotContent[1].innerHTML).to.contain('Lorem ipsum dolor sit amet,');
+            });
+    });
+
+    it('should not contain toggle text by default', () => {
+        mountDefault({});
+
+        cy.get('vl-side-sheet')
+            .shadow()
+            .find('vl-toggle-button')
+            .find('span#vl-side-sheet-toggle-text')
+            .should('not.contain.text');
+    });
+
+    it('should contain toggle text if set', () => {
+        const toggleText = 'text on toggle button';
+        mountDefault({ toggleText });
+
+        cy.get('vl-side-sheet')
+            .shadow()
+            .find('vl-toggle-button')
+            .find('span#vl-side-sheet-toggle-text')
+            .contains(toggleText);
+    });
+
+    it('should not be absolutely positioned by default', () => {
+        mountDefault({});
+
+        cy.get('vl-side-sheet')
+            .shouldHaveComputedStyle({ style: 'position', value: 'absolute', not: true })
+            .should('not.have.class', 'vl-side-sheet--absolute');
+    });
+
+    it('should be absolutely positioned', () => {
+        mountDefault({ absolute: true });
+
+        cy.get('vl-side-sheet')
+            .shouldHaveComputedStyle({ style: 'position', value: 'absolute' })
+            .should('have.class', 'vl-side-sheet--absolute');
+    });
+
+    it('should not contain a tooltip by default', () => {
+        mountDefault({});
+
+        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('not.have.attr', 'title');
+    });
+
+    it('should contain a custom tooltip', () => {
+        const tooltipText = 'text on native tooltip';
+        mountDefault({ tooltipText: tooltipText });
+
+        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('have.attr', 'title', tooltipText);
+    });
+
+    it('should be right by default & change default icon direction when opening or closing', () => {
+        mountDefault({});
+
+        cy.get('vl-side-sheet').shouldHaveComputedStyle({ style: 'right', value: '0px' });
+        shouldHaveIcon('nav-left');
+        shouldClickToggleButton();
+        shouldHaveIcon('nav-right');
+        shouldClickToggleButton();
+        shouldHaveIcon('nav-left');
+    });
+
+    it('should be left & change icon direction when opening or closing', () => {
+        mountDefault({ left: true });
+
+        cy.get('vl-side-sheet').shouldHaveComputedStyle({ style: 'left', value: '0px' });
+        shouldHaveIcon('nav-right');
+        shouldClickToggleButton();
+        shouldHaveIcon('nav-left');
+        shouldClickToggleButton();
+        shouldHaveIcon('nav-right');
+    });
+
+    it('should have a custom icon & remain the same when opening or closing', () => {
+        const customIcon = 'list-add';
+        mountDefault({ customIcon });
+
+        shouldHaveIcon(customIcon);
+        shouldClickToggleButton();
+        shouldHaveIcon(customIcon);
+        shouldClickToggleButton();
+        shouldHaveIcon(customIcon);
+    });
+
+    it('should hide toggle button', () => {
+        mountDefault({ hideToggleButton: true });
+
+        cy.get('vl-side-sheet').shadow().find('vl-toggle-button').should('have.class', 'vl-u-visually-hidden');
+    });
+
+    it('should open and close the side-sheet when toggle button is hidden', () => {
+        mountDefault({ hideToggleButton: true });
+
+        shouldBeClosed();
+        shouldClickToggleButton();
+        shouldBeOpen();
+        shouldClickToggleButton();
+        shouldBeClosed();
+    });
+
+    it('should place icon before the text by default', () => {
+        mountDefault({ toggleText: 'toggle-side-sheet' });
+
+        cy.get('vl-side-sheet')
+            .shadow()
+            .find('vl-toggle-button')
+            .shadow()
+            .find('button.vl-button')
+            .children()
+            .first()
+            .should('have.class', 'vl-icon');
+    });
+
+    it('should place icon behind the text ', () => {
+        mountDefault({ iconPlacement: 'after', toggleText: 'toggle-side-sheet' });
+
+        cy.get('vl-side-sheet')
+            .shadow()
+            .find('vl-toggle-button')
+            .shadow()
+            .find('button.vl-button')
+            .children()
+            .last()
+            .should('have.class', 'vl-icon');
+    });
+});
+
+const shouldClickToggleButton = () => {
+    cy.get('vl-side-sheet').shadow().find('vl-toggle-button').shadow().find('button').click({ force: true });
+};
+
+const shouldBeOpen = () => {
+    cy.get('vl-side-sheet').should('have.attr', 'data-vl-open');
+    cy.get('vl-side-sheet')
+        .shadow()
+        .find('div#vl-side-sheet')
+        .shouldHaveComputedStyle({ style: 'display', value: 'block' });
+};
+
+const shouldBeClosed = () => {
+    cy.get('vl-side-sheet').should('not.have.attr', 'data-vl-open');
+    cy.get('vl-side-sheet')
+        .shadow()
+        .find('div#vl-side-sheet')
+        .shouldHaveComputedStyle({ style: 'display', value: 'none' });
+};
+
+const shouldHaveIcon = (iconName: string) => {
+    cy.get('vl-side-sheet')
+        .shadow()
+        .find('vl-toggle-button')
+        .shadow()
+        .find('button')
+        .find('span[is=vl-icon]')
+        .should('have.class', `vl-vi-${iconName}`);
+};
+
+const mountDefault = ({
+    enableSwipe,
+    absolute,
+    left,
+    toggleText,
+    tooltipText,
+    right,
+    customIcon,
+    hideToggleButton,
+    iconPlacement = 'before',
+    open,
+}: {
+    enableSwipe?: boolean;
+    absolute?: boolean;
+    left?: boolean;
+    toggleText?: string;
+    tooltipText?: string;
+    right?: boolean;
+    customIcon?: string;
+    hideToggleButton?: boolean;
+    open?: boolean;
+    iconPlacement?: string;
+}) => {
+    cy.mount(html`
+        <vl-side-sheet
+            ?data-vl-enable-swipe=${enableSwipe}
+            ?data-vl-absolute=${absolute}
+            ?data-vl-left=${left}
+            ?data-vl-right=${right}
+            data-vl-toggle-text=${toggleText}
+            data-vl-tooltip-text=${tooltipText}
+            data-vl-custom-icon=${customIcon}
+            data-vl-icon-placement=${iconPlacement}
+            ?data-vl-hide-toggle-button=${hideToggleButton}
+            ?data-vl-open=${open}
+        >
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla interdum urna ante. Integer eu sem
+                mollis, ornare libero nec, pulvinar augue. Nunc ac rhoncus ipsum. Mauris vitae elementum erat. Donec
+                gravida hendrerit magna, quis feugiat felis sodales quis. Sed tempor ornare elit, non aliquam urna
+                maximus imperdiet. Suspendisse finibus ullamcorper dictum. Sed vehicula tortor quis dignissim tincidunt.
+                Maecenas turpis ante, blandit sed efficitur eu, varius vitae nibh. Vivamus porttitor mi in massa
+                elementum sollicitudin. Cras id porta nisi, vel pulvinar neque. Mauris sodales mi sem, sit amet
+                fringilla tellus ultrices et. Quisque sed interdum mauris. Suspendisse rutrum maximus ornare. Morbi sed
+                vestibulum magna, a tincidunt mi. Aliquam in imperdiet diam.
+            </p>
+            <p>
+                Nulla mattis eget mi at mattis. Donec ut nisi ipsum. Sed placerat, augue vel dapibus blandit, nulla
+                purus hendrerit orci, ut maximus ligula quam at sapien. Nunc efficitur augue est, ac laoreet libero
+                blandit in. Aliquam non sagittis libero. Fusce posuere magna venenatis, facilisis magna quis, dictum
+                risus. In nulla augue, efficitur congue porta sit amet, convallis eu justo. Etiam facilisis maximus
+                dolor, a scelerisque sapien fringilla non. Quisque vestibulum mauris erat, vel ultrices massa dictum sit
+                amet. Integer nec bibendum arcu, sit amet pretium turpis.
+            </p>
+            <p>
+                Vivamus ligula diam, lobortis eget ultricies vitae, varius id arcu. Sed id mauris sed augue ultricies
+                luctus. Donec pulvinar a sapien quis posuere. Suspendisse non varius dui. Nullam eu posuere neque.
+                Vivamus eget felis turpis. Curabitur tortor ante, vulputate vel quam ut, posuere mattis ipsum. Maecenas
+                vel metus tortor. Quisque id turpis est. Donec est eros, laoreet vel metus id, tempor pulvinar eros. Nam
+                sed semper eros. Aenean placerat tellus ex, ac ultricies dui ornare ac. Suspendisse eget semper risus.
+                Nullam eleifend leo justo, eu rhoncus erat lacinia quis. Nam finibus nunc sit amet justo interdum
+                dignissim.
+            </p>
+            <p>
+                Donec iaculis purus leo. Aliquam pulvinar magna vitae dolor varius auctor. Sed dapibus convallis est,
+                non pharetra felis eleifend nec. Donec erat ex, tempus in sem quis, imperdiet gravida justo. Morbi sem
+                purus, efficitur eget massa ut, molestie placerat orci. Phasellus sollicitudin convallis augue, ut
+                tincidunt nulla faucibus ut. Praesent ullamcorper erat sit amet nisi venenatis eleifend. Vestibulum
+                vehicula tristique ipsum, vel placerat tortor maximus eu. Phasellus mauris purus, semper vulputate
+                maximus sit amet, faucibus eget risus. Sed in imperdiet dui, vel suscipit nibh. Nunc ac lectus tempus,
+                venenatis mauris non, ornare nunc. Cras at nibh nec sem vestibulum facilisis. Curabitur et elit
+                hendrerit, ullamcorper nibh vitae, eleifend augue. Aliquam imperdiet eros quis pulvinar suscipit.
+            </p>
+            <p>
+                In dapibus, est eu eleifend vehicula, purus arcu consequat nulla, accumsan viverra mi massa vel metus.
+                Vestibulum ut nunc viverra, pellentesque urna et, consectetur metus. Quisque bibendum diam non eros
+                porta, non volutpat leo commodo. Morbi odio nulla, tempus non lobortis ac, imperdiet vitae sem. Class
+                aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Fusce ac sodales
+                eros. In hac habitasse platea dictumst.
+            </p>
+        </vl-side-sheet>
+    `);
+};

--- a/libs/components/src/side-sheet/vl-side-sheet.component.ts
+++ b/libs/components/src/side-sheet/vl-side-sheet.component.ts
@@ -53,6 +53,7 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
             'hide-toggle-button',
             'icon-position',
             'custom-size',
+            'open',
         ];
     }
 
@@ -172,6 +173,9 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
      */
     open() {
         this.setAttribute('data-vl-open', '');
+    }
+
+    _handleOnOpen() {
         this._toggleButton.setAttribute('aria-expanded', 'true');
         let openIcon: string;
         if (!this.customIcon) {
@@ -189,6 +193,10 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
      */
     close() {
         this.removeAttribute('data-vl-open');
+        this._handleOnClose();
+    }
+
+    _handleOnClose() {
         this._toggleButton.setAttribute('aria-expanded', 'false');
         let closeIcon: string;
         if (!this.customIcon) {
@@ -202,6 +210,7 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
         }
     }
 
+    // TODO storybook documentatie
     /**
      * De callback wordt uitgevoerd direct na de afsluiten van een side sheet.
      *
@@ -245,6 +254,14 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
         }
     }
 
+    _openChangedCallback() {
+        if (this.isOpen) {
+            this._handleOnOpen();
+        } else {
+            this._handleOnClose();
+        }
+    }
+
     updateToggleText(value: string): void {
         if (value && value !== '') {
             this._toggleButton.removeAttribute('data-vl-text-hidden');
@@ -259,7 +276,12 @@ export class VlSideSheet extends BaseElementOfType(HTMLElement) {
     }
 
     _tooltipTextChangedCallback(oldValue: any, newValue: any) {
-        this._toggleButton.title = newValue;
+        // we voegen de title toe aan de button behalve als de waarde null / undefined is
+        if (newValue ?? false) {
+            this._toggleButton?.setAttribute('title', newValue);
+        } else {
+            this._toggleButton?.removeAttribute('title');
+        }
     }
 
     _hideToggleButtonChangedCallback(oldValue: any, newValue: any) {


### PR DESCRIPTION
Vroeger werd de logica voor het openen en sluiten van de side-sheet enkel juist behandeld wanneer er op de toggle knop werd geklikt of de `open()` of `close()` functies werden aangeroepen, nu wordt diezelfde logica ook aangeroepen bij het handmatig verwijderen of instellen van het `open` attribuut. Storybook verbeterd.
Cypress testen gemigreerd & cypress testen toegevoegd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3024)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC377)