### PR TITLE
fix: UIG-3129 - vl-link-next - onnodige witruimte verwijderd wanneer er geen icon is ingesteld

### DIFF
--- a/libs/components/src/next/link/vl-link.component.cy.ts
+++ b/libs/components/src/next/link/vl-link.component.cy.ts
@@ -85,6 +85,12 @@ describe('component - vl-link-next', () => {
             .should('have.class', 'vl-icon--left-margin');
     });
 
+    it('should not render icon when no icon value is set', () => {
+        cy.mount(html`<vl-link-next>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').shadow().find('a').find('span.vl-icon').should('not.exist');
+    });
+
     it('should set content', () => {
         cy.mount(html`<vl-link-next>Vlaanderen</vl-link-next>`);
 

--- a/libs/components/src/next/link/vl-link.component.ts
+++ b/libs/components/src/next/link/vl-link.component.ts
@@ -76,7 +76,7 @@ export class VlLinkComponent extends BaseLitElement {
             'vl-icon--left-margin': this.iconPlacement === 'after',
         };
 
-        return html`<span class=${classMap(classes)}></span>`;
+        return this.icon ? html`<span class=${classMap(classes)}></span>` : nothing;
     }
 
     renderExternalIcon(): TemplateResult {


### PR DESCRIPTION
Vroeger toonden we ofwel witruimte tussen het icon & link tekst, ongeacht of de icon was ingesteld, nu wordt het icon en bijhorende witruimte enkel gerenderd als er een icon is gedefiniëerd. Cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3129)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC451)