### PR TITLE
fix: UIG-3171 - vl-icon-next - icon margins verbeterd

### DIFF
--- a/libs/common/utilities/src/css/base/icon/vl-icon.css.ts
+++ b/libs/common/utilities/src/css/base/icon/vl-icon.css.ts
@@ -17,6 +17,12 @@ export const vlIconStyles: CSSResult = css`
         display: inline;
         color: inherit;
 
+        &:before,
+        &:after {
+            display: inline-block;
+            text-decoration: none;
+        }
+
         &.vl-icon--small {
             font-size: 0.8em;
         }
@@ -34,6 +40,14 @@ export const vlIconStyles: CSSResult = css`
         }
 
         &.vl-icon--left-margin {
+            margin-left: 0.5em;
+        }
+
+        &.vl-icon--before {
+            margin-right: 0.5em;
+        }
+
+        &.vl-icon--after {
             margin-left: 0.5em;
         }
 

--- a/libs/common/utilities/src/css/base/link/vl-link.css.ts
+++ b/libs/common/utilities/src/css/base/link/vl-link.css.ts
@@ -74,23 +74,8 @@ export const vlLinkStyles: CSSResult = css`
 
         /* Icon styles */
 
-        .vl-icon {
-            &:before {
-                display: inline-block;
-                text-decoration: none;
-            }
-
-            &.vl-icon--before {
-                margin-right: 0.4rem;
-            }
-
-            &.vl-icon--after {
-                margin-left: 0.4rem;
-            }
-
-            &.vl-icon--external {
-                color: var(--vl-light-text-color);
-            }
+        .vl-icon.vl-icon--external {
+            color: var(--vl-light-text-color);
         }
 
         &:hover,


### PR DESCRIPTION
Margins voor de icon horen `em` units te gebruiken, zodat die relatief blijven tegenover de font-size van het huidige element, en niet (zoals `rem`), relatief tegenover de font-size van het root document.
Algemene icon css styling gemigreerd van `vl-link.css.ts` naar `vl-icon.css.ts`.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3171)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC474)