### PR TITLE
fix: UIG-3155 / UIG-3130 - vl-button-next - tertiary styling verbeterd & icon-only attribuut verwijderd

### DIFF
--- a/libs/common/utilities/src/index.ts
+++ b/libs/common/utilities/src/index.ts
@@ -27,7 +27,8 @@ export {
     ifDefinedNumber,
     findDeepestElementThroughShadowRoot,
     findNodesForSlot,
-    hexToString
+    hexToString,
+    isSlotEmpty,
 } from './util/utils';
 export { onChildListChange } from './util/mutation-utils';
 export { buildSpan, buildDiv, buildLabel, buildData } from './util/html-element.builder';

--- a/libs/common/utilities/src/util/utils.ts
+++ b/libs/common/utilities/src/util/utils.ts
@@ -195,3 +195,15 @@ export const findNodesForSlot = (element: HTMLElement, slotName: string) => {
 export const hexToString = (hex: string): string => {
     return hex.split(' ').map(s => String.fromCharCode(parseInt(s,16))).join('');
 }
+
+/**
+ * Checkt of een slot leeg is (en geen nodes of text bevat)
+ * @param slot
+ */
+export const isSlotEmpty = (slot: HTMLSlotElement): boolean =>
+    slot
+        .assignedNodes({ flatten: true })
+        .every(
+            (node) =>
+                (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()) || node.nodeType === Node.COMMENT_NODE
+        );

--- a/libs/components/src/next/button/stories/vl-button.stories-arg.ts
+++ b/libs/components/src/next/button/stories/vl-button.stories-arg.ts
@@ -136,16 +136,6 @@ export const buttonArgTypes: ArgTypes<ButtonArgs> = {
             defaultValue: { summary: buttonArgs.iconPlacement },
         },
     },
