### PR TITLE
fix: UIG-3063 - vl-autocomplete - API-story bijgewerkt met huidige url

### DIFF
--- a/libs/components/src/autocomplete/stories/vl-autocomplete-api.stories-util.ts
+++ b/libs/components/src/autocomplete/stories/vl-autocomplete-api.stories-util.ts
@@ -1,6 +1,6 @@
 export async function fetchDataFromApiCall(autocomplete: any, searchTerm: any) {
     const result = await fetch(
-        `https://loc.geopunt.be/geolocation/suggestion?q=${searchTerm}&c=${autocomplete.maxSuggestions}`
+        `https://geo.api.vlaanderen.be/geolocation/suggestion?q=${searchTerm}&c=${autocomplete.maxSuggestions}`
     );
     const responseBody = await result.json();
     autocomplete.matches = responseBody.SuggestionResult.map((obj: string) => ({

--- a/libs/components/src/autocomplete/stories/vl-autocomplete.stories-doc.mdx
+++ b/libs/components/src/autocomplete/stories/vl-autocomplete.stories-doc.mdx
@@ -47,6 +47,8 @@ Zie het onderstaande code voorbeeld.
     <Source code={autocompleteApiImplementation} language="ts" dark={true} />
 </details>
 
+[Documentatie voor de Geolocation API](https://geo.api.vlaanderen.be/geolocation/)
+
 ### Voorbeeld met mocked API call
 
 Type "Drab" om een van de mocked resultaten te zien.
@@ -87,6 +89,7 @@ Je kan hiervoor ofwel:
 ### Digitaal Vlaanderen
 
 [Documentatie Digitaal Vlaanderen - Autocomplete](https://overheid.vlaanderen.be/webuniversum/v3/documentation/js-components/vl-ui-autocomplete)
+[Documentatie voor de Geolocation API](https://geo.api.vlaanderen.be/geolocation/)
 
 ### Legacy Documentatie
 


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3063)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC393)


<img width="1398" alt="image" src="https://github.com/user-attachments/assets/69f28857-8e6a-4d9c-8ae6-a8aa4e7e1e2f">
