### PR TITLE
feat: UIG-3126 - vl-typography - gekende beperking gedocumenteerd in verband met event handling

### DIFF
--- a/libs/components/src/typography/stories/vl-typography.stories-doc.mdx
+++ b/libs/components/src/typography/stories/vl-typography.stories-doc.mdx
@@ -1,0 +1,69 @@
+import {ArgTypes, Canvas, Stories} from '@storybook/blocks';
+import * as VlTypographyStories from './vl-typography.stories';
+
+# Typography
+
+<VluxMetaData id="components-typography" />
+
+Gebruik de `typography` component om de standaard elementen binnen een container visueel te stylen. De typography
+component wordt voornamelijk gebruikt om de inhoud van een wysiwyg-editor te stylen zonder extra klassen toe te
+voegen voor elk element.
+
+## Voorbeeld
+
+```js
+import { VlTypographyComponent } from '@domg-wc/components';
+```
+
+```html
+<vl-typography></vl-typography>
+```
+
+
+## Default
+
+<Canvas of={VlTypographyStories.TypographyDefault}/>
+
+
+## Configuratie
+
+<ArgTypes of={VlTypographyStories.TypographyDefault}/>
+
+## Gekende beperkingen
+
+<VluxAlert type="warning">
+{`
+  De vl-typography component kan niet goed om met interactieve elementen zoals knoppen of formulieren. Het is
+  aangeraden om dit component enkel te gebruiken voor statische content.
+`}
+</VluxAlert>
+
+We raden dus aan om interactieve componenten buiten `vl-typography`-tags te definiëren en de `vl-typography` enkel
+te gebruiken om statische native html te stylen.
+
+Als je dan toch een interactief element in een `vl-typography`-tag wil gebruiken en de events van dat element wil
+afhandelen, kan je dit doen door een event listener toe te voegen aan de `vl-typography`-tag.
+
+In Lit kan dit bijvoorbeeld als volgt:
+
+```html
+<vl-typography @vl-click=${this.handleButtonClick}>
+   <vl-button-next>Indienen</vl-button-next>
+</vl-typography>
+```
+
+<Stories title={'Varianten'} includePrimary={false} />
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Typography](https://overheid.vlaanderen.be/webuniversum/v3/documentation/js-components/vl-ui-typography)
+
+### Legacy Documentatie
+
+[Legacy Storybook - Typography](https://webcomponenten.omgeving.vlaanderen.be/storybook/?path=/docs/custom-elements-vl-typography--default)
+
+[Legacy Documentatie - Typography](https://webcomponenten.omgeving.vlaanderen.be/doc/VlTypography.html)
+
+[Legacy Demo - Typography](https://webcomponenten.omgeving.vlaanderen.be/demo/vl-typography.html)

--- a/libs/components/src/typography/stories/vl-typography.stories.ts
+++ b/libs/components/src/typography/stories/vl-typography.stories.ts
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 import '../vl-typography.component';
 import { typographyArgs, typographyArgTypes } from './vl-typography.stories-arg';
+import typographyDocs from './vl-typography.stories-doc.mdx';
 
 export default {
     id: 'components-typography',
@@ -10,13 +11,16 @@ export default {
     args: typographyArgs,
     argTypes: typographyArgTypes,
     parameters: {
+        docs: {
+            page: typographyDocs,
+        },
         controls: {
             hideNoControlsWarning: true,
         },
     },
 } as Meta<typeof typographyArgs>;
 
-export const typographyDefault = () => html` <vl-typography data-cy="typography">
+export const TypographyDefault = () => html` <vl-typography data-cy="typography">
     <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
         <a href="#">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -26,9 +30,9 @@ export const typographyDefault = () => html` <vl-typography data-cy="typography"
     </p>
     <p>Lorem dolor sit amet, consectetur adipisicing elit. Deleniti, in.</p>
 </vl-typography>`;
-typographyDefault.storyName = 'vl-typography - default';
+TypographyDefault.storyName = 'vl-typography - default';
 
-export const typographyTitles = () => html` <vl-typography data-cy="typography">
+export const TypographyTitles = () => html` <vl-typography data-cy="typography">
     <h1>Heading 1</h1>
     <h2>Heading 2</h2>
     <h3>Heading 3</h3>
@@ -36,9 +40,9 @@ export const typographyTitles = () => html` <vl-typography data-cy="typography">
     <h5>Heading 5</h5>
     <h6>Heading 6</h6>
 </vl-typography>`;
-typographyTitles.storyName = 'vl-typography - titles';
+TypographyTitles.storyName = 'vl-typography - titles';
 
-export const typographyLists = () => html` <vl-typography data-cy="typography">
+export const TypographyLists = () => html` <vl-typography data-cy="typography">
     <ul>
         <li>Lorem ipsum dolor sit amet.</li>
         <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</li>
@@ -112,9 +116,9 @@ export const typographyLists = () => html` <vl-typography data-cy="typography">
         </li>
     </ul>
 </vl-typography>`;
-typographyLists.storyName = 'vl-typography - lists';
+TypographyLists.storyName = 'vl-typography - lists';
 
-export const typographyMarkup = () => html` <vl-typography data-cy="typography">
+export const TypographyMarkup = () => html` <vl-typography data-cy="typography">
     <p><strong>strong-tag</strong></p>
     <p><b>b-tag</b></p>
     <p><em>em-tag</em></p>
@@ -134,9 +138,9 @@ export const typographyMarkup = () => html` <vl-typography data-cy="typography">
     <blockquote>Lorem ipsum dolor sit amet.</blockquote>
     <p></p>
 </vl-typography>`;
-typographyMarkup.storyName = 'vl-typography - markup';
+TypographyMarkup.storyName = 'vl-typography - markup';
 
-export const typographyTable = () => html` <vl-typography data-cy="typography">
+export const TypographyTable = () => html` <vl-typography data-cy="typography">
     <table>
         <caption>
             table title
@@ -167,9 +171,9 @@ export const typographyTable = () => html` <vl-typography data-cy="typography">
         </tbody>
     </table>
 </vl-typography>`;
-typographyTable.storyName = 'vl-typography - table';
+TypographyTable.storyName = 'vl-typography - table';
 
-export const typographyParameters = ({ parameters, key1, key2 }: any) => {
+export const TypographyParameters = ({ parameters, key1, key2 }: any) => {
     return html` <vl-typography data-vl-parameters=${parameters} data-cy="typography">
         <p>
             Lorem <b>${key1}</b> dolor sit amet, consectetur adipiscing elit. Duis iaculis molestie feugiat. Lorem
@@ -186,12 +190,12 @@ export const typographyParameters = ({ parameters, key1, key2 }: any) => {
         </p>
     </vl-typography>`;
 };
-typographyParameters.storyName = 'vl-typography - parameters';
-typographyParameters.args = {
+TypographyParameters.storyName = 'vl-typography - parameters';
+TypographyParameters.args = {
     key1: '${parameter.key1}',
     key2: '${parameter.key1}',
 };
-typographyParameters.argTypes = {
+TypographyParameters.argTypes = {
     parameters: { control: { disable: false } },
     key1: { name: 'key1 (for demo purposes)' },
     key2: { name: 'key1 (for demo purposes)' },


### PR DESCRIPTION
De vl-typography component verplaatst slotted content naar zijn eigen shadow dom, dit zorgt voor problemen wanneer de afnemer probeert events af te handelen die uit de slotted content komen. Deze beperking is & bijhorende workaround is nu gedocumenteerd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3126)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC448)