### PR TITLE
feat: UIG-3053 - vl-functional-header - attribuut toegevoegd om sub-header te verbergen

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/functional-header/vl-functional-header.stories.cy.ts
@@ -9,350 +9,42 @@ const functionalHeaderBreadcrumbUrl =
 const functionalHeaderSlotsUrl =
     'http://localhost:8080/iframe.html?id=components-functional-header--functional-header-slots&viewMode=story';
 
-const shouldHaveDefaultBackText = () => {
-    cy.get('vl-functional-header').shadow().find('a#back-link').contains('Terug');
-};
-
-const shouldSetBackText = () => {
-    cy.get('vl-functional-header').shadow().find('a#back-link').contains('Keer terug');
-};
-
-const shouldHaveDefaultBackLink = () => {
-    cy.get('vl-functional-header').shadow().find('a#back-link').should('have.attr', 'href', '');
-};
-
-const shouldSetBackLink = () => {
-    cy.get('vl-functional-header').shadow().find('a#back-link').should('have.attr', 'href', 'test');
-};
-
-const shouldDisableBackLinkAndEmitEvent = () => {
-    cy.createStubForEvent('vl-functional-header', 'vl-click-back');
-    cy.get('vl-functional-header').shadow().find('a#back-link').click();
-    cy.get('@vl-click-back').should('have.been.calledOnce');
-};
-
-const shouldSetTitleLink = () => {
-    cy.get('vl-functional-header')
-        .shadow()
-        .find('.vl-functional-header__title')
-        .find('a')
-        .should('have.attr', 'href', 'test');
-};
-
-const shouldSetSubTitleText = () => {
-    cy.get('vl-functional-header')
-        .shadow()
-        .find('li.vl-functional-header__sub__action')
-        .contains('Voor lager onderwijs');
-};
-
-const shouldSetTitleText = () => {
-    cy.get('vl-functional-header')
-        .shadow()
-        .find('.vl-functional-header__title')
-        .find('a')
-        .contains('School en studietoelagen');
-};
-
-describe('story - vl-functional-header', () => {
-    it('should have default back text', () => {
+describe('story - vl-functional-header - default', () => {
+    it('should render', () => {
         cy.visit(functionalHeaderUrl);
 
-        shouldHaveDefaultBackText();
-    });
-
-    it('should set back text', () => {
-        cy.visit(`${functionalHeaderUrl}&args=back:Keer+terug`);
-
-        shouldSetBackText();
-    });
-
-    it('should have default back link', () => {
-        cy.visit(functionalHeaderUrl);
-
-        shouldHaveDefaultBackLink();
-    });
-
-    it('should set back link', () => {
-        cy.visit(`${functionalHeaderUrl}&args=backLink:test`);
-
-        shouldSetBackLink();
-    });
-
-    it('should disable back link and emit event', () => {
-        cy.visit(`${functionalHeaderUrl}&args=disableBackLink:true`);
-
-        shouldDisableBackLinkAndEmitEvent();
-    });
-
-    it('should set title link', () => {
-        cy.visit(`${functionalHeaderUrl}&args=link:test`);
-
-        shouldSetTitleLink();
-    });
-
-    it('should set sub title text', () => {
-        cy.visit(`${functionalHeaderUrl}&args=subTitle:Voor+lager+onderwijs`);
-
-        shouldSetSubTitleText();
-    });
-
-    it('should set title text', () => {
-        cy.visit(`${functionalHeaderUrl}&args=title:School+en+studietoelagen`);
-
-        shouldSetTitleText();
+        cy.get('vl-functional-header').shadow().find('header');
     });
 });
 
 describe('story - vl-functional-header - actions', () => {
-    it('should have default back text', () => {
+    it('should render', () => {
         cy.visit(functionalHeaderActionsUrl);
 
-        shouldHaveDefaultBackText();
-    });
-
-    it('should set back text', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=back:Keer+terug`);
-
-        shouldSetBackText();
-    });
-
-    it('should have default back link', () => {
-        cy.visit(functionalHeaderActionsUrl);
-
-        shouldHaveDefaultBackLink();
-    });
-
-    it('should set back link', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=backLink:test`);
-
-        shouldSetBackLink();
-    });
-
-    it('should disable back link and emit event', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=disableBackLink:true`);
-
-        shouldDisableBackLinkAndEmitEvent();
-    });
-
-    it('should set title link', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=link:test`);
-
-        shouldSetTitleLink();
-    });
-
-    it('should set sub title text', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=subTitle:Voor+lager+onderwijs`);
-
-        shouldSetSubTitleText();
-    });
-
-    it('should set title text', () => {
-        cy.visit(`${functionalHeaderActionsUrl}&args=title:School+en+studietoelagen`);
-
-        shouldSetTitleText();
-    });
-
-    it('should set actions slot', () => {
-        cy.visit(functionalHeaderActionsUrl);
-
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('div.vl-functional-header__actions')
-            .find('li.vl-functional-header__action')
-            .find('a')
-            .should('have.attr', 'href', '#')
-            .contains('Actie 1');
-
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('div.vl-functional-header__actions')
-            .find('li.vl-functional-header__action')
-            .find('a')
-            .should('have.attr', 'href', '#')
-            .contains('Actie 2');
+        cy.get('vl-functional-header').shadow().find('header');
     });
 });
 
 describe('story - vl-functional-header - tabs', () => {
-    it('should set title link', () => {
-        cy.visit(`${functionalHeaderTabsUrl}&args=link:test`);
-
-        shouldSetTitleLink();
-    });
-
-    it('should set title text', () => {
-        cy.visit(`${functionalHeaderTabsUrl}&args=title:School+en+studietoelagen`);
-
-        shouldSetTitleText();
-    });
-
-    it('should have three tabs with titles', () => {
+    it('should render', () => {
         cy.visit(functionalHeaderTabsUrl);
 
-        cy.get('vl-tabs')
-            .shadow()
-            .find('ul.vl-tabs')
-            .find('li[data-vl-id="trein"]')
-            .find('a')
-            .find('slot')
-            .contains('Trein');
-
-        cy.get('vl-tabs')
-            .shadow()
-            .find('ul.vl-tabs')
-            .find('li[data-vl-id="metro"]')
-            .find('a')
-            .find('slot')
-            .contains('Metro, tram en bus');
-
-        cy.get('vl-tabs')
-            .shadow()
-            .find('ul.vl-tabs')
-            .find('li[data-vl-id="fiets"]')
-            .find('a')
-            .find('slot')
-            .contains('Fiets');
-    });
-
-    it('should emit event on click tab', () => {
-        cy.visit(functionalHeaderTabsUrl);
-
-        cy.createStubForEvent('vl-tabs', 'change');
-        cy.get('vl-tabs').shadow().find('button[data-vl-tabs-toggle]').click({ force: true });
-        cy.get('vl-tabs').shadow().find('a#trein').click();
-        cy.get('@change').should('have.been.calledOnce');
-    });
-
-    it('should open/close tablist on mobile', () => {
-        cy.viewport(550, 750);
-        cy.visit(functionalHeaderTabsUrl);
-
-        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
-        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
-        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'true');
-        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
-        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
-        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
-        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'true');
-        cy.get('vl-tabs').shadow().find('a#trein').click();
-        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
+        cy.get('vl-functional-header').shadow().find('header');
     });
 });
 
 describe('story - vl-functional-header - breadcrumb', () => {
-    it('should set title link', () => {
-        cy.visit(`${functionalHeaderBreadcrumbUrl}&args=link:test`);
-
-        shouldSetTitleLink();
-    });
-
-    it('should set title text', () => {
-        cy.visit(`${functionalHeaderBreadcrumbUrl}&args=title:School+en+studietoelagen`);
-
-        shouldSetTitleText();
-    });
-
-    it('should contain 4 breadcrumb items', () => {
+    it('should render', () => {
         cy.visit(functionalHeaderBreadcrumbUrl);
 
-        cy.get('vl-breadcrumb')
-            .shadow()
-            .find('.vl-breadcrumb__list')
-            .children('.vl-breadcrumb__list__item')
-            .should('have.length', 4);
-    });
-
-    it('should contain correct breadcrumb items', () => {
-        cy.visit(functionalHeaderBreadcrumbUrl);
-
-        cy.get('vl-breadcrumb')
-            .find('vl-breadcrumb-item')
-            .first()
-            .contains('Vlaanderen Intern')
-            .next()
-            .contains('Regelgeving')
-            .next()
-            .contains('Webuniversum')
-            .next()
-            .contains('Componenten');
-    });
-
-    it('should set correct links for breadcrumb items', () => {
-        cy.visit(functionalHeaderBreadcrumbUrl);
-
-        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(0).shadow().find('a').should('have.attr', 'href', '1');
-        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(1).shadow().find('a').should('have.attr', 'href', '2');
-        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(2).shadow().find('a').should('have.attr', 'href', '3');
-        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(3).shadow().find('span');
+        cy.get('vl-functional-header').shadow().find('header');
     });
 });
 
 describe('story - vl-functional-header - slots', () => {
-    it('should set title slot', () => {
+    it('should render', () => {
         cy.visit(functionalHeaderSlotsUrl);
 
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('.vl-functional-header__title')
-            .find('a')
-            .find('slot[name="title"]');
-        cy.get('vl-functional-header').find('span[slot="title"]').contains('School- en studietoelagen');
-    });
-
-    it('should set sub header slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header').shadow().find('div.vl-functional-header__sub').find('slot[name="sub-header"]');
-        cy.get('vl-functional-header').find('span[slot="sub-header"]').contains('Sub header content');
-    });
-
-    it('should set sub title slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('li.vl-functional-header__sub__action')
-            .find('slot[name="sub-title"]');
-
-        cy.get('vl-functional-header')
-            .find('span[slot="sub-title"]')
-            .contains('Voor lager, middelbaar en hoger onderwijs');
-    });
-
-    it('should set back link slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('li.vl-functional-header__sub__action')
-            .find('slot[name="back-link"]');
-
-        cy.get('vl-functional-header').find('a[slot="back-link"]').should('have.attr', 'href', '#').contains('Terug');
-    });
-
-    it('should set back slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header').shadow().find('li.vl-functional-header__sub__action').find('slot[name="back"]');
-        cy.get('vl-functional-header').find('span[slot="back"]').contains('Terug');
-    });
-
-    it('should set top-left slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header').shadow().find('div.vl-functional-header__content').find('slot[name="top-left"]');
-        cy.get('vl-functional-header').find('span[slot="top-left"]').contains('Linkerbovenhoek content');
-    });
-
-    it('should set top-right slot', () => {
-        cy.visit(functionalHeaderSlotsUrl);
-
-        cy.get('vl-functional-header')
-            .shadow()
-            .find('div.uig-functional-header__top-right')
-            .find('slot[name="top-right"]');
-
-        cy.get('vl-functional-header').find('span[slot="top-right"]').contains('Rechterbovenhoek content');
+        cy.get('vl-functional-header').shadow().find('header');
     });
 });

--- a/libs/components/src/functional-header/stories/vl-functional-header.stories-arg.ts
+++ b/libs/components/src/functional-header/stories/vl-functional-header.stories-arg.ts
@@ -17,6 +17,7 @@ export const functionalHeaderArgs = {
     disableBackLink: false,
     fullWidth: false,
     hideBackLink: false,
+    hideSubHeader: false,
     link: '',
     marginBottom: 'large',
     subTitle: '',
@@ -77,6 +78,15 @@ export const functionalHeaderArgTypes: ArgTypes<typeof functionalHeaderArgs> = {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: functionalHeaderArgs.hideBackLink },
+        },
+    },
+    hideSubHeader: {
+        name: 'data-vl-hide-sub-header',
+        description: 'Verbergt de sub header.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: functionalHeaderArgs.hideSubHeader },
         },
     },
     link: {

--- a/libs/components/src/functional-header/stories/vl-functional-header.stories.ts
+++ b/libs/components/src/functional-header/stories/vl-functional-header.stories.ts
@@ -33,6 +33,7 @@ const Template = story(
         disableBackLink,
         fullWidth,
         hideBackLink,
+        hideSubHeader,
         link,
         marginBottom,
         subTitle,
@@ -53,6 +54,7 @@ const Template = story(
             ?data-vl-disable-back-link=${disableBackLink}
             ?data-vl-full-width=${fullWidth}
             ?data-vl-hide-back-link=${hideBackLink}
+            ?data-vl-hide-sub-header=${hideSubHeader}
             data-vl-link=${link}
             data-vl-margin-bottom=${marginBottom}
             data-vl-sub-title=${subTitle}

--- a/libs/components/src/functional-header/vl-functional-header.component.cy.ts
+++ b/libs/components/src/functional-header/vl-functional-header.component.cy.ts
@@ -1,0 +1,684 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlFunctionalHeaderComponent } from './vl-functional-header.component';
+import { VlBreadcrumbComponent } from './../breadcrumb';
+import { VlTabsComponent } from './../tabs';
+
+registerWebComponents([VlFunctionalHeaderComponent, VlTabsComponent, VlBreadcrumbComponent]);
+
+describe('story - vl-functional-header', () => {
+    it('should be accessible', () => {
+        cy.mount(html` <vl-functional-header title="test"> </vl-functional-header>`);
+
+        cy.injectAxe();
+        cy.checkA11y();
+    });
+
+    it('should have default back text', () => {
+        cy.mount(html` <vl-functional-header> </vl-functional-header>`);
+
+        shouldHaveDefaultBackText();
+    });
+
+    it('should set back text', () => {
+        cy.mount(html` <vl-functional-header data-vl-back="Keer terug"> </vl-functional-header>`);
+
+        shouldSetBackText();
+    });
+
+    it('should have default back link', () => {
+        cy.mount(html` <vl-functional-header> </vl-functional-header>`);
+
+        shouldHaveDefaultBackLink();
+    });
+
+    it('should set back link', () => {
+        cy.mount(html` <vl-functional-header data-vl-back-link="test"> </vl-functional-header>`);
+
+        shouldSetBackLink();
+    });
+
+    it('should hide back link', () => {
+        cy.mount(html` <vl-functional-header data-vl-hide-back-link=""> </vl-functional-header>`);
+
+        cy.get('vl-functional-header').shadow().find('a#back-link').should('not.exist');
+    });
+
+    it('should hide sub-header', () => {
+        cy.mount(html` <vl-functional-header data-vl-hide-sub-header=""> </vl-functional-header>`);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('#sub-header')
+            .should('have.class', 'sub-header-hidden')
+            .shouldHaveComputedStyle({ style: 'padding-bottom', value: '13px' })
+            .find('slot')
+            .and('not.be.visible');
+    });
+
+    it('should disable back link and emit event', () => {
+        cy.mount(html` <vl-functional-header data-vl-disable-back-link=""> </vl-functional-header>`);
+
+        shouldDisableBackLinkAndEmitEvent();
+    });
+
+    it('should set title link', () => {
+        cy.mount(html` <vl-functional-header data-vl-link="test"> </vl-functional-header>`);
+
+        shouldSetTitleLink();
+    });
+
+    it('should set sub title text', () => {
+        cy.mount(html` <vl-functional-header data-vl-sub-title="Voor lager onderwijs"> </vl-functional-header>`);
+
+        shouldSetSubTitleText();
+    });
+
+    it('should set title text', () => {
+        cy.mount(html` <vl-functional-header data-vl-title="School en studietoelagen"> </vl-functional-header>`);
+
+        shouldSetTitleText();
+    });
+});
+
+describe('story - vl-functional-header - actions', () => {
+    it('should be accessible', () => {
+        cy.mount(html`
+            <vl-functional-header title="test">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        cy.injectAxe();
+        cy.checkA11y();
+    });
+
+    it('should have default back text', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldHaveDefaultBackText();
+    });
+
+    it('should set back text', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-back="Keer terug">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldSetBackText();
+    });
+
+    it('should have default back link', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldHaveDefaultBackLink();
+    });
+
+    it('should set back link', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-back-link="test">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldSetBackLink();
+    });
+
+    it('should disable back link and emit event', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-disable-back-link="">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldDisableBackLinkAndEmitEvent();
+    });
+
+    it('should set title link', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-link="test">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleLink();
+    });
+
+    it('should set sub title text', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-sub-title="Voor lager onderwijs">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldSetSubTitleText();
+    });
+
+    it('should set title text', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleText();
+    });
+
+    it('should set actions slot', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <div slot="actions">
+                    <a href="#">Actie 1</a>
+                    <a href="#">Actie 2</a>
+                </div>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('div.vl-functional-header__actions')
+            .find('li.vl-functional-header__action')
+            .find('a')
+            .should('have.attr', 'href', '#')
+            .contains('Actie 1');
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('div.vl-functional-header__actions')
+            .find('li.vl-functional-header__action')
+            .find('a')
+            .should('have.attr', 'href', '#')
+            .contains('Actie 2');
+    });
+});
+
+describe('story - vl-functional-header - tabs', () => {
+    it('should be accessible', () => {
+        cy.mount(html`
+            <vl-functional-header title="test">
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        cy.injectAxe();
+        cy.checkA11y();
+    });
+
+    it('should set title link', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-link="test">
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleLink();
+    });
+
+    it('should set title text', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleText();
+    });
+
+    it('should have three tabs with titles', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-tabs')
+            .shadow()
+            .find('ul.vl-tabs')
+            .find('li[data-vl-id="trein"]')
+            .find('a')
+            .find('slot')
+            .contains('Trein');
+
+        cy.get('vl-tabs')
+            .shadow()
+            .find('ul.vl-tabs')
+            .find('li[data-vl-id="metro"]')
+            .find('a')
+            .find('slot')
+            .contains('Metro, tram en bus');
+
+        cy.get('vl-tabs')
+            .shadow()
+            .find('ul.vl-tabs')
+            .find('li[data-vl-id="fiets"]')
+            .find('a')
+            .find('slot')
+            .contains('Fiets');
+    });
+
+    it('should emit event on click tab', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        cy.createStubForEvent('vl-tabs', 'change');
+        cy.get('vl-tabs').shadow().find('button[data-vl-tabs-toggle]').click({ force: true });
+        cy.get('vl-tabs').shadow().find('a#trein').click({ force: true });
+        cy.get('@change').should('have.been.calledOnce');
+    });
+
+    it('should open/close tablist on mobile', () => {
+        cy.viewport(550, 750);
+        cy.mount(html`
+            <vl-functional-header>
+                <vl-tabs
+                    slot="sub-header"
+                    data-vl-disable-links
+                    data-vl-within-functional-header
+                    data-vl-active-tab="trein"
+                >
+                    <vl-tabs-pane data-vl-id="trein" data-vl-title="Trein"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="metro" data-vl-title="Metro, tram en bus"></vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="fiets" data-vl-title="Fiets"></vl-tabs-pane>
+                </vl-tabs>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
+        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
+        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'true');
+        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
+        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
+        cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
+        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'true');
+        cy.get('vl-tabs').shadow().find('a#trein').click();
+        cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'data-vl-show', 'false');
+    });
+});
+
+describe('story - vl-functional-header - breadcrumb', () => {
+    it('should be accessible', () => {
+        cy.mount(html`
+            <vl-functional-header title="test">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        cy.injectAxe();
+        cy.checkA11y();
+    });
+
+    it('should set title link', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-link="test">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleLink();
+    });
+
+    it('should set title text', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        shouldSetTitleText();
+    });
+
+    it('should contain 4 breadcrumb items', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-breadcrumb')
+            .shadow()
+            .find('.vl-breadcrumb__list')
+            .children('.vl-breadcrumb__list__item')
+            .should('have.length', 4);
+    });
+
+    it('should contain correct breadcrumb items', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-breadcrumb')
+            .find('vl-breadcrumb-item')
+            .first()
+            .contains('Vlaanderen Intern')
+            .next()
+            .contains('Regelgeving')
+            .next()
+            .contains('Webuniversum')
+            .next()
+            .contains('Componenten');
+    });
+
+    it('should set correct links for breadcrumb items', () => {
+        cy.mount(html`
+            <vl-functional-header data-vl-title="School en studietoelagen">
+                <vl-breadcrumb slot="sub-title">
+                    <vl-breadcrumb-item data-vl-href="1">Vlaanderen Intern</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="2">Regelgeving</vl-breadcrumb-item>
+                    <vl-breadcrumb-item data-vl-href="3">Webuniversum</vl-breadcrumb-item>
+                    <vl-breadcrumb-item>Componenten</vl-breadcrumb-item>
+                </vl-breadcrumb>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(0).shadow().find('a').should('have.attr', 'href', '1');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(1).shadow().find('a').should('have.attr', 'href', '2');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(2).shadow().find('a').should('have.attr', 'href', '3');
+        cy.get('vl-breadcrumb').find('vl-breadcrumb-item').eq(3).shadow().find('span');
+    });
+});
+
+describe('story - vl-functional-header - slots', () => {
+    it('should be accessible', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.injectAxe();
+        cy.checkA11y();
+    });
+
+    it('should set title slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="title">School- en studietoelagen</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('.vl-functional-header__title')
+            .find('a')
+            .find('slot[name="title"]');
+        cy.get('vl-functional-header').find('span[slot="title"]').contains('School- en studietoelagen');
+    });
+
+    it('should set sub header slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header').shadow().find('div.vl-functional-header__sub').find('slot[name="sub-header"]');
+        cy.get('vl-functional-header').find('span[slot="sub-header"]').contains('Sub header content');
+    });
+
+    it('should set sub title slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('li.vl-functional-header__sub__action')
+            .find('slot[name="sub-title"]');
+
+        cy.get('vl-functional-header')
+            .find('span[slot="sub-title"]')
+            .contains('Voor lager, middelbaar en hoger onderwijs');
+    });
+
+    it('should set back link slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('li.vl-functional-header__sub__action')
+            .find('slot[name="back-link"]');
+
+        cy.get('vl-functional-header').find('a[slot="back-link"]').should('have.attr', 'href', '#').contains('Terug');
+    });
+
+    it('should set back slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header').shadow().find('li.vl-functional-header__sub__action').find('slot[name="back"]');
+        cy.get('vl-functional-header').find('span[slot="back"]').contains('Terug');
+    });
+
+    it('should set top-left slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header').shadow().find('div.vl-functional-header__content').find('slot[name="top-left"]');
+        cy.get('vl-functional-header').find('span[slot="top-left"]').contains('Linkerbovenhoek content');
+    });
+
+    it('should set top-right slot', () => {
+        cy.mount(html`
+            <vl-functional-header>
+                <span slot="back">Terug</span>
+                <a slot="back-link" href="#">Terug</a>
+                <span slot="sub-header">Sub header content</span>
+                <span slot="sub-title">Voor lager, middelbaar en hoger onderwijs</span>
+                <span slot="title">School- en studietoelagen</span>
+                <span slot="top-left">Linkerbovenhoek content</span>
+                <span slot="top-right">Rechterbovenhoek content</span>
+            </vl-functional-header>
+        `);
+
+        cy.get('vl-functional-header')
+            .shadow()
+            .find('div.uig-functional-header__top-right')
+            .find('slot[name="top-right"]');
+
+        cy.get('vl-functional-header').find('span[slot="top-right"]').contains('Rechterbovenhoek content');
+    });
+});
+
+const shouldHaveDefaultBackText = () => {
+    cy.get('vl-functional-header').shadow().find('a#back-link').contains('Terug');
+};
+
+const shouldSetBackText = () => {
+    cy.get('vl-functional-header').shadow().find('a#back-link').contains('Keer terug');
+};
+
+const shouldHaveDefaultBackLink = () => {
+    cy.get('vl-functional-header').shadow().find('a#back-link').should('have.attr', 'href', document.referrer);
+};
+
+const shouldSetBackLink = () => {
+    cy.get('vl-functional-header').shadow().find('a#back-link').should('have.attr', 'href', 'test');
+};
+
+const shouldDisableBackLinkAndEmitEvent = () => {
+    cy.createStubForEvent('vl-functional-header', 'vl-click-back');
+    cy.get('vl-functional-header').shadow().find('a#back-link').click();
+    cy.get('@vl-click-back').should('have.been.calledOnce');
+};
+
+const shouldSetTitleLink = () => {
+    cy.get('vl-functional-header')
+        .shadow()
+        .find('.vl-functional-header__title')
+        .find('a')
+        .should('have.attr', 'href', 'test');
+};
+
+const shouldSetSubTitleText = () => {
+    cy.get('vl-functional-header')
+        .shadow()
+        .find('li.vl-functional-header__sub__action')
+        .contains('Voor lager onderwijs');
+};
+
+const shouldSetTitleText = () => {
+    cy.get('vl-functional-header')
+        .shadow()
+        .find('.vl-functional-header__title')
+        .find('a')
+        .contains('School en studietoelagen');
+};

--- a/libs/components/src/functional-header/vl-functional-header.component.ts
+++ b/libs/components/src/functional-header/vl-functional-header.component.ts
@@ -30,6 +30,7 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
             'back-link',
             'disable-back-link',
             'hide-back-link',
+            'hide-sub-header',
             'link',
             'margin-bottom',
             'sub-title',
@@ -204,6 +205,14 @@ export class VlFunctionalHeaderComponent extends BaseElementOfType(HTMLElement) 
     _hideBackLinkChangedCallback(oldValue: string, newValue: string) {
         if (newValue != undefined) {
             this._backLinkContainer?.remove();
+        }
+    }
+
+    _hideSubHeaderChangedCallback(oldValue: string, newValue: string) {
+        if (newValue != undefined) {
+            this._subHeaderElement?.classList.add('sub-header-hidden');
+        } else {
+            this._subHeaderElement?.classList.remove('sub-header-hidden');
         }
     }
 

--- a/libs/components/src/functional-header/vl-functional-header.uig-css.ts
+++ b/libs/components/src/functional-header/vl-functional-header.uig-css.ts
@@ -23,5 +23,13 @@ const styles: CSSResult = css`
     :host(.vl-functional-header--full-width) .vl-layout {
         max-width: 100%;
     }
+
+    .sub-header-hidden slot {
+        display: none;
+    }
+
+    .sub-header-hidden {
+        padding-bottom: 1.3rem;
+    }
 `;
 export default styles;


### PR DESCRIPTION
Storybook verbeterd & cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3053)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC403)

<img width="959" alt="image" src="https://github.com/user-attachments/assets/21d794f3-e866-4b0c-a42b-bb02f5e366cc">

<img width="968" alt="image" src="https://github.com/user-attachments/assets/4adbd619-ea6b-450a-8775-f41390ed0e06">