-    iconOnly: {
-        name: 'icon-only',
-        description:
-            'Beeldt de button correct af als er enkel een icoon is en geen tekst.<br/>Te gebruiken in combinatie met het `icon` attribuut.',
-        table: {
-            type: { summary: TYPES.BOOLEAN },
-            category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: buttonArgs.iconOnly },
-        },
-    },
     toggle: {
         name: 'toggle',
         description: 'Beeldt de button af als een toggle button.',

--- a/libs/components/src/next/button/stories/vl-button.stories.ts
+++ b/libs/components/src/next/button/stories/vl-button.stories.ts
@@ -38,7 +38,6 @@ const ButtonTemplate = story(
         icon,
         ctaLink,
         iconPlacement,
-        iconOnly,
         toggle,
         on,
         controlled,
@@ -61,7 +60,6 @@ const ButtonTemplate = story(
             icon=${icon}
             cta-link=${ctaLink}
             icon-placement=${iconPlacement}
-            ?icon-only=${iconOnly}
             ?toggle=${toggle}
             ?on=${on}
             ?controlled=${controlled}
@@ -154,7 +152,6 @@ export const ButtonIconOnly = ButtonTemplate.bind({});
 ButtonIconOnly.storyName = 'vl-button-next - icon only';
 ButtonIconOnly.args = {
     icon: 'location',
-    iconOnly: true,
 };
 
 export const ButtonToggle = ButtonTemplate.bind({});

--- a/libs/components/src/next/button/vl-button.component.cy.ts
+++ b/libs/components/src/next/button/vl-button.component.cy.ts
@@ -112,11 +112,12 @@ describe('component - vl-button-next', () => {
             .should('have.class', 'vl-icon--left-margin');
     });
 
-    it('should set icon-only', () => {
-        cy.mount(html`<vl-button-next icon="pin" icon-only></vl-button-next>`);
+    it('should set empty-slot style when slot does not have content', () => {
+        cy.mount(html`<vl-button-next icon="pin"></vl-button-next>`);
 
         cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
-        cy.get('vl-button-next').should('have.attr', 'icon-only', '');
+        cy.get('vl-button-next').shadow().find('slot').should('be.empty');
+        cy.get('vl-button-next').shadow().find('button').should('have.class', 'empty-slot');
         cy.get('vl-button-next')
             .shadow()
             .find('button')
@@ -293,13 +294,18 @@ describe('component - vl-button-next - cta-link', () => {
     it('should set icon-only', () => {
         cy.mount(html`<vl-button-next icon="pin" icon-only cta-link="https://www.vlaanderen.be"></vl-button-next>`);
 
-        cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
-        cy.get('vl-button-next').should('have.attr', 'icon-only', '');
-        cy.get('vl-button-next')
-            .shadow()
-            .find('a')
-            .shouldHaveComputedStyle({ style: 'padding', value: '0px' })
-            .shouldHaveComputedStyle({ style: 'width', value: '35px' });
+        it('should set empty-slot style when slot does not have content', () => {
+            cy.mount(html`<vl-button-next icon="pin"></vl-button-next>`);
+
+            cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
+            cy.get('vl-button-next').shadow().find('slot').should('be.empty');
+            cy.get('vl-button-next').shadow().find('button').should('have.class', 'empty-slot');
+            cy.get('vl-button-next')
+                .shadow()
+                .find('button')
+                .shouldHaveComputedStyle({ style: 'padding', value: '0px' })
+                .shouldHaveComputedStyle({ style: 'width', value: '35px' });
+        });
     });
 
     it('should set content', () => {

--- a/libs/components/src/next/button/vl-button.component.ts
+++ b/libs/components/src/next/button/vl-button.component.ts
@@ -1,4 +1,4 @@
-import { BaseLitElement, ICON_PLACEMENT, webComponent } from '@domg-wc/common-utilities';
+import { BaseLitElement, ICON_PLACEMENT, isSlotEmpty, webComponent } from '@domg-wc/common-utilities';
 import { globalStylesNext, vlIconStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
@@ -21,12 +21,13 @@ export class VlButtonComponent extends BaseLitElement {
     private loading = buttonDefaults.loading;
     private icon = buttonDefaults.icon;
     private iconPlacement = buttonDefaults.iconPlacement;
-    private iconOnly = buttonDefaults.iconOnly;
     private toggle = buttonDefaults.toggle;
     private on = buttonDefaults.on;
     private controlled = buttonDefaults.controlled;
     private ctaLink = buttonDefaults.ctaLink;
     private external = buttonDefaults.external;
+
+    private hasEmptySlot = false;
 
     static get styles(): CSSResult[] {
         return [buttonStyles, linkButtonStyles, vlIconStyles];
@@ -46,7 +47,6 @@ export class VlButtonComponent extends BaseLitElement {
             loading: { type: Boolean },
             icon: { type: String },
             iconPlacement: { type: String, attribute: 'icon-placement', reflect: true },
-            iconOnly: { type: Boolean, attribute: 'icon-only' },
             toggle: { type: Boolean },
             on: {
                 type: Boolean,
@@ -63,7 +63,14 @@ export class VlButtonComponent extends BaseLitElement {
             controlled: { type: Boolean },
             ctaLink: { type: String, attribute: 'cta-link' },
             external: { type: Boolean },
+            hasEmptySlot: { type: Boolean },
         };
+    }
+
+    protected firstUpdated(_changedProperties: PropertyValues) {
+        super.firstUpdated(_changedProperties);
+
+        this.isSlotEmpty();
     }
 
     updated(changedProperties: Map<string, unknown>) {
@@ -95,21 +102,23 @@ export class VlButtonComponent extends BaseLitElement {
             secondary: this.secondary,
             tertiary: displayAsTertiaryButton,
             loading: this.loading,
-            'icon-only': this.icon && this.iconOnly,
             'button-in-map': isInMap,
+            'empty-slot': this.hasEmptySlot,
         };
 
         return !this.ctaLink
-            ? html`<button
-                  class=${classMap(classes)}
-                  type=${this.type}
-                  ?disabled=${this.disabled}
-                  @click=${this.handleClick}
-              >
-                  ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
-                  <slot></slot>
-                  ${this.renderIcon(ICON_PLACEMENT.AFTER)}
-              </button>`
+            ? html`
+                  <button
+                      class=${classMap(classes)}
+                      type=${this.type}
+                      ?disabled=${this.disabled}
+                      @click=${this.handleClick}
+                  >
+                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
+                      <slot @slotchange=${this.isSlotEmpty}></slot>
+                      ${this.renderIcon(ICON_PLACEMENT.AFTER)}
+                  </button>
+              `
             : html`
                   <a
                       href=${this.disabled ? 'javascript:void(0);' : this.ctaLink}
@@ -122,7 +131,7 @@ export class VlButtonComponent extends BaseLitElement {
                       ?aria-disabled=${this.disabled}
                   >
                       ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
-                      <slot></slot>
+                      <slot @slotchange=${this.isSlotEmpty}></slot>
                       ${this.renderIcon(ICON_PLACEMENT.AFTER)}
                   </a>
               `;
@@ -140,11 +149,16 @@ export class VlButtonComponent extends BaseLitElement {
         const classes = {
             'vl-icon': true,
             [`vl-icon--${this.icon}`]: true,
-            'vl-icon--right-margin': !this.iconOnly && this.iconPlacement === 'before',
-            'vl-icon--left-margin': !this.iconOnly && this.iconPlacement === 'after',
+            'vl-icon--right-margin': !this.hasEmptySlot && this.iconPlacement === 'before',
+            'vl-icon--left-margin': !this.hasEmptySlot && this.iconPlacement === 'after',
         };
 
         return html`<span class=${classMap(classes)}></span>`;
+    }
+
+    isSlotEmpty() {
+        const slot = this.shadowRoot?.querySelector('slot');
+        this.hasEmptySlot = Boolean(slot && isSlotEmpty(slot!));
     }
 
     protected handleClick(event: Event) {

--- a/libs/components/src/next/button/vl-button.css.ts
+++ b/libs/components/src/next/button/vl-button.css.ts
@@ -256,11 +256,17 @@ export const buttonStyles: CSSResult = css`
             }
         }
 
-        /* Icon styles */
-
-        &.icon-only {
+        /* Empty slot styles */
+        &.empty-slot {
             width: 3.5rem;
             padding: 0;
+            &.tertiary {
+                padding: 0;
+            }
+            .vl-icon {
+                margin-left: 0;
+                margin-right: 0;
+            }
         }
     }
 `;

--- a/libs/components/src/next/button/vl-button.defaults.ts
+++ b/libs/components/src/next/button/vl-button.defaults.ts
@@ -13,7 +13,6 @@ export const buttonDefaults = {
     loading: false as boolean,
     icon: '' as string,
     iconPlacement: 'before' as ICON_PLACEMENT,
-    iconOnly: false as boolean,
     toggle: false as boolean,
     on: false as boolean,
     controlled: false as boolean,

--- a/libs/components/src/next/button/vl-link-button.css.ts
+++ b/libs/components/src/next/button/vl-link-button.css.ts
@@ -60,6 +60,7 @@ export const linkButtonStyles: CSSResult = css`
             background-color: transparent;
             border: ${unsafeCSS(borderWidth)} solid currentColor;
             transition: color 0.2s, border-color 0.2s;
+            min-height: 3.1rem;
 
             &:focus {
                 color: var(--vl-action-color--active);
@@ -260,11 +261,26 @@ export const linkButtonStyles: CSSResult = css`
             }
         }
 
-        /* Icon styles */
-
-        &.icon-only {
+        /* Empty slot styles */
+        &.empty-slot {
             width: 3.5rem;
             padding: 0;
+            min-height: 3.5rem;
+
+            &.secondary {
+                width: 3.1rem;
+                min-height: 3.1rem;
+                padding: 0;
+            }
+            &.tertiary {
+                width: 3.1rem;
+                min-height: 3.1rem;
+                padding: 0.1rem;
+            }
+            .vl-icon {
+                margin-left: 0;
+                margin-right: 0;
+            }
         }
     }
 `;


### PR DESCRIPTION
Vroeger moest je als afnemer `icon-only`-attribuut plaatsen om er voor te zorgen dat de `vl-button-next` de juiste styling instelde. Nu wordt dit door het component zelf behandeld en is het niet meer nodig om het `icon-only`-attribuut te plaatsen.

Storybook verbeterd & cypress testen uitgebreid.

[Jira - UIG-3155](https://www.milieuinfo.be/jira/browse/UIG-3155)
[Jira - UIG-3130](https://www.milieuinfo.be/jira/browse/UIG-3130)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC461)