### PR TITLE
feat: UIG-3057 - vl-wizard - numeric attribuut toegevoegd

### DIFF
--- a/libs/components/src/wizard/stories/vl-wizard.stories-arg.ts
+++ b/libs/components/src/wizard/stories/vl-wizard.stories-arg.ts
@@ -1,10 +1,11 @@
-import { CONTROLS, defaultArgs, defaultArgTypes } from '@domg-wc/common-storybook';
+import { CATEGORIES, CONTROLS, defaultArgs, defaultArgTypes, TYPES } from '@domg-wc/common-storybook';
 import { action } from '@storybook/addon-actions';
 
 export const wizardArgs = {
     ...defaultArgs,
     activeStep: 0,
     hideLabels: false,
+    numeric: false,
     title: '',
     header: '',
     onClickStep: action('vl-click-step'),
@@ -17,11 +18,9 @@ export const wizardArgTypes = {
         description: 'Zet de actieve stap.',
         control: { type: CONTROLS.RANGE, min: 1, max: 2, step: 1 },
         table: {
-            type: {
-                summary: 'Number',
-            },
-            category: 'Attributes',
-            defaultValue: { summary: 1 },
+            type: { summary: TYPES.NUMBER },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: wizardArgs.activeStep },
         },
     },
     hideLabels: {
@@ -29,29 +28,41 @@ export const wizardArgTypes = {
         description: 'Bepaalt of de labels van de stappen verborgen moeten worden.',
         control: { type: CONTROLS.BOOLEAN },
         table: {
-            type: {
-                summary: 'Boolean',
-            },
-            category: 'Attributes',
-            defaultValue: { summary: false },
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: wizardArgs.hideLabels },
+        },
+    },
+    numeric: {
+        name: 'data-vl-numeric',
+        description: 'Voorziet numerieke indicatoren bij de stappen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: wizardArgs.numeric },
         },
     },
     title: {
         description: 'Slot voor de titel.',
         table: {
-            category: 'Slots',
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: wizardArgs.title },
         },
     },
     header: {
         description: 'Slot voor de header.',
         table: {
-            category: 'Slots',
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: wizardArgs.header },
         },
     },
     onClickStep: {
         name: 'vl-click-step',
         description:
             'Afgevuurd wanneer er op een stap geklikt wordt. In het event wordt het nummer en de naam vermeld.',
-        table: { category: 'Events' },
+        table: {
+            category: CATEGORIES.EVENTS,
+            defaultValue: { summary: wizardArgs.onClickStep() },
+        },
     },
 };

--- a/libs/components/src/wizard/stories/vl-wizard.stories.ts
+++ b/libs/components/src/wizard/stories/vl-wizard.stories.ts
@@ -29,10 +29,13 @@ export default {
 
 export const WizardDefault = story(
     wizardArgs,
-    ({ activeStep, hideLabels, title, header, onClickStep }: typeof wizardArgs) => html` <div style="max-width: 780px;">
+    ({ activeStep, hideLabels, title, header, onClickStep, numeric }: typeof wizardArgs) => html` <div
+        style="max-width: 780px;"
+    >
         <vl-wizard
             data-vl-active-step=${activeStep}
             ?data-vl-hide-labels=${hideLabels}
+            ?data-vl-numeric=${numeric}
             @vl-click-step=${(event: VlClickStepEvent) => {
                 onClickStep(event.detail);
                 getWizard().activeStep = event.detail.number;

--- a/libs/components/src/wizard/vl-wizard.component.cy.ts
+++ b/libs/components/src/wizard/vl-wizard.component.cy.ts
@@ -9,19 +9,27 @@ type MountDefaultProps = {
     activeStep?: number;
     panes?: string[];
     hideLabels?: boolean;
+    numeric?: boolean;
 };
 
-const mountDefault = ({ activeStep, panes, hideLabels = false }: MountDefaultProps) => {
-    const paneElements = panes?.map((paneName) => {
-        const pane = document.createElement('vl-wizard-pane');
-        pane.setAttribute('data-vl-name', paneName);
-        pane.innerHTML = `<p>Wizard Pane Content (${paneName})</p>`;
-        return pane;
-    });
+const mountDefault = ({ activeStep, panes, hideLabels = false, numeric = false }: MountDefaultProps) => {
+    const paneElements = panes
+        ? panes.map((paneName) => {
+              return html`
+                  <vl-wizard-pane data-vl-name=${paneName}>
+                      <p>Wizard Pane Content (${paneName})</p>
+                  </vl-wizard-pane>
+              `;
+          })
+        : nothing;
 
     cy.mount(
         html`
-            <vl-wizard data-vl-active-step=${activeStep || nothing} ?data-vl-hide-labels=${hideLabels}>
+            <vl-wizard
+                data-vl-active-step=${activeStep || nothing}
+                ?data-vl-hide-labels=${hideLabels}
+                ?data-vl-numeric=${numeric}
+            >
                 ${paneElements}
             </vl-wizard>
         `
@@ -74,6 +82,15 @@ describe('component vl-wizard-pane - properties', () => {
             activeStep: 2,
         });
         cy.get('vl-wizard').find('vl-wizard-pane[data-vl-name="Step 2"]').contains('Wizard Pane Content (Step 2)');
+    });
+
+    it('should add numeric steps', () => {
+        mountDefault({ numeric: true, panes: ['Step 1', 'Step 2', 'Step 3'] });
+        cy.get('vl-wizard')
+            .shadow()
+            .find('vl-progress-bar')
+            .shadow()
+            .find('div.vl-progress-bar.vl-progress-bar--numeric');
     });
 
     it('should display the step labels by default', () => {

--- a/libs/components/src/wizard/vl-wizard.component.ts
+++ b/libs/components/src/wizard/vl-wizard.component.ts
@@ -12,6 +12,7 @@ export class VlWizard extends BaseLitElement {
     private activeStep: number;
     private panes: VlWizardPane[];
     private hideLabels: boolean;
+    private numeric = false;
 
     static {
         registerWebComponents([VlProgressBarComponent, VlWizardPane]);
@@ -30,6 +31,7 @@ export class VlWizard extends BaseLitElement {
                 reflect: true,
             },
             hideLabels: { type: Boolean, attribute: 'data-vl-hide-labels' },
+            numeric: { type: Boolean, attribute: 'data-vl-numeric' },
         };
     }
 
@@ -60,6 +62,7 @@ export class VlWizard extends BaseLitElement {
                 <vl-progress-bar
                     data-vl-active-step=${this.activeStep}
                     ?data-vl-show-labels=${!this.hideLabels}
+                    ?data-vl-numeric=${this.numeric}
                     .steps=${this.panes.map((pane) => pane.name)}
                 ></vl-progress-bar>
                 <div class="vl-wizard__panes">


### PR DESCRIPTION
Storybook verbeterd & cypress tests toegevoegd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3057)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC391)

Progress bar had al het `data-vl-numeric` attribuut. VlWizard gebruikt intern de `vl-progress-bar`. Bij deze ook gezorgd dat dit attribuut ook op `vl-wizard` kan gezet worden en doorgegeven wordt aan de `vl-progress-bar`.

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/14f14e1e-f825-4fb2-81d0-46daceb776b9">
