### PR TITLE
fix: UIG-3040 - vl-select-rich-next - timing voor initialisatie event listeners en value reset bijgewerkt

### DIFF
--- a/libs/form/src/next/select-rich/vl-select-rich.component.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.ts
@@ -3,6 +3,7 @@ import { SelectRichOption } from '@domg-wc/form/next/select-rich/vl-select-rich.
 import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
 import { iconStyle, inputFieldStyle } from '@domg/govflanders-style/component';
 import { FormValue } from '@open-wc/form-control/src/types';
+import * as choices from 'choices.js';
 import { Item, Options } from 'choices.js';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
@@ -11,7 +12,6 @@ import multiselectStyle from './styles/vl-multiselect.dv-css';
 import selectRichUigStyle from './styles/vl-select-rich.uig-css';
 import selectStyle from './styles/vl-select.dv-css';
 import { selectRichDefaults } from './vl-select-rich.defaults';
-import * as choices from 'choices.js';
 
 // web-dev-server (rollup) fix: ambiguous indirect export
 export const DEFAULT_CLASSNAMES = choices.DEFAULT_CLASSNAMES;
@@ -85,21 +85,29 @@ export class VlSelectRichComponent extends FormControl {
         this.choices = new Choices(this.validationTarget!, this.getChoicesConfig());
         this.initialOptions = [...JSON.parse(JSON.stringify(this.options))];
 
-        setTimeout(() => {
-            // Fix voor Choices.js dropdown te openen in een Shadow DOM
-            this.getChoicesElement()?.addEventListener('click', this.onClickChoices);
-
-            // Fix voor Choices.js dropdown te openen als er geklikt wordt op het label
-            this.internals.labels[0]?.addEventListener('click', this.onClickChoices);
-
+        this.updateComplete.then(() => {
             // Fix voor required validator
             if (!this.value) {
                 this.setValue(null);
             }
+        });
 
-            // Fix voor Choices.js search event dat niet afgevuurd wordt als de search value verwijderd wordt.
-            this.choices?.input?.element?.addEventListener('input', this.onSearchInput);
-        }, 0);
+        const checkInputReady = () => {
+            if (this.choices?.input) {
+                // Fix voor Choices.js dropdown te openen in een Shadow DOM
+                this.getChoicesElement()?.addEventListener('click', this.onClickChoices);
+
+                // Fix voor Choices.js dropdown te openen als er geklikt wordt op het label
+                this.internals.labels[0]?.addEventListener('click', this.onClickChoices);
+
+                // Fix voor Choices.js search event dat niet afgevuurd wordt als de search value verwijderd wordt.
+                this.choices?.input?.element?.addEventListener('input', this.onSearchInput);
+            } else {
+                // indien input nog niet klaar is, wachten we tot deze klaar is
+                requestAnimationFrame(checkInputReady);
+            }
+        };
+        checkInputReady();
     }
 
     updated(changedProperties: Map<string, unknown>) {


### PR DESCRIPTION
Vroeger werd de initialisatie van event listeners en het resetten van de form-control value uitgevoerd binnen een setTimeout die in de meeste gevallen werkte, maar voor bepaalde afnemers bij initialisatie problemen gaf. Nu worden de event listeners pas toegevoegd nadat de input gerenderd is & wordt de form-control value ook pas gereset nadat updateComplete Promise voldaan is.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3040)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC459)

Meer over Lit's [updateComplete](https://lit.dev/docs/components/lifecycle/#updatecomplete)