### PR TITLE
feat: UIG-3138 - vl-link-next - optie toegevoegd die een button als link stileert

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/next/link/vl-link.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/next/link/vl-link.stories.cy.ts
@@ -5,6 +5,8 @@ const linkNextLargeUrl = 'http://localhost:8080/iframe.html?id=components-next-l
 const linkNextErrorUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-error&viewMode=story';
 const linkNextExternalUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-external&viewMode=story';
 const linkNextIconUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-icon&viewMode=story';
+const linkButtonStyledAsLink =
+    'http://localhost:8080/iframe.html?args=&id=components-next-link--button-styled-as-link&viewMode=story';
 
 describe('story - vl-link-next - default', () => {
     it('should render', () => {
@@ -59,5 +61,13 @@ describe('story - vl-link-next - icon', () => {
         cy.visit(linkNextIconUrl);
 
         cy.get('vl-link-next').shadow().find('a');
+    });
+});
+
+describe('story - vl-link-next - button styled as link', () => {
+    it('should render', () => {
+        cy.visit(linkButtonStyledAsLink);
+
+        cy.get('vl-link-next').shadow().find('button');
     });
 });

--- a/apps/storybook/.storybook/vlux-meta-data/vlux-meta-data.json
+++ b/apps/storybook/.storybook/vlux-meta-data/vlux-meta-data.json
@@ -102,7 +102,7 @@
     },
     "components-next-button": {
         "vStatus": "v2-next",
-        "legacyText": "[vl-button](/docs/elements-button-button--documentatie)",
+        "legacyText": "o.a. [vl-button](/docs/elements-button-button--documentatie), [vl-icon-button](/docs/elements-button-icon-button--documentatie) en [vl-link-button](/docs/elements-button-link-button--documentatie)",
         "nextText": "vl-button-next",
         "planningInfo": "[v1 naar v2 - beschikbaar](/docs/planning-2024-van-v1-naar-v2-beschikbaar--documentatie#button)"
     },
@@ -324,8 +324,9 @@
         "planningInfo": "[v1 naar v2 - beschikbaar](/docs/planning-2024-van-v1-naar-v2-beschikbaar--documentatie#link)"
     },
     "elements-link-button-link": {
-        "vStatus": "v1-remove",
+        "vStatus": "v1-replace",
         "legacyText": "vl-button-link",
+        "nextText": "[vl-link-next](/docs/components-next-link--documentatie#button-styled-as-link)",
         "planningInfo": "[v1 naar v2 - beschikbaar](/docs/planning-2024-van-v1-naar-v2-beschikbaar--documentatie#link)"
     },
     "elements-link-list": {
@@ -336,7 +337,7 @@
     },
     "components-next-link": {
         "vStatus": "v2-next",
-        "legacyText": "[vl-link](/docs/elements-link-link--documentatie)",
+        "legacyText": "o.a. [vl-link](/docs/elements-link-link--documentatie) en [vl-button-link](/docs/elements-link-button-link--documentatie)",
         "nextText": "vl-link-next",
         "planningInfo": "[v1 naar v2 - beschikbaar](/docs/planning-2024-van-v1-naar-v2-beschikbaar--documentatie#link)"
     },

--- a/apps/storybook/docs/d_planning/3_2024-van-v1-naar-v2-beschikbaar.stories.mdx
+++ b/apps/storybook/docs/d_planning/3_2024-van-v1-naar-v2-beschikbaar.stories.mdx
@@ -758,7 +758,8 @@ uitgebreid om deze groepering functionaliteit te ondersteunen.
 
 ### Link
 
-`Button Link [legacy]` verdwijnt in v2, gebruik een `<vl-link>` of een `<vl-button>`.
+`Button Link [legacy]` verdwijnt in v2, gebruik de `<vl-link button-as-link>`
+    (zie de [button-as-link](/docs/components-next-link--documentatie#button-styled-as-link) documentatie).
 
 <table  style={{width: 100 + '%'}}>
     <tr>

--- a/libs/common/utilities/src/css/base/link/stories/vl-link.stories.ts
+++ b/libs/common/utilities/src/css/base/link/stories/vl-link.stories.ts
@@ -18,7 +18,7 @@ export default {
 export const LinkDefault = ({}) => html`
     <style>
         .sb-link {
-            ${vlLinkStyles};
+            ${vlLinkStyles()};
             ${vlIconStyles};
             margin-bottom: 1rem;
         }

--- a/libs/common/utilities/src/css/base/link/vl-link.css.cy.ts
+++ b/libs/common/utilities/src/css/base/link/vl-link.css.cy.ts
@@ -9,7 +9,7 @@ describe('link styles', () => {
         cy.then(() => RegisterGlobalStyles.register());
         cy.mount(html`
             <style>
-                ${vlLinkStyles}
+                ${vlLinkStyles()}
                 ${vlIconStyles}
             </style>
             <div>

--- a/libs/common/utilities/src/css/base/link/vl-link.css.ts
+++ b/libs/common/utilities/src/css/base/link/vl-link.css.ts
@@ -1,9 +1,9 @@
-import { css, CSSResult } from 'lit';
+import { css, unsafeCSS } from 'lit';
 import { vlFocusOutlineMixin } from '../../base/mixin/vl-outlines.css';
 import { vlMediaScreenSmall } from '../../base/var/vl-media-screen.css';
 
-export const vlLinkStyles: CSSResult = css`
-    a {
+export const vlLinkStyles = (selector = 'a') => css`
+    ${unsafeCSS(selector)} {
         /* Reset styles (gebaseerd op DV _reset.scss) */
         margin: 0;
         border: 0;

--- a/libs/components/src/next/doormat/vl-doormat.component.ts
+++ b/libs/components/src/next/doormat/vl-doormat.component.ts
@@ -19,7 +19,7 @@ export class VlDoormatComponent extends BaseLitElement {
     private graphic = doormatDefaults.graphic;
 
     static get styles(): CSSResult[] {
-        return [vlLinkStyles, doormatStyle];
+        return [vlLinkStyles(), doormatStyle];
     }
 
     static get properties(): PropertyDeclarations {

--- a/libs/components/src/next/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/next/link/stories/vl-link.stories-arg.ts
@@ -23,7 +23,7 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     ...defaultArgTypes(true),
     href: {
         name: 'href',
-        description: 'De url waar de link naar verwijst.',
+        description: 'De url waar de link naar verwijst.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
@@ -68,7 +68,7 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     },
     external: {
         name: 'external',
-        description: 'Opent de link in een nieuw tabblad.',
+        description: 'Opent de link in een nieuw tabblad.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
@@ -93,6 +93,15 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
             type: { summary: getSelectControlOptions(Object.values(ICON_PLACEMENT)) },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: linkArgs.iconPlacement },
+        },
+    },
+    buttonAsLink: {
+        name: 'button-as-link',
+        description: 'Maakt van de link een button maar behoudt de link-stijl.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: linkArgs.buttonAsLink },
         },
     },
     defaultSlot: {

--- a/libs/components/src/next/link/stories/vl-link.stories-doc.mdx
+++ b/libs/components/src/next/link/stories/vl-link.stories-doc.mdx
@@ -52,6 +52,18 @@ import { VlLinkComponent } from '@domg-wc/components/next/link';
 
 <Canvas of={VlLinkStories.LinkIcon} />
 
+### Button als link
+
+Soms wil je een button stylen als een link. Een specifieke use-case is bvb. om van `Annuleren` een link te maken
+zodat die visueel minder prominent is dan de knop `Opslaan`.
+
+Als richtlijn geldt:
+- gebruik een `<button>`-element wanneer het een actie is die op dezelfde pagina blijft
+  bvb. het sluiten van een modal, het gaan naar een volgende stap, het openklappen van een accordion, enzovoort.
+- gebruik een `<a>`-element om te navigeren naar een andere pagina.
+
+<Canvas of={VlLinkStories.ButtonStyledAsLink} />
+
 
 ## Referenties
 

--- a/libs/components/src/next/link/stories/vl-link.stories.ts
+++ b/libs/components/src/next/link/stories/vl-link.stories.ts
@@ -24,7 +24,7 @@ export default {
 
 const LinkTemplate = story(
     linkArgs,
-    ({ href, bold, small, large, error, external, icon, iconPlacement, defaultSlot }) =>
+    ({ href, bold, small, large, error, external, buttonAsLink, icon, iconPlacement, defaultSlot }) =>
         html`
             <vl-link-next
                 href=${href}
@@ -33,6 +33,7 @@ const LinkTemplate = story(
                 ?large=${large}
                 ?error=${error}
                 ?external=${external}
+                ?button-as-link=${buttonAsLink}
                 icon=${icon}
                 icon-placement=${iconPlacement}
                 >${unsafeHTML(defaultSlot)}</vl-link-next
@@ -93,4 +94,11 @@ LinkIcon.args = {
     href: 'https://www.vlaanderen.be',
     defaultSlot: 'Vlaanderen',
     icon: 'arrow-right-fat',
+};
+
+export const ButtonStyledAsLink = LinkTemplate.bind({});
+ButtonStyledAsLink.storyName = 'vl-link-next - button as link';
+ButtonStyledAsLink.args = {
+    defaultSlot: 'Annuleren',
+    buttonAsLink: true,
 };

--- a/libs/components/src/next/link/vl-button-as-link.css.ts
+++ b/libs/components/src/next/link/vl-button-as-link.css.ts
@@ -1,0 +1,28 @@
+import { vlLinkStyles } from '@domg-wc/common-utilities/css';
+import { css } from 'lit';
+
+export const buttonAsLinkStyles = css`
+    ${vlLinkStyles('button')}
+
+    button {
+        border-radius: 0;
+        appearance: none;
+        -webkit-appearance: none;
+        border: 0;
+        background-color: transparent;
+        padding: 0;
+        text-decoration: underline;
+        display: inline-flex;
+        align-items: center;
+        cursor: pointer;
+        font-weight: inherit;
+        text-align: left;
+        font-family: inherit;
+        font-size: inherit;
+        color: var(--vl-theme-action-color, #05c);
+        position: relative;
+        word-break: break-word;
+        line-height: inherit;
+        cursor: default;
+    }
+`;

--- a/libs/components/src/next/link/vl-link.component.cy.ts
+++ b/libs/components/src/next/link/vl-link.component.cy.ts
@@ -4,7 +4,7 @@ import { VlLinkComponent } from './vl-link.component';
 
 registerWebComponents([VlLinkComponent]);
 
-describe('component - vl-link-next', () => {
+describe('component - vl-link-next - default', () => {
     it('should mount', () => {
         cy.mount(html`<vl-link-next></vl-link-next>`);
 
@@ -95,6 +95,105 @@ describe('component - vl-link-next', () => {
         cy.mount(html`<vl-link-next>Vlaanderen</vl-link-next>`);
 
         cy.get('vl-link-next').shadow().find('a').find('slot');
+        cy.get('vl-link-next').contains('Vlaanderen');
+    });
+});
+
+describe('component - vl-link-next - button as link', () => {
+    it('should mount', () => {
+        cy.mount(html`<vl-link-next button-as-link></vl-link-next>`);
+
+        cy.get('vl-link-next').shadow().find('button');
+    });
+
+    it('should be accessible', () => {
+        cy.mount(html`<vl-link-next button-as-link href="https://www.vlaanderen.be">Vlaanderen</vl-link-next>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-link-next');
+    });
+
+    it('should set href', () => {
+        cy.mount(html`<vl-link-next button-as-link href="https://www.vlaanderen.be"></vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'href', 'https://www.vlaanderen.be');
+        cy.get('vl-link-next').shadow().find('button').should('not.have.attr', 'href');
+    });
+
+    it('should set bold', () => {
+        cy.mount(html`<vl-link-next button-as-link bold>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'bold');
+        cy.get('vl-link-next').shadow().find('button').should('have.class', 'bold');
+    });
+
+    it('should set small', () => {
+        cy.mount(html`<vl-link-next button-as-link small>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'small');
+        cy.get('vl-link-next').shadow().find('button').should('have.class', 'small');
+    });
+
+    it('should set large', () => {
+        cy.mount(html`<vl-link-next button-as-link large>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'large');
+        cy.get('vl-link-next').shadow().find('button').should('have.class', 'large');
+    });
+
+    it('should set error', () => {
+        cy.mount(html`<vl-link-next button-as-link error>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'error');
+        cy.get('vl-link-next').shadow().find('button').should('have.class', 'error');
+    });
+
+    it('should set external', () => {
+        cy.mount(html`<vl-link-next button-as-link external>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'external');
+        cy.get('vl-link-next').shadow().find('button').should('not.have.attr', 'target');
+    });
+
+    it('should set icon', () => {
+        cy.mount(html`<vl-link-next button-as-link icon="pin">Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').should('have.attr', 'icon', 'pin');
+        cy.get('vl-link-next')
+            .shadow()
+            .find('button')
+            .find('span.vl-icon')
+            .should('have.class', 'vl-icon--pin')
+            .should('have.class', 'vl-icon--right-margin');
+    });
+
+    it('should set icon-placement', () => {
+        cy.mount(
+            html`<vl-link-next button-as-link icon="pin" icon-placement=${ICON_PLACEMENT.AFTER}
+                >Vlaanderen</vl-link-next
+            >`
+        );
+
+        cy.get('vl-link-next').should('have.attr', 'icon', 'pin');
+        cy.get('vl-link-next').should('have.attr', 'icon-placement', ICON_PLACEMENT.AFTER);
+        cy.get('vl-link-next')
+            .shadow()
+            .find('button')
+            .find('span.vl-icon')
+            .should('have.class', 'vl-icon--pin')
+            .should('have.class', 'vl-icon--left-margin');
+    });
+
+    it('should not render icon when no icon value is set', () => {
+        cy.mount(html`<vl-link-next button-as-link>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').shadow().find('button').find('span.vl-icon').should('not.exist');
+    });
+
+    it('should set content', () => {
+        cy.mount(html`<vl-link-next button-as-link>Vlaanderen</vl-link-next>`);
+
+        cy.get('vl-link-next').shadow().find('button').find('slot');
         cy.get('vl-link-next').contains('Vlaanderen');
     });
 });

--- a/libs/components/src/next/link/vl-link.component.ts
+++ b/libs/components/src/next/link/vl-link.component.ts
@@ -2,6 +2,7 @@ import { BaseLitElement, ICON_PLACEMENT, webComponent } from '@domg-wc/common-ut
 import { globalStylesNext, vlIconStyles, vlLinkStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { buttonAsLinkStyles } from './vl-button-as-link.css';
 import { linkDefaults } from './vl-link.defaults';
 
 @globalStylesNext()
@@ -15,9 +16,10 @@ export class VlLinkComponent extends BaseLitElement {
     private external = linkDefaults.external;
     private icon = linkDefaults.icon;
     private iconPlacement = linkDefaults.iconPlacement;
+    private buttonAsLink = linkDefaults.buttonAsLink;
 
     static get styles(): CSSResult[] {
-        return [vlLinkStyles, vlIconStyles];
+        return [vlLinkStyles(), buttonAsLinkStyles, vlIconStyles];
     }
 
     static get properties(): PropertyDeclarations {
@@ -31,6 +33,7 @@ export class VlLinkComponent extends BaseLitElement {
             external: { type: Boolean },
             icon: { type: String },
             iconPlacement: { type: String, attribute: 'icon-placement', reflect: true },
+            buttonAsLink: { type: Boolean, attribute: 'button-as-link' },
         };
     }
 
@@ -53,13 +56,21 @@ export class VlLinkComponent extends BaseLitElement {
         };
         const target = this.external ? '_blank' : nothing;
 
-        return html`
-            <a class=${classMap(classes)} href=${this.href} target=${target}>
-                ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
-                <slot></slot>
-                ${this.renderIcon(ICON_PLACEMENT.AFTER)} ${this.external ? this.renderExternalIcon() : ''}
-            </a>
-        `;
+        return !this.buttonAsLink
+            ? html`
+                  <a class=${classMap(classes)} href=${this.href} target=${target}>
+                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
+                      <slot></slot>
+                      ${this.renderIcon(ICON_PLACEMENT.AFTER)} ${this.external ? this.renderExternalIcon() : ''}
+                  </a>
+              `
+            : html`
+                  <button class="vl-button-as-link ${classMap(classes)}">
+                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
+                      <slot></slot>
+                      ${this.renderIcon(ICON_PLACEMENT.AFTER)} ${this.external ? this.renderExternalIcon() : ''}
+                  </button>
+              `;
     }
 
     renderIcon(iconPlacement: ICON_PLACEMENT): TemplateResult | typeof nothing {

--- a/libs/components/src/next/link/vl-link.defaults.ts
+++ b/libs/components/src/next/link/vl-link.defaults.ts
@@ -9,4 +9,5 @@ export const linkDefaults = {
     external: false as boolean,
     icon: '' as string,
     iconPlacement: 'before' as ICON_PLACEMENT,
+    buttonAsLink: false as boolean,
 } as const;


### PR DESCRIPTION
In sommige gevallen kan het nuttig zijn om een button te stylen als een link. Daarom wordt `button-as-link`-attribuut toegevoegd die dit toelaat. Storybook verbeterd & cypress testen uitgebreid.
Een mixin functie gemaakt van vlLinkStyles zodat die hergebruikt kan worden voor de `button-as-link`-variant. Die is toegepast waar relevant.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3138)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC475)