### PR TITLE
fix: UIG-3170 - vl-button-next - native click event wordt ontsloten

### DIFF
--- a/apps/storybook/docs/g_recepten/events.stories.mdx
+++ b/apps/storybook/docs/g_recepten/events.stories.mdx
@@ -1,0 +1,29 @@
+import {Meta} from '@storybook/addon-docs';
+
+<Meta title="Recepten/Events"/>
+
+# Events
+
+## Native- vs Custom-events
+
+De UIG-componenten bieden eigen - custom -
+events aan, deze hebben de prefix `vl-`. De prefix maakt duidelijk dat het UIG-events zijn en vermijden conflicten
+met standaard events of events van andere bibliotheken. Op de documentatie pagina van een component vind je onder
+`Configuratie` een overzicht van de custom-events, de native events worden niet vermeld!
+
+Indien aanwezig heeft het de voorkeur te luisteren naar de custom events; deze worden voorzien bij componenten:
+- die een complexe DOM-structuur hebben
+- waar extra informatie meegegeven wordt met het event
+
+Luister bvb. naar `vl-change` of `vl-input` (i.p.v. `click`) bij het aanvinken van `vl-checkbox-next`.
+
+## Events in Lit
+
+Lit, waar de nieuwere UIG-componenten gebruik van maken, heeft zelf een documentatie pagina over
+[events](https://lit.dev/docs/components/events/).
+
+## Retargeting
+
+De UIG-componenten ontsluiten typisch native componenten die op hun beurt native events hebben. Web-componenten
+[re-targetten](https://web.dev/articles/shadowdom-v1#the_shadow_dom_event_model) zelf bepaalde events, hierdoor lijken
+die native events voor afnemers van de web-component zelf te komen of worden bepaalde event meerdere keren binnen.

--- a/libs/components/src/next/button/vl-button.component.ts
+++ b/libs/components/src/next/button/vl-button.component.ts
@@ -176,10 +176,7 @@ export class VlButtonComponent extends BaseLitElement {
         this.hasEmptySlot = Boolean(slot && isSlotEmpty(slot!));
     }
 
-    protected handleClick(event: Event) {
-        event.preventDefault();
-        event.stopPropagation();
-
+    protected handleClick() {
         if (this.toggle && !this.controlled) {
             this.on = !this.on;
         }
@@ -195,9 +192,7 @@ export class VlButtonComponent extends BaseLitElement {
         this.dispatchEvent(new CustomEvent('vl-click', { bubbles: true, composed: true }));
     }
 
-    protected handleLinkClick(event: Event) {
-        event.stopPropagation();
-
+    protected handleLinkClick() {
         if (this.toggle && !this.controlled) {
             this.on = !this.on;
         }


### PR DESCRIPTION
We ontsluiten nu voor alle "next" componenten ook de native events & ontsluiten in bepaalde gevallen ook custom events met prefix `vl-`. Storybook verbeterd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3170)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC477)