### PR TITLE
feat: UIG-3106 - form-next componenten - backwards incompatibele event wijziging: vl-checked, vl-input en vl-select vervangen door vl-change + vl-input

### DIFF
--- a/apps/playground-lit/src/app/form/form.component.ts
+++ b/apps/playground-lit/src/app/form/form.component.ts
@@ -860,7 +860,7 @@ export class FormComponent extends LitElement {
                                 ?disabled=${this.preferredContactMethodDisabled}
                                 ?readonly=${this.preferredContactMethodReadonly}
                                 value=${this.preferredContactMethod}
-                                @vl-checked=${(e: CustomEvent) => (this.preferredContactMethod = e.detail.value)}
+                                @vl-input=${(e: CustomEvent) => (this.preferredContactMethod = e.detail.value)}
                             >
                                 <vl-radio-next value="e-mail">e-mail</vl-radio-next>
                                 <vl-radio-next value="telefoon">telefoon</vl-radio-next>
@@ -989,7 +989,7 @@ export class FormComponent extends LitElement {
                                 ?required=${this.filledInTruthfullyRequired}
                                 ?disabled=${this.filledInTruthfullyDisabled || this.filledInTruthfullyReadonly}
                                 ?checked=${this.filledInTruthfully}
-                                @vl-checked=${(e: CustomEvent) => (this.filledInTruthfully = e.detail.checked)}
+                                @vl-input=${(e: CustomEvent) => (this.filledInTruthfully = e.detail.checked)}
                             >
                                 Naar waarheid ingevuld
                             </vl-checkbox-next>

--- a/libs/form/src/next/checkbox/stories/vl-checkbox.stories-arg.ts
+++ b/libs/form/src/next/checkbox/stories/vl-checkbox.stories-arg.ts
@@ -5,13 +5,19 @@ import { formControlArgs, formControlArgTypes } from '../../form-control/stories
 import { checkboxDefaults } from '../vl-checkbox.defaults';
 
 type CheckboxArgs = typeof formControlArgs &
-    typeof checkboxDefaults & { contentSlot: string; onVlChecked: () => void; onVlValid: () => void };
+    typeof checkboxDefaults & {
+        contentSlot: string;
+        onVlChange: () => void;
+        onVlInput: () => void;
+        onVlValid: () => void;
+    };
 
 export const checkboxArgs: CheckboxArgs = {
     ...formControlArgs,
     ...checkboxDefaults,
     contentSlot: '',
-    onVlChecked: action('vl-checked'),
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
 
@@ -62,10 +68,19 @@ export const checkboxArgTypes: ArgTypes<CheckboxArgs> = {
             defaultValue: { summary: checkboxArgs.contentSlot },
         },
     },
-    onVlChecked: {
-        name: 'vl-checked',
+    onVlChange: {
+        name: 'vl-change',
         description:
-            'Event dat afgevuurd wordt als de checkbox aangevinkt of uitgevinkt wordt.<br>Het detail object van het event bevat de checked state en de waarde van de checkbox indien deze aangevinkt is.',
+            'Event dat afgevuurd wordt als de checkbox aangevinkt of uitgevinkt wordt (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de checked state en de waarde van de checkbox indien deze aangevinkt is.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat alleen afgevuurd wordt als de gebruiker de checkbox aanvinkt of uitvinkt.<br>Het detail object van het event bevat de checked state en de waarde van de checkbox indien deze aangevinkt is.',
         table: {
             type: { summary: '{ checked: boolean, value?: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/checkbox/stories/vl-checkbox.stories.ts
+++ b/libs/form/src/next/checkbox/stories/vl-checkbox.stories.ts
@@ -38,7 +38,8 @@ const CheckboxTemplate = story(
         checked,
         isSwitch,
         contentSlot,
-        onVlChecked,
+        onVlChange,
+        onVlInput,
         onVlReset,
         onVlValid,
     }) => html`
@@ -54,7 +55,8 @@ const CheckboxTemplate = story(
             value=${value}
             ?checked=${checked}
             ?switch=${isSwitch}
-            @vl-checked=${onVlChecked}
+            @vl-input=${onVlInput}
+            @vl-change=${onVlChange}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}
         >
@@ -104,7 +106,7 @@ export const CheckboxReadonly = story(
         checked,
         isSwitch,
         contentSlot,
-        onVlChecked,
+        onVlInput,
     }) => html`
         <vl-checkbox-next
             id=${id}
@@ -118,7 +120,7 @@ export const CheckboxReadonly = story(
             value=${value}
             ?checked=${checked}
             ?switch=${isSwitch}
-            @vl-checked=${onVlChecked}
+            @vl-input=${onVlInput}
         >
             ${unsafeHTML(contentSlot)}
         </vl-checkbox-next>

--- a/libs/form/src/next/checkbox/vl-checkbox.component.cy.ts
+++ b/libs/form/src/next/checkbox/vl-checkbox.component.cy.ts
@@ -140,18 +140,43 @@ describe('component - vl-checkbox-next', () => {
             .shouldHaveComputedStyle({ pseudo: ':before', style: 'color', value: 'rgb(210, 55, 60)' });
     });
 
-    it('should dispatch vl-checked event on check and uncheck', () => {
+    it('should dispatch vl-change & vl-input event on check and uncheck', () => {
         cy.mount(html` <vl-checkbox-next value=${value}>Bevestig.</vl-checkbox-next> `);
-        cy.createStubForEvent('vl-checkbox-next', 'vl-checked');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-change');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-input');
 
         cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__toggle').click({ force: true });
-        cy.get('@vl-checked')
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
-            .its('secondCall.args.0.detail')
+            .its('lastCall.args.0.detail')
             .should('deep.equal', { checked: true, value });
         cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__toggle').click({ force: true });
-        cy.get('@vl-checked').its('callCount').should('eq', 3);
-        cy.get('@vl-checked').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-change').its('callCount').should('eq', 3);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-input').its('callCount').should('eq', 2);
+        cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+    });
+
+    it('should dispatch vl-change but not vl-input event on programmatic check and uncheck', () => {
+        cy.mount(html` <vl-checkbox-next value=${value}>Bevestig.</vl-checkbox-next> `);
+        cy.createStubForEvent('vl-checkbox-next', 'vl-change');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-input');
+
+        cy.get('vl-checkbox-next').invoke('attr', 'checked', true);
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
+
+        cy.get('vl-checkbox-next').invoke('removeAttr', 'checked');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
     it('should dispatch vl-valid event on valid input', () => {
@@ -275,18 +300,44 @@ describe('component - vl-checkbox-next - switch', () => {
         shouldHaveErrorStyleSwitch();
     });
 
-    it('should dispatch vl-checked event on check and uncheck', () => {
+    it('should dispatch vl-change & vl-input event on check and uncheck', () => {
         cy.mount(html` <vl-checkbox-next value=${value} switch>Bevestig.</vl-checkbox-next> `);
-        cy.createStubForEvent('vl-checkbox-next', 'vl-checked');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-change');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-input');
 
         cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__label').click({ force: true });
-        cy.get('@vl-checked')
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
-            .its('secondCall.args.0.detail')
+            .its('lastCall.args.0.detail')
             .should('deep.equal', { checked: true, value });
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+
         cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__label').click({ force: true });
-        cy.get('@vl-checked').its('callCount').should('eq', 3);
-        cy.get('@vl-checked').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-change').its('callCount').should('eq', 3);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-input').its('callCount').should('eq', 2);
+        cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+    });
+
+    it('should dispatch vl-change but not vl-input event on programmatic check and uncheck', () => {
+        cy.mount(html` <vl-checkbox-next value=${value} switch>Bevestig.</vl-checkbox-next> `);
+        cy.createStubForEvent('vl-checkbox-next', 'vl-change');
+        cy.createStubForEvent('vl-checkbox-next', 'vl-input');
+
+        cy.get('vl-checkbox-next').invoke('attr', 'checked', true);
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
+
+        cy.get('vl-checkbox-next').invoke('removeAttr', 'checked');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
     it('should dispatch vl-valid event on valid input', () => {

--- a/libs/form/src/next/checkbox/vl-checkbox.component.ts
+++ b/libs/form/src/next/checkbox/vl-checkbox.component.ts
@@ -19,6 +19,7 @@ export class VlCheckboxComponent extends FormControl {
     // Variables
     private initialValue: string | null = null;
     private initialCheckedValue = false;
+    private dispatchInput = false;
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [resetStyle, baseStyle, vlElementsStyle, checkboxStyle, checkboxUigStyle];
@@ -54,13 +55,11 @@ export class VlCheckboxComponent extends FormControl {
             }
 
             this.setValue(value);
-            this.dispatchEvent(
-                new CustomEvent('vl-checked', {
-                    bubbles: true,
-                    composed: true,
-                    detail,
-                })
-            );
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
     }
@@ -149,6 +148,7 @@ export class VlCheckboxComponent extends FormControl {
 
     private toggle() {
         this.checked = !this.checked;
+        this.dispatchInput = true;
     }
 }
 

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -6,11 +6,12 @@ import { datepickerDefaults } from '../vl-datepicker.defaults';
 import { DATEPICKER_TYPES } from '../vl-datepicker.model';
 
 type DatepickerArgs = typeof formControlArgs &
-    typeof datepickerDefaults & { onVlInput: () => void; onVlValid: () => void };
+    typeof datepickerDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
 
 export const datepickerArgs: DatepickerArgs = {
     ...formControlArgs,
     ...datepickerDefaults,
+    onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
@@ -166,7 +167,16 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
     onVlInput: {
         name: 'vl-input',
         description:
-            'Event dat afgevuurd wordt als de waarde van het datepicker-input veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
+            'Event dat alleen afgevuurd wordt als de gebruiker de waarde van het datepicker-input veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als de waarde van het datepicker-input veld verandert (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de ingegeven waarde.',
         table: {
             type: { summary: '{ value: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/form/src/next/datepicker/stories/vl-datepicker.stories.ts
@@ -47,6 +47,7 @@ export const DatepickerDefault = story(
         pattern,
         regex,
         name,
+        onVlChange,
         onVlInput,
         onVlReset,
         onVlValid,
@@ -75,6 +76,7 @@ export const DatepickerDefault = story(
                     am-pm=${amPm}
                     pattern=${pattern}
                     .regex=${regex}
+                    @vl-change=${onVlChange}
                     @vl-input=${onVlInput}
                     @vl-reset=${onVlReset}
                     @vl-valid=${onVlValid}

--- a/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
@@ -326,16 +326,39 @@ describe('component - vl-datepicker-next', () => {
     });
 
     // deze test slaagt in Electron/Firefox, maar niet in Chromium browsers gezien verschil in event werking
-    it('should dispatch vl-input event on input', () => {
+    it('should dispatch vl-input event on user input', () => {
         cy.mount(html`<vl-datepicker-next></vl-datepicker-next>`);
         cy.createStubForEvent('vl-datepicker-next', 'vl-input');
 
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next').shadow().find('.flatpickr-calendar').find('.flatpickr-day').contains('15').click();
         cy.get('@vl-input')
+            .should('have.been.called')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { value: createIsoDateString({ day: 15 }) });
+    });
+
+    // deze test slaagt in Electron/Firefox, maar niet in Chromium browsers gezien verschil in event werking
+    it('should dispatch vl-change event and not vl-input event on when changing value programmatically', () => {
+        const value = createIsoDateString({ day: 21, month: 12, year: 2023 });
+
+        cy.mount(html`<vl-datepicker-next></vl-datepicker-next>`);
+        cy.createStubForEvent('vl-datepicker-next', 'vl-change');
+        cy.createStubForEvent('vl-datepicker-next', 'vl-input');
+
+        cy.get('vl-datepicker-next').shadow().find('div.flatpickr-calendar');
+        cy.get('vl-datepicker-next').then((datepicker$) => {
+            const datepicker = datepicker$[0];
+            datepicker.setAttribute('value', value);
+        });
+        cy.get('vl-datepicker-next').should('have.value', value);
+        cy.get('vl-datepicker-next').shadow().find('input.vl-input-field').should('have.value', '21.12.2023');
+
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
-            .should('deep.equal', { value: createIsoDateString({ day: 15 }) });
+            .should('deep.equal', { value });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
     });
 
     // deze test slaagt in Electron/Firefox, maar niet in Chromium browsers gezien verschil in event werking

--- a/libs/form/src/next/input-field-masked/stories/vl-input-field-masked.stories.ts
+++ b/libs/form/src/next/input-field-masked/stories/vl-input-field-masked.stories.ts
@@ -49,6 +49,7 @@ const InputFieldMaskedTemplate = story(
         rawValue,
         disableMaskValidation,
         regex,
+        onVlChange,
         onVlInput,
         onVlReset,
         onVlValid,
@@ -78,6 +79,7 @@ const InputFieldMaskedTemplate = story(
                 ?raw-value=${rawValue}
                 ?disable-mask-validation=${disableMaskValidation}
                 .regex=${regex}
+                @vl-change=${onVlChange}
                 @vl-input=${onVlInput}
                 @vl-reset=${onVlReset}
                 @vl-valid=${onVlValid}

--- a/libs/form/src/next/input-field-masked/vl-input-field-masked.component.cy.ts
+++ b/libs/form/src/next/input-field-masked/vl-input-field-masked.component.cy.ts
@@ -207,6 +207,31 @@ describe('component - vl-input-field-masked-next', () => {
         cy.checkA11y('vl-input-field-masked-next');
     });
 
+    it('should dispatch vl-change & vl-input event on input', () => {
+        cy.mount(html`<vl-input-field-masked-next label="test-label" mask="phone"></vl-input-field-masked-next>`);
+        cy.createStubForEvent('vl-input-field-masked-next', 'vl-change');
+        cy.createStubForEvent('vl-input-field-masked-next', 'vl-input');
+
+        cy.get('vl-input-field-masked-next').shadow().find('input').type('12345678');
+        cy.get('@vl-change').its('callCount').should('eq', 10);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: '+32 12 34 56 78' });
+        // change event wordt ook gedispatched bij focus verandering, daarom 1 extra
+        cy.get('@vl-input').its('callCount').should('eq', 8);
+        cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { value: '+32 12 34 56 78' });
+    });
+
+    it('should dispatch vl-change but not vl-input event on programmatic value change', () => {
+        cy.mount(html`<vl-input-field-masked-next label="test-label" mask="rrn"></vl-input-field-masked-next>`);
+        cy.createStubForEvent('vl-input-field-masked-next', 'vl-change');
+        cy.createStubForEvent('vl-input-field-masked-next', 'vl-input');
+        const value = '85.01.05-123.45';
+
+        cy.get('vl-input-field-masked-next').invoke('attr', 'value', value);
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('firstCall.args.0.detail').should('deep.equal', { value: value });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
+    });
+
     it('should dispatch vl-valid event on valid input', () => {
         cy.mount(html`<vl-input-field-masked-next label="test-label" mask="phone"></vl-input-field-masked-next>`);
         cy.injectAxe();

--- a/libs/form/src/next/input-field-masked/vl-input-field-masked.component.ts
+++ b/libs/form/src/next/input-field-masked/vl-input-field-masked.component.ts
@@ -85,6 +85,7 @@ export class VlInputFieldMaskedComponent extends VlInputFieldComponent {
     protected onInput() {
         // we definiëren hier een lege functie om de standaard onInput() van VlInputFieldComponent te overschrijven
         // we updaten de transformeerde value alreeds in een cleave.js callback (handleValueChanged()) daarom moet deze functie leeg zijn
+        this.dispatchInput = true;
     }
 
     protected onUpdated(changedProperties: Map<string, unknown>) {
@@ -100,7 +101,11 @@ export class VlInputFieldMaskedComponent extends VlInputFieldComponent {
             const detail = { value };
 
             this.setValue(value);
-            this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
     }

--- a/libs/form/src/next/input-field/stories/vl-input-field.stories-arg.ts
+++ b/libs/form/src/next/input-field/stories/vl-input-field.stories-arg.ts
@@ -5,11 +5,12 @@ import { formControlArgs, formControlArgTypes } from '../../form-control/stories
 import { inputFieldDefaults } from '../vl-input-field.defaults';
 
 type InputFieldArgs = typeof formControlArgs &
-    typeof inputFieldDefaults & { onVlInput: () => void; onVlValid: () => void };
+    typeof inputFieldDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
 
 export const inputFieldArgs: InputFieldArgs = {
     ...formControlArgs,
     ...inputFieldDefaults,
+    onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
@@ -151,10 +152,19 @@ export const inputFieldArgTypes: ArgTypes<InputFieldArgs> = {
             defaultValue: { summary: inputFieldArgs.regex },
         },
     },
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als de waarde van het input veld verandert (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de ingegeven waarde.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
     onVlInput: {
         name: 'vl-input',
         description:
-            'Event dat afgevuurd wordt als de waarde van het input veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
+            'Event dat alleen afgevuurd wordt als de gebruiker de waarde van het input veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
         table: {
             type: { summary: '{ value: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/input-field/stories/vl-input-field.stories.ts
+++ b/libs/form/src/next/input-field/stories/vl-input-field.stories.ts
@@ -47,6 +47,7 @@ const InputFieldTemplate = story(
         regex,
         onVlInput,
         onVlReset,
+        onVlChange,
         onVlValid,
     }) => {
         return html` <vl-input-field-next
@@ -71,6 +72,7 @@ const InputFieldTemplate = story(
             max-exclusive=${maxExclusive}
             pattern=${pattern}
             .regex=${regex}
+            @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}

--- a/libs/form/src/next/input-field/vl-input-field.component.cy.ts
+++ b/libs/form/src/next/input-field/vl-input-field.component.cy.ts
@@ -154,13 +154,28 @@ describe('component - vl-input-field-next', () => {
         });
     });
 
-    it('should dispatch vl-input event on input', () => {
+    it('should dispatch vl-change & vl-input event on input', () => {
         cy.mount(html`<vl-input-field-next></vl-input-field-next>`);
+        cy.createStubForEvent('vl-input-field-next', 'vl-change');
         cy.createStubForEvent('vl-input-field-next', 'vl-input');
 
         cy.get('vl-input-field-next').shadow().find('input').type('test');
-        cy.get('@vl-input').its('callCount').should('eq', 5);
+        cy.get('@vl-change').its('callCount').should('eq', 5);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        // change event wordt ook gedispatched bij focus verandering, daarom 1 extra
+        cy.get('@vl-input').its('callCount').should('eq', 4);
         cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+    });
+
+    it('should dispatch vl-change but not vl-input event on programmatic value change', () => {
+        cy.mount(html`<vl-input-field-next></vl-input-field-next>`);
+        cy.createStubForEvent('vl-input-field-next', 'vl-change');
+        cy.createStubForEvent('vl-input-field-next', 'vl-input');
+
+        cy.get('vl-input-field-next').invoke('attr', 'value', 'test');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
     it('should dispatch vl-valid event on valid input', () => {

--- a/libs/form/src/next/input-field/vl-input-field.component.ts
+++ b/libs/form/src/next/input-field/vl-input-field.component.ts
@@ -31,6 +31,7 @@ export class VlInputFieldComponent extends FormControl {
 
     // Variables
     protected initialValue = '';
+    protected dispatchInput = false;
 
     static formControlValidators = [
         ...FormControl.formControlValidators,
@@ -122,6 +123,7 @@ export class VlInputFieldComponent extends FormControl {
     }
 
     protected onInput(event: Event & { target: HTMLInputElement }) {
+        this.dispatchInput = true;
         this.value = event?.target?.value;
     }
 
@@ -130,7 +132,11 @@ export class VlInputFieldComponent extends FormControl {
             const detail = { value: this.value };
 
             this.setValue(this.value);
-            this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
     }

--- a/libs/form/src/next/radio-group/stories/vl-radio-group.stories-arg.ts
+++ b/libs/form/src/next/radio-group/stories/vl-radio-group.stories-arg.ts
@@ -5,12 +5,13 @@ import { formControlArgs, formControlArgTypes } from '../../form-control/stories
 import { radioGroupDefaults } from '../vl-radio-group.defaults';
 
 type RadioGroupArgs = typeof formControlArgs &
-    typeof radioGroupDefaults & { onVlChecked: () => void; onVlValid: () => void };
+    typeof radioGroupDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
 
 export const radioGroupArgs: RadioGroupArgs = {
     ...formControlArgs,
     ...radioGroupDefaults,
-    onVlChecked: action('vl-checked'),
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
 
@@ -34,10 +35,19 @@ export const radioGroupArgTypes: ArgTypes<RadioGroupArgs> = {
             defaultValue: { summary: radioGroupArgs.value },
         },
     },
-    onVlChecked: {
-        name: 'vl-checked',
+    onVlChange: {
+        name: 'vl-change',
         description:
-            'Event dat afgevuurd wordt als een radio aangevinkt wordt.<br>Het detail object van het event bevat de checked state en de waarde van de radio.',
+            'Event dat afgevuurd wordt als een radio aangevinkt of uitgevinkt wordt (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de checked state en de waarde van de radio.',
+        table: {
+            type: { summary: '{ checked: boolean, value?: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat alleen afgevuurd wordt als een gebruiker een radio aanvinkt.<br>Het detail object van het event bevat de checked state en de waarde van de radio.',
         table: {
             type: { summary: '{ checked: boolean, value?: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/radio-group/stories/vl-radio-group.stories.ts
+++ b/libs/form/src/next/radio-group/stories/vl-radio-group.stories.ts
@@ -34,7 +34,8 @@ export const RadioGroupDefault = story(
         label,
         name,
         value,
-        onVlChecked,
+        onVlChange,
+        onVlInput,
         onVlReset,
         onVlValid,
     }) => html`
@@ -48,7 +49,8 @@ export const RadioGroupDefault = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
-            @vl-checked=${onVlChecked}
+            @vl-change=${onVlChange}
+            @vl-input=${onVlInput}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}
         >

--- a/libs/form/src/next/radio-group/stories/vl-radio.stories-arg.ts
+++ b/libs/form/src/next/radio-group/stories/vl-radio.stories-arg.ts
@@ -4,13 +4,19 @@ import { ArgTypes } from '@storybook/web-components';
 import { radioDefaults } from '../vl-radio.defaults';
 
 type RadioArgs = typeof defaultArgs &
-    typeof radioDefaults & { defaultSlot: string; onVlChecked: () => void; onVlValid: () => void };
+    typeof radioDefaults & {
+        defaultSlot: string;
+        onVlChange: () => void;
+        onVlInput: () => void;
+        onVlValid: () => void;
+    };
 
 export const radioArgs: RadioArgs = {
     ...defaultArgs,
     ...radioDefaults,
     defaultSlot: '',
-    onVlChecked: action('vl-checked'),
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
 
@@ -116,8 +122,17 @@ export const radioArgTypes: ArgTypes<RadioArgs> = {
             defaultValue: { summary: radioArgs.defaultSlot },
         },
     },
-    onVlChecked: {
-        name: 'vl-checked',
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als de radio aangevinkt of uitgevinkt wordt (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de checked state en de waarde van de radio.',
+        table: {
+            type: { summary: '{ checked: boolean, value?: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
         description:
             'Event dat afgevuurd wordt als de radio aangevinkt wordt.<br>Het detail object van het event bevat de checked state en de waarde van de radio.',
         table: {

--- a/libs/form/src/next/radio-group/stories/vl-radio.stories.ts
+++ b/libs/form/src/next/radio-group/stories/vl-radio.stories.ts
@@ -30,7 +30,8 @@ export const RadioDefault = story(
         success,
         value,
         defaultSlot,
-        onVlChecked,
+        onVlChange,
+        onVlInput,
         onVlValid,
     }) => html`
         <vl-radio-next
@@ -44,7 +45,8 @@ export const RadioDefault = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
-            @vl-checked=${onVlChecked}
+            @vl-change=${onVlChange}
+            @vl-input=${onVlInput}
             @vl-valid=${onVlValid}
         >
             ${unsafeHTML(defaultSlot)}

--- a/libs/form/src/next/radio-group/vl-radio-group.component.cy.ts
+++ b/libs/form/src/next/radio-group/vl-radio-group.component.cy.ts
@@ -332,7 +332,7 @@ describe('component - vl-radio-group-next - in form', () => {
             .shouldHaveComputedStyle({ pseudo: ':after', style: 'border-color', value: 'rgb(210, 55, 60)' });
     });
 
-    it('should dispatch vl-checked event on check', () => {
+    it('should dispatch vl-input & vl-change event on check', () => {
         cy.mount(html`
             <vl-radio-group-next id="land-zee" name="land-zee">
                 <vl-radio-next value="land">Land</vl-radio-next>
@@ -342,16 +342,42 @@ describe('component - vl-radio-group-next - in form', () => {
         `);
         const value = 'land';
 
-        cy.createStubForEvent('vl-radio-group-next', 'vl-checked');
+        cy.createStubForEvent('vl-radio-group-next', 'vl-change');
+        cy.createStubForEvent('vl-radio-group-next', 'vl-input');
         cy.get('vl-radio-group-next')
             .find(`vl-radio-next[value=${value}]`)
             .shadow()
             .find('.vl-radio__toggle')
             .click({ force: true });
-        cy.get('@vl-checked')
+        cy.get('@vl-change')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', { checked: true, value });
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+    });
+
+    it('should only dispatch vl-change but not vl-input event on checking programmatically', () => {
+        cy.mount(html`
+            <vl-radio-group-next id="land-zee" name="land-zee">
+                <vl-radio-next value="land">Land</vl-radio-next>
+                <vl-radio-next value="zee">Zee</vl-radio-next>
+                <vl-radio-next value="lucht">Lucht</vl-radio-next>
+            </vl-radio-group-next>
+        `);
+        const value = 'lucht';
+
+        cy.createStubForEvent('vl-radio-group-next', 'vl-change');
+        cy.createStubForEvent('vl-radio-group-next', 'vl-input');
+        cy.get('vl-radio-group-next').invoke('attr', 'value', value);
+
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
     it('should set success', () => {

--- a/libs/form/src/next/radio-group/vl-radio-group.component.ts
+++ b/libs/form/src/next/radio-group/vl-radio-group.component.ts
@@ -32,7 +32,7 @@ export class VlRadioGroupComponent extends FormControl {
     connectedCallback() {
         super.connectedCallback();
 
-        this.addEventListener('vl-checked', this.updateGroupAfterCheck);
+        this.addEventListener('vl-change', this.updateGroupAfterCheck);
         this.addEventListener('keydown', this.handleKeyDown);
     }
 
@@ -87,7 +87,7 @@ export class VlRadioGroupComponent extends FormControl {
     disconnectedCallback() {
         super.disconnectedCallback();
 
-        this.removeEventListener('vl-checked', this.updateGroupAfterCheck);
+        this.removeEventListener('vl-change', this.updateGroupAfterCheck);
     }
 
     render(): TemplateResult {

--- a/libs/form/src/next/radio-group/vl-radio.component.cy.ts
+++ b/libs/form/src/next/radio-group/vl-radio.component.cy.ts
@@ -56,15 +56,42 @@ describe('component - vl-radio-next', () => {
             .shouldHaveComputedStyle({ pseudo: ':after', style: 'border-color', value: 'rgb(0, 158, 71)' });
     });
 
-    it('should dispatch vl-checked event on check', () => {
+    it('should dispatch vl-change & vl-input event on check', () => {
         const value = 'test';
 
         cy.mount(html`<vl-radio-next label="plaats" value=${value}></vl-radio-next>`);
         cy.injectAxe();
-        cy.createStubForEvent('vl-radio-next', 'vl-checked');
+        cy.createStubForEvent('vl-radio-next', 'vl-input');
+        cy.createStubForEvent('vl-radio-next', 'vl-change');
 
         cy.get('vl-radio-next').shadow().find('.vl-radio__toggle').click({ force: true });
-        cy.get('@vl-checked')
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.checkA11y('vl-radio-next');
+
+        cy.get('vl-radio-next').shadow().find('.vl-radio__toggle').click({ force: true });
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { checked: true, value });
+        cy.checkA11y('vl-radio-next');
+    });
+
+    it('should dispatch vl-change but not vl-input when changing value programmatically', () => {
+        const value = 'test';
+
+        cy.mount(html`<vl-radio-next label="plaats" value=${value}></vl-radio-next>`);
+        cy.injectAxe();
+        cy.createStubForEvent('vl-radio-next', 'vl-input');
+        cy.createStubForEvent('vl-radio-next', 'vl-change');
+
+        cy.get('vl-radio-next').invoke('attr', 'checked', 'true');
+        cy.get('@vl-input').its('callCount').should('eq', 0);
+        cy.checkA11y('vl-radio-next');
+
+        cy.get('@vl-change')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', { checked: true, value });

--- a/libs/form/src/next/radio-group/vl-radio.component.ts
+++ b/libs/form/src/next/radio-group/vl-radio.component.ts
@@ -22,6 +22,9 @@ export class VlRadioComponent extends BaseLitElement {
     private success = radioDefaults.success;
     private checked = radioDefaults.checked;
 
+    // Variables
+    private dispatchInput = false;
+
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
     static get styles(): (CSSResult | CSSResult[])[] {
@@ -50,13 +53,11 @@ export class VlRadioComponent extends BaseLitElement {
             if (this.checked) {
                 const detail = { checked: true, value: this.value };
 
-                this.dispatchEvent(
-                    new CustomEvent('vl-checked', {
-                        bubbles: true,
-                        composed: true,
-                        detail,
-                    })
-                );
+                this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+                if (this.dispatchInput) {
+                    this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                    this.dispatchInput = false;
+                }
                 this.dispatchEvent(new CustomEvent('vl-valid', { composed: true, bubbles: true, detail }));
             }
         }
@@ -83,6 +84,7 @@ export class VlRadioComponent extends BaseLitElement {
                     ?disabled=${this.disabled}
                     ?readonly=${this.readonly}
                     @change=${this.onChange}
+                    @input=${this.onInput}
                 />
                 <div class="vl-radio__label">
                     <span id="label-text">
@@ -99,6 +101,10 @@ export class VlRadioComponent extends BaseLitElement {
 
     private onChange() {
         this.checked = !this.checked;
+    }
+
+    private onInput() {
+        this.dispatchInput = true;
     }
 }
 

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories-arg.ts
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories-arg.ts
@@ -6,12 +6,18 @@ import { selectRichDefaults } from '../vl-select-rich.defaults';
 import { SelectRichPosition } from '../vl-select-rich.model';
 
 type SelectRichArgs = typeof formControlArgs &
-    typeof selectRichDefaults & { onVlSelect: () => void; onVlSelectSearch: () => void; onVlValid: () => void };
+    typeof selectRichDefaults & {
+        onVlChange: () => void;
+        onVlInput: () => void;
+        onVlSelectSearch: () => void;
+        onVlValid: () => void;
+    };
 
 export const selectRichArgs: SelectRichArgs = {
     ...formControlArgs,
     ...selectRichDefaults,
-    onVlSelect: action('vl-select'),
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
     onVlSelectSearch: action('vl-select-search'),
     onVlValid: action('vl-valid'),
 };
@@ -112,10 +118,19 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
             defaultValue: { summary: selectRichArgs.options },
         },
     },
-    onVlSelect: {
-        name: 'vl-select',
+    onVlChange: {
+        name: 'vl-change',
         description:
             'Event dat afgevuurd wordt als er een optie selecteerd of verwijderd wordt.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
+        table: {
+            type: { summary: '{ value: string | string[] }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat enkel afgevuurd wordt als de gebruiker een optie selecteert of verwijdert.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
         table: {
             type: { summary: '{ value: string | string[] }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories-doc.mdx
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories-doc.mdx
@@ -60,9 +60,14 @@ Er werd gebruik gemaakt van een `data:` attribuut om een SVG op te halen van w3.
 Hierdoor breekt de CSP compliance tenzij je alle `data:` attributen whitelist, wat niet de bedoeling is.
 
 
-## Select event
+## Change event
 
-Bij het selecteren of verwijderen van een optie wordt het `vl-select` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+Bij het selecteren of verwijderen van een optie (zowel programmatorisch als door de gebruiker) wordt het `vl-change` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de multi select een array van strings.
+
+## Input event
+
+Wanneer de gebruiker een optie verwijdert of selecteert, wordt het `vl-input` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
 Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de multi select een array van strings.
 
 

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories.ts
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories.ts
@@ -44,7 +44,8 @@ const SelectRichTemplate = story(
         noResultsText,
         noChoicesText,
         searchPlaceholder,
-        onVlSelect,
+        onVlChange,
+        onVlInput,
         onVlSelectSearch,
         onVlReset,
         onVlValid,
@@ -67,7 +68,8 @@ const SelectRichTemplate = story(
             no-results-text=${noResultsText}
             no-choices-text=${noChoicesText}
             search-placeholder=${searchPlaceholder}
-            @vl-select=${onVlSelect}
+            @vl-change=${onVlChange}
+            @vl-input=${onVlInput}
             @vl-select-search=${onVlSelectSearch}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}

--- a/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
@@ -345,11 +345,11 @@ describe('component - vl-select-rich-next - single', () => {
         cy.checkA11y('vl-select-rich-next');
     });
 
-    it('should dispatch vl-select event on select and delete option', () => {
+    it('should dispatch vl-change event on select and delete option', () => {
         cy.mount(html`<vl-select-rich-next label="geboorteplaats" .options=${options}></vl-select-rich-next>`);
         cy.injectAxe();
 
-        cy.createStubForEvent('vl-select-rich-next', 'vl-select');
+        cy.createStubForEvent('vl-select-rich-next', 'vl-change');
         cy.checkA11y('vl-select-rich-next');
         cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich-next')
@@ -358,7 +358,7 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-select__item')
             .contains('Hasselt')
             .click();
-        cy.get('@vl-select')
+        cy.get('@vl-change')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', { value: 'hasselt' });
@@ -368,11 +368,76 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-select__item')
             .find('.vl-pill__close')
             .click();
-        cy.get('@vl-select')
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
             .should('deep.equal', { value: null });
         cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should dispatch vl-select on select and delete option', () => {
+        cy.mount(html`<vl-select-rich-next label="geboorteplaats" .options=${options}></vl-select-rich-next>`);
+        cy.injectAxe();
+        cy.createStubForEvent('vl-select-rich-next', 'vl-input');
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Hasselt')
+            .click();
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-input-field')
+            .find('.vl-select__item')
+            .find('.vl-pill__close')
+            .click();
+        cy.get('@vl-input')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should dispatch vl-change, but not vl-select when programmatically selecting and deleting option', () => {
+        cy.mount(html`<vl-select-rich-next label="geboorteplaats" .options=${options}></vl-select-rich-next>`);
+        cy.injectAxe();
+        cy.createStubForEvent('vl-select-rich-next', 'vl-change');
+        cy.createStubForEvent('vl-select-rich-next', 'vl-input');
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'hasselt');
+            select.options = [...filteredOptions, { label: 'Hasselt', value: 'hasselt', selected: true }];
+        });
+
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'hasselt');
+            select.options = [...filteredOptions, { label: 'Hasselt', value: 'hasselt' }];
+        });
+
+        cy.get('@vl-change')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.checkA11y('vl-select-rich-next');
+
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
     });
 
     it('should dispatch vl-select-search event on input search value', () => {
@@ -585,11 +650,11 @@ describe('component - vl-select-rich-next - multiple', () => {
         cy.checkA11y('vl-select-rich-next');
     });
 
-    it('should dispatch vl-select event on select and delete option', () => {
+    it('should dispatch vl-change event on select and delete option', () => {
         cy.mount(html`<vl-select-rich-next label="hobby's" multiple .options=${options}></vl-select-rich-next>`);
         cy.injectAxe();
 
-        cy.createStubForEvent('vl-select-rich-next', 'vl-select');
+        cy.createStubForEvent('vl-select-rich-next', 'vl-change');
         cy.checkA11y('vl-select-rich-next');
         cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich-next')
@@ -598,7 +663,7 @@ describe('component - vl-select-rich-next - multiple', () => {
             .find('.vl-select__item')
             .contains('Padel')
             .click();
-        cy.get('@vl-select')
+        cy.get('@vl-change')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
             .should('deep.equal', { value: ['padel'] });
@@ -608,7 +673,7 @@ describe('component - vl-select-rich-next - multiple', () => {
             .find('.vl-select__item')
             .contains('Dans')
             .click();
-        cy.get('@vl-select')
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
             .should('deep.equal', { value: ['padel', 'dans'] });
@@ -618,10 +683,98 @@ describe('component - vl-select-rich-next - multiple', () => {
             .find('.vl-select__item[data-value="padel"]')
             .find('.vl-pill__close')
             .click();
-        cy.get('@vl-select').its('callCount').should('eq', 3);
-        cy.get('@vl-select')
+        cy.get('@vl-change').its('callCount').should('eq', 3);
+        cy.get('@vl-change')
             .its('lastCall.args.0.detail')
             .should('deep.equal', { value: ['dans'] });
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should dispatch vl-select event on select and delete option', () => {
+        cy.mount(html`<vl-select-rich-next label="hobby's" multiple .options=${options}></vl-select-rich-next>`);
+        cy.injectAxe();
+
+        cy.createStubForEvent('vl-select-rich-next', 'vl-input');
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Padel')
+            .click();
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: ['padel'] });
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Dans')
+            .click();
+        cy.get('@vl-input')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: ['padel', 'dans'] });
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-input-field')
+            .find('.vl-select__item[data-value="padel"]')
+            .find('.vl-pill__close')
+            .click();
+        cy.get('@vl-input').its('callCount').should('eq', 3);
+        cy.get('@vl-input')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { value: ['dans'] });
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should dispatch vl-change, but not vl-select when programmatically selecting and deleting option', () => {
+        cy.mount(html`<vl-select-rich-next label="hobby's" multiple .options=${options}></vl-select-rich-next>`);
+        cy.injectAxe();
+        cy.createStubForEvent('vl-select-rich-next', 'vl-change');
+        cy.createStubForEvent('vl-select-rich-next', 'vl-input');
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'padel');
+            select.options = [...filteredOptions, { label: 'Padel', value: 'padel', selected: true }];
+        });
+
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: ['padel'] });
+
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'dans');
+            select.options = [...filteredOptions, { label: 'Dans', value: 'dans', selected: true }];
+        });
+
+        cy.get('@vl-change')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: ['padel', 'dans'] });
+
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.checkA11y('vl-select-rich-next');
+
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'padel');
+            select.options = [...filteredOptions, { label: 'Padel', value: 'padel' }];
+        });
+
+        cy.get('@vl-change')
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { value: ['dans'] });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
         cy.checkA11y('vl-select-rich-next');
     });
 

--- a/libs/form/src/next/select-rich/vl-select-rich.component.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.ts
@@ -36,6 +36,7 @@ export class VlSelectRichComponent extends FormControl {
 
     // State
     private value: FormValue = null;
+    private dispatchInput = false;
 
     // Variables
     private choices: Choices | null = null;
@@ -118,7 +119,11 @@ export class VlSelectRichComponent extends FormControl {
             const detail = { value: this.getSelected() };
 
             this.setValue(this.value);
-            this.dispatchEvent(new CustomEvent('vl-select', { bubbles: true, composed: true, detail }));
+            this.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
 
@@ -167,6 +172,8 @@ export class VlSelectRichComponent extends FormControl {
                 ?error=${this.error}
                 ?multiple=${this.multiple}
                 @change=${this.onChange}
+                @choice=${this.onSelect}
+                @removeItem=${this.onSelect}
             ></select>
         `;
     }
@@ -350,6 +357,10 @@ export class VlSelectRichComponent extends FormControl {
 
     private onChange() {
         this.value = this.collectFormData();
+    }
+
+    private onSelect() {
+        this.dispatchInput = true;
     }
 
     private onClickChoices = (event: Event) => {

--- a/libs/form/src/next/select/stories/vl-select.stories-arg.ts
+++ b/libs/form/src/next/select/stories/vl-select.stories-arg.ts
@@ -4,12 +4,14 @@ import { formControlArgs, formControlArgTypes } from '../../form-control/stories
 import { selectDefaults } from '../vl-select.defaults';
 import { action } from '@storybook/addon-actions';
 
-type SelectArgs = typeof formControlArgs & typeof selectDefaults & { onVlSelect: () => void; onVlValid: () => void };
+type SelectArgs = typeof formControlArgs &
+    typeof selectDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
 
 export const selectArgs: SelectArgs = {
     ...formControlArgs,
     ...selectDefaults,
-    onVlSelect: action('vl-select'),
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
 
@@ -61,10 +63,19 @@ export const selectArgTypes: ArgTypes<SelectArgs> = {
             defaultValue: { summary: selectArgs.options },
         },
     },
-    onVlSelect: {
-        name: 'vl-select',
+    onVlChange: {
+        name: 'vl-change',
         description:
-            'Event dat afgevuurd wordt als er een optie selecteerd of verwijderd wordt.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.',
+            'Event dat afgevuurd wordt als er een optie selecteerd of verwijderd wordt (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de waarde van de geselecteerde optie.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat alleen afgevuurd wordt als de gebruiker een optie selecteert of verwijdert.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.',
         table: {
             type: { summary: '{ value: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/select/stories/vl-select.stories-doc.mdx
+++ b/libs/form/src/next/select/stories/vl-select.stories-doc.mdx
@@ -55,9 +55,14 @@ Er werd gebruik gemaakt van een `data:` attribuut om een SVG op te halen van w3.
 Hierdoor breekt de CSP compliance tenzij je alle `data:` attributen whitelist, wat niet de bedoeling is.
 
 
-## Select event
+## Change event
 
-Bij het selecteren of verwijderen van een optie wordt het `vl-select` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+Bij het selecteren of verwijderen van een optie (zowel programmatorisch als door een gebruiker), wordt het `vl-change` event afgevuurd. Het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+
+## Input event
+
+Als de gebruiker een optie selecteert of verwijdert, wordt het `vl-input` event afgevuurd. Het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+
 
 
 ## Select opties

--- a/libs/form/src/next/select/stories/vl-select.stories.ts
+++ b/libs/form/src/next/select/stories/vl-select.stories.ts
@@ -36,7 +36,8 @@ const SelectTemplate = story(
         notDeletable,
         autocomplete,
         block,
-        onVlSelect,
+        onVlChange,
+        onVlInput,
         onVlValid,
         onVlReset,
     }) => {
@@ -53,7 +54,8 @@ const SelectTemplate = story(
             ?not-deletable=${notDeletable}
             ?block=${block}
             autocomplete=${autocomplete}
-            @vl-select=${onVlSelect}
+            @vl-change=${onVlChange}
+            @vl-input=${onVlInput}
             @vl-valid=${onVlValid}
             @vl-reset=${onVlReset}
         ></vl-select-next>`;

--- a/libs/form/src/next/select/vl-select.component.cy.ts
+++ b/libs/form/src/next/select/vl-select.component.cy.ts
@@ -140,22 +140,73 @@ describe('component - vl-select-next', () => {
         cy.get('vl-select-next').shadow().find('select').should('have.class', 'vl-select--block');
     });
 
-    it('should dispatch vl-select event on select and delete option', () => {
+    it('should dispatch vl-change event on select and delete option', () => {
         cy.mount(html`<vl-select-next label="geboorteplaats" .options=${options}></vl-select-next>`);
         cy.injectAxe();
 
-        cy.createStubForEvent('vl-select-next', 'vl-select');
+        cy.createStubForEvent('vl-select-next', 'vl-change');
         cy.checkA11y('vl-select-next');
-        cy.get('vl-select-next').shadow().find('select').select('hasselt').trigger('change');
-        cy.get('@vl-select')
+        cy.get('vl-select-next').shadow().find('select').select('turnhout').trigger('change');
+        cy.get('@vl-change')
             .should('have.been.calledOnce')
             .its('firstCall.args.0.detail')
-            .should('deep.equal', { value: 'hasselt' });
+            .should('deep.equal', { value: 'turnhout' });
         cy.get('vl-select-next').shadow().find('button.vl-select__button').click();
-        cy.get('@vl-select')
+        cy.get('@vl-change')
             .should('have.been.calledTwice')
             .its('secondCall.args.0.detail')
             .should('deep.equal', { value: null });
+        cy.checkA11y('vl-select-next');
+    });
+
+    it('should dispatch vl-select event when the user selects and deletes an option', () => {
+        cy.mount(html`<vl-select-next label="geboorteplaats" .options=${options}></vl-select-next>`);
+        cy.injectAxe();
+
+        cy.createStubForEvent('vl-select-next', 'vl-input');
+        cy.checkA11y('vl-select-next');
+        cy.get('vl-select-next').shadow().find('select').select('turnhout');
+
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'turnhout' });
+        cy.get('vl-select-next').shadow().find('button.vl-select__button').click();
+        cy.get('@vl-input')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.checkA11y('vl-select-next');
+    });
+
+    it('should dispatch vl-change, but not vl-select when programmatically selecting and deleting option', () => {
+        cy.mount(html`<vl-select-next label="geboorteplaats" .options=${options}></vl-select-next>`);
+        cy.injectAxe();
+
+        cy.createStubForEvent('vl-select-next', 'vl-change');
+        cy.createStubForEvent('vl-select-next', 'vl-input');
+        cy.checkA11y('vl-select-next');
+        cy.get('vl-select-next').then((el) => {
+            const select = el[0] as VlSelectComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'turnhout');
+            select.options = [...filteredOptions, { label: 'Turnhout', value: 'turnhout', selected: true }];
+        });
+        cy.get('@vl-change')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'turnhout' });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-next').then((el) => {
+            const select = el[0] as VlSelectComponent;
+            const filteredOptions = select.options.filter((option) => option.value !== 'turnhout');
+            select.options = [...filteredOptions, { label: 'Turnhout', value: 'turnhout' }];
+        });
+        cy.get('@vl-change')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
         cy.checkA11y('vl-select-next');
     });
 

--- a/libs/form/src/next/select/vl-select.component.ts
+++ b/libs/form/src/next/select/vl-select.component.ts
@@ -27,6 +27,7 @@ export class VlSelectComponent extends FormControl {
     // Variables
     private initialOptions = [] as SelectOption[];
     private DEFAULT_GROUP_LABEL = 'Overig';
+    private dispatchInput = false;
 
     static get styles(): CSSResult[] {
         return [resetStyle, baseStyle, selectStyle, iconStyle, selectUigStyle];
@@ -64,7 +65,11 @@ export class VlSelectComponent extends FormControl {
             const detail = { value: this.value };
 
             this.setValue(this.value);
-            this.dispatchEvent(new CustomEvent('vl-select', { composed: true, bubbles: true, detail }));
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
     }
@@ -97,6 +102,7 @@ export class VlSelectComponent extends FormControl {
                     .value=${live(this.value)}
                     autocomplete=${this.autocomplete || nothing}
                     @change=${this.onChange}
+                    @input=${this.onSelect}
                 >
                     ${this.placeholder ? this.renderPlaceholder(hasValue) : nothing}
                     ${hasGroups ? this.renderGroupedOptions() : this.renderSelectOptions(this.options)}
@@ -160,7 +166,12 @@ export class VlSelectComponent extends FormControl {
         this.value = event?.target?.value;
     }
 
+    private onSelect() {
+        this.dispatchInput = true;
+    }
+
     private clearValue() {
+        this.dispatchInput = true;
         this.value = null;
     }
 

--- a/libs/form/src/next/textarea-rich/stories/vl-textarea-rich.stories.ts
+++ b/libs/form/src/next/textarea-rich/stories/vl-textarea-rich.stories.ts
@@ -44,6 +44,7 @@ const Template = story(
         plugins,
         preview,
         customConfig,
+        onVlChange,
         onVlInput,
         onVlReset,
         onVlValid,
@@ -66,6 +67,7 @@ const Template = story(
             plugins=${plugins}
             ?preview=${preview}
             .customConfig=${customConfig}
+            @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}

--- a/libs/form/src/next/textarea-rich/vl-textarea-rich.component.cy.ts
+++ b/libs/form/src/next/textarea-rich/vl-textarea-rich.component.cy.ts
@@ -84,12 +84,27 @@ describe('component - vl-textarea-next', () => {
         cy.get('vl-textarea-rich-next').shadow().find('.tox-editor-header').should('not.be.visible');
     });
 
-    it('should dispatch vl-input event on input', () => {
-        cy.mount(html`<vl-textarea-rich-next></vl-textarea-rich-next>`);
-        cy.createStubForEvent('vl-textarea-rich-next', 'vl-input');
+    it('should dispatch both vl-input & vl-change events on input', () => {
+        cy.mount(html`<vl-textarea-next></vl-textarea-next>`);
+        cy.createStubForEvent('vl-textarea-next', 'vl-input');
+        cy.createStubForEvent('vl-textarea-next', 'vl-change');
 
-        cy.get('vl-textarea-rich-next').invoke('attr', 'value', 'test');
-        cy.get('@vl-input').its('callCount').should('eq', 1);
-        cy.get('@vl-input').its('firstCall.args.0.detail').should('deep.equal', { value: 'test' });
+        cy.get('vl-textarea-next').shadow().find('textarea').type('test');
+        cy.get('@vl-input').its('callCount').should('eq', 4);
+        cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        // change event wordt ook gedispatched bij focus verandering, daarom 1 extra
+        cy.get('@vl-change').its('callCount').should('eq', 5);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+    });
+
+    it('should dispatch vl-change event on programmatic value change but no vl-input events', () => {
+        cy.mount(html`<vl-textarea-next></vl-textarea-next>`);
+        cy.createStubForEvent('vl-textarea-next', 'vl-change');
+        cy.createStubForEvent('vl-textarea-next', 'vl-input');
+
+        cy.get('vl-textarea-next').invoke('attr', 'value', 'test');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 });

--- a/libs/form/src/next/textarea/stories/vl-textarea.stories-arg.ts
+++ b/libs/form/src/next/textarea/stories/vl-textarea.stories-arg.ts
@@ -4,11 +4,13 @@ import { ArgTypes } from '@storybook/web-components';
 import { formControlArgs, formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
 import { textareaDefaults } from '../vl-textarea.defaults';
 
-type TextareaArgs = typeof formControlArgs & typeof textareaDefaults & { onVlInput: () => void; onVlValid: () => void };
+type TextareaArgs = typeof formControlArgs &
+    typeof textareaDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
 
 export const textareaArgs: TextareaArgs = {
     ...formControlArgs,
     ...textareaDefaults,
+    onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
 };
@@ -101,10 +103,19 @@ export const textareaArgTypes: ArgTypes<TextareaArgs> = {
             defaultValue: { summary: textareaArgs.cols },
         },
     },
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als de waarde van het textarea veld verandert (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de ingegeven waarde.',
+        table: {
+            type: { summary: '{ value: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
     onVlInput: {
         name: 'vl-input',
         description:
-            'Event dat afgevuurd wordt als de waarde van het textarea veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
+            'Event dat alleen afgevuurd wordt als een gebruiker de waarde van het textarea veld verandert.<br>Het detail object van het event bevat de ingegeven waarde.',
         table: {
             type: { summary: '{ value: string }' },
             category: CATEGORIES.EVENTS,

--- a/libs/form/src/next/textarea/stories/vl-textarea.stories.ts
+++ b/libs/form/src/next/textarea/stories/vl-textarea.stories.ts
@@ -40,6 +40,7 @@ export const TextareaDefault = story(
         maxLength,
         rows,
         cols,
+        onVlChange,
         onVlInput,
         onVlReset,
         onVlValid,
@@ -61,6 +62,7 @@ export const TextareaDefault = story(
             max-length=${maxLength}
             rows=${rows}
             cols=${cols}
+            @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-reset=${onVlReset}
             @vl-valid=${onVlValid}

--- a/libs/form/src/next/textarea/vl-textarea.component.cy.ts
+++ b/libs/form/src/next/textarea/vl-textarea.component.cy.ts
@@ -105,13 +105,28 @@ describe('component - vl-textarea-next', () => {
         cy.get('vl-textarea-next').shadow().find('textarea').should('have.attr', 'cols', 10);
     });
 
-    it('should dispatch vl-input event on input', () => {
+    it('should dispatch both vl-input & vl-change events on input', () => {
         cy.mount(html`<vl-textarea-next></vl-textarea-next>`);
         cy.createStubForEvent('vl-textarea-next', 'vl-input');
+        cy.createStubForEvent('vl-textarea-next', 'vl-change');
 
         cy.get('vl-textarea-next').shadow().find('textarea').type('test');
-        cy.get('@vl-input').its('callCount').should('eq', 5);
+        cy.get('@vl-input').its('callCount').should('eq', 4);
         cy.get('@vl-input').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        // change event wordt ook gedispatched bij focus verandering, daarom 1 extra
+        cy.get('@vl-change').its('callCount').should('eq', 5);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+    });
+
+    it('should dispatch vl-change event on programmatic value change but no vl-input events', () => {
+        cy.mount(html`<vl-textarea-next></vl-textarea-next>`);
+        cy.createStubForEvent('vl-textarea-next', 'vl-change');
+        cy.createStubForEvent('vl-textarea-next', 'vl-input');
+
+        cy.get('vl-textarea-next').invoke('attr', 'value', 'test');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: 'test' });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
     it('should dispatch vl-valid event on valid input', () => {

--- a/libs/form/src/next/textarea/vl-textarea.component.ts
+++ b/libs/form/src/next/textarea/vl-textarea.component.ts
@@ -23,6 +23,7 @@ export class VlTextareaComponent extends FormControl {
 
     // Variables
     protected initialValue = '';
+    protected dispatchInput = false;
 
     static formControlValidators = [...FormControl.formControlValidators, minLengthValidator, maxLengthValidator];
 
@@ -59,7 +60,11 @@ export class VlTextareaComponent extends FormControl {
             const detail = { value: this.value };
 
             this.setValue(this.value);
-            this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+                this.dispatchInput = false;
+            }
             this.dispatchEventIfValid(detail);
         }
     }
@@ -106,6 +111,7 @@ export class VlTextareaComponent extends FormControl {
     }
 
     private onInput(event: Event & { target: HTMLTextAreaElement }) {
+        this.dispatchInput = true;
         this.value = event?.target?.value;
     }
 }

--- a/libs/form/src/next/upload/stories/vl-upload.stories-arg.ts
+++ b/libs/form/src/next/upload/stories/vl-upload.stories-arg.ts
@@ -6,6 +6,7 @@ import { uploadDefaults } from '../vl-upload.defaults';
 
 type UploadArgs = typeof uploadDefaults &
     typeof formControlArgs & {
+        onVlChange: () => void;
         onVlInput: () => void;
         onVlError: () => void;
         onVlValid: () => void;
@@ -14,6 +15,7 @@ type UploadArgs = typeof uploadDefaults &
 export const uploadArgs: UploadArgs = {
     ...formControlArgs,
     ...uploadDefaults,
+    onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
     onVlError: action('vl-error'),
@@ -158,10 +160,21 @@ export const uploadArgTypes: ArgTypes<UploadArgs> = {
             defaultValue: { summary: uploadArgs.url },
         },
     },
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als bestanden worden toegevoegd of verwijderd (zowel programmatorisch als door een gebruiker).<br>Het detail object van het event bevat de ingegeven waarde.<br>Daarnaast geeft het ook aan welke file werd verwijderd of toegevoegd.',
+        table: {
+            type: {
+                summary: '{ value: string, type: string, file: File}',
+            },
+            category: CATEGORIES.EVENTS,
+        },
+    },
     onVlInput: {
         name: 'vl-input',
         description:
-            'Event dat afgevuurd wordt als bestanden worden toegevoegd of verwijderd.<br>Het detail object van het event bevat de ingegeven waarde.<br>Daarnaast geeft het ook aan welke file werd verwijderd of toegevoegd.',
+            'Event dat alleen afgevuurd wordt als bestanden worden toegevoegd of verwijderd door een gebruiker.<br>Het detail object van het event bevat de ingegeven waarde.<br>Daarnaast geeft het ook aan welke file werd verwijderd of toegevoegd.',
         table: {
             type: {
                 summary: '{ value: string, type: string, file: File}',

--- a/libs/form/src/next/upload/stories/vl-upload.stories.ts
+++ b/libs/form/src/next/upload/stories/vl-upload.stories.ts
@@ -42,6 +42,7 @@ export const UploadDefault = story(
         errorMessageMaxFiles,
         errorMessageFilesize,
         errorMessageAcceptedFiles,
+        onVlChange,
         onVlInput,
         onVlValid,
         onVlError,
@@ -66,6 +67,7 @@ export const UploadDefault = story(
                 error-message-max-files=${errorMessageMaxFiles}
                 error-message-filesize=${errorMessageFilesize}
                 error-message-accepted-files=${errorMessageAcceptedFiles}
+                @vl-change=${onVlChange}
                 @vl-input=${onVlInput}
                 @vl-valid=${onVlValid}
                 @vl-error=${onVlError}

--- a/libs/form/src/next/upload/vl-upload.component.ts
+++ b/libs/form/src/next/upload/vl-upload.component.ts
@@ -50,6 +50,7 @@ export class VlUploadComponent extends FormControl {
 
     // Variables
     private dropzoneInstance: DropzoneInstance | undefined | null;
+    private dispatchInput = false;
 
     static formControlValidators = [...FormControl.formControlValidators, dropzoneValidator];
 
@@ -267,6 +268,14 @@ export class VlUploadComponent extends FormControl {
         }
     }
 
+    removeFile(file: File) {
+        this.dropzoneInstance?.removeFile(<DropzoneFile>file);
+    }
+
+    removeAllFiles() {
+        this.dropzoneInstance?.removeAllFiles();
+    }
+
     /**
      * Handmatig de upload aanroepen. Indien een url gegeven is, laad op naar die url.
      */
@@ -444,6 +453,10 @@ export class VlUploadComponent extends FormControl {
         this.dropzoneInstance.on('dragover', this.handleDragOver);
         this.dropzoneInstance.on('dragleave', this.handleDragLeave);
         this.dropzoneInstance.on('drop', this.handleDragLeave);
+
+        this.getInput()?.addEventListener('input', () => {
+            this.dispatchInput = true;
+        });
     }
 
     private removeDropzoneEvents() {
@@ -464,13 +477,11 @@ export class VlUploadComponent extends FormControl {
 
     private updateValue(detail: { type: string; file?: DropzoneFile; value: FormValue }) {
         this.value = this.collectFormData();
-        this.dispatchEvent(
-            new CustomEvent('vl-input', {
-                composed: true,
-                bubbles: true,
-                detail: detail,
-            })
-        );
+        this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+        if (this.dispatchInput) {
+            this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
+            this.dispatchInput = false;
+        }
         this.dispatchEventIfValid(detail);
     }
 
@@ -511,6 +522,7 @@ export class VlUploadComponent extends FormControl {
     private handleFilesCloseButtonClick = (event: Event) => {
         this.dropzoneInstance?.removeAllFiles();
         if (this.dropzoneInstance) this.updateFileList(this.dropzoneInstance);
+        this.dispatchInput = true;
         event.preventDefault();
     };
 
@@ -521,6 +533,7 @@ export class VlUploadComponent extends FormControl {
     private handleDragOver = () => {
         this.getUploadElement()?.classList.add('vl-upload--dragging');
     };
+
     private handleDragLeave = () => {
         this.getUploadElement()?.classList.remove('vl-upload--dragging');
     };


### PR DESCRIPTION
Vroeger was er geen mogelijkheid om op basis van events te weten, of de gebruiker de value veranderde, of als het programmatorisch gebeurde, in elk geval werd 1 event gedispatcht. Nu voorzien we aparte `vl-input` en `vl-change` events. Gelijkaardig aan de HTML-standaard, representeert `vl-input` event gebruikersinteractie terwijl `vl-change` event voor eender welke wijziging wordt voorzien.

Hierdoor zijn ook backwards incompatibele wijzigingen gebeurd; bij de vl-radio-group-next & vl-checkbox-next is er geen `vl-checked` event meer en bij de vl-select-next en vl-select-rich-next verdwijnt ook het `vl-select` event. In de plaats ervan wordt zoals voor alle andere form-next componenten zoals hierboven beschreven enkel de `vl-input` en `vl-change` events voorzien.

Storybook verbeterd & cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3106)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC425)