### PR TITLE
fix: UIG-3073 - vl-alert - actions en message slot rendering verbeterd

### DIFF
--- a/libs/common/utilities/src/index.ts
+++ b/libs/common/utilities/src/index.ts
@@ -27,6 +27,7 @@ export {
     ifDefinedNumber,
     findDeepestElementThroughShadowRoot,
     findNodesForSlot,
+    assignedNodesForSlot,
 } from './util/utils';
 export { onChildListChange } from './util/mutation-utils';
 export { buildSpan, buildDiv, buildLabel, buildData } from './util/html-element.builder';

--- a/libs/common/utilities/src/util/utils.ts
+++ b/libs/common/utilities/src/util/utils.ts
@@ -188,3 +188,8 @@ export const findDeepestElementThroughShadowRoot = (
 export const findNodesForSlot = (element: HTMLElement, slotName: string) => {
     return element?.querySelectorAll<Element>(`:scope > [slot=${slotName}]`);
 };
+
+export const assignedNodesForSlot = (element: HTMLElement, slotName?: string): Node[] | undefined =>
+    element?.shadowRoot
+        ?.querySelector<HTMLSlotElement>(slotName ? `slot[name="${slotName}"]` : `slot:not([name])`)
+        ?.assignedNodes();

--- a/libs/components/src/alert/vl-alert.component.ts
+++ b/libs/components/src/alert/vl-alert.component.ts
@@ -1,6 +1,6 @@
 import { html, PropertyDeclarations, TemplateResult, CSSResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { BaseLitElement } from '@domg-wc/common-utilities';
+import { assignedNodesForSlot, BaseLitElement } from '@domg-wc/common-utilities';
 import { alertStyle, iconStyle } from '@domg/govflanders-style/component';
 import { accessibilityStyle, resetStyle, markStyle } from '@domg/govflanders-style/common';
 import { VlAlertClosedEvent } from './vl-alert.model';
@@ -46,6 +46,7 @@ export class VlAlert extends BaseLitElement {
         };
 
         const markClass = this.naked ? `vl-u-mark--${this.type}` : '';
+        const hideEmptyActionsSlot = assignedNodesForSlot(this, 'actions')?.length ? '' : 'vl-u-visually-hidden';
 
         return html`
             <div id="alert" class=${classMap(classes)} role="alert">
@@ -61,8 +62,8 @@ export class VlAlert extends BaseLitElement {
                         <p class=${markClass}>${this.message}</p>
                         <slot id="message-slot"></slot>
                     </div>
-                    <div id="actions" class="vl-alert__actions">
-                        <slot id="actions-slot" name="actions"></slot>
+                    <div id="actions" class="vl-alert__actions ${hideEmptyActionsSlot}">
+                        <slot id="actions-slot" @slotchange=${this.requestUpdate} name="actions"></slot>
                     </div>
                 </div>
                 ${this.closable


### PR DESCRIPTION
Vroeger nam het element waarin de actions & message slots in gerenderd werden onnodig hoogte in, ook al werden die slots niet gebruikt. Nu worden deze elementen niet meer gerenderd als er geen slots voor gevonden worden.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3073)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC384)