### PR TITLE
fix: UIG-3137 - vl-upload - upload timeout uitgeschakeld

### DIFF
--- a/libs/components/src/upload/vl-upload.component.ts
+++ b/libs/components/src/upload/vl-upload.component.ts
@@ -253,7 +253,7 @@ export class VlUploadComponent extends vlFormValidationElement(BaseHTMLElement) 
                 this.__triggerChange(file);
             });
             this._dropzone.on('duplicateRemoved', (file: File) => this.__duplicateRemoved(file));
-            this._dropzone.timeout = 0; // 0 value will disable the connection timeout
+            this._dropzone.options.timeout = 0; // 0 value will disable the connection timeout
         }
     }
 


### PR DESCRIPTION
Vroeger werd in de `vl-upload` op de verkeerde manier de timeout ingesteld waardoor die standaard op 30 seconden kwam te staan, nu is die correct ingesteld.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3137)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC453)

Voor de `vl-upload-next` is dit niet nodig gezien die gebruik maakte van een nieuwere versie van Dropzone waarin de default `timeout` ook op `null` staat (en er bijgevolg geen `timeout` is).

In code van Dropzone versie die afgenomen wordt in `vl-upload-next`:
<img width="617" alt="image" src="https://github.com/user-attachments/assets/7f3abe5f-4d70-4706-8aa8-3b4f9b8e1292">
