### PR TITLE
fix: UIG-3128 - vl-checkbox-next - switch variant verbeterd

### DIFF
--- a/libs/form/src/next/checkbox/stories/vl-checkbox.stories-arg.ts
+++ b/libs/form/src/next/checkbox/stories/vl-checkbox.stories-arg.ts
@@ -32,6 +32,16 @@ export const checkboxArgTypes: ArgTypes<CheckboxArgs> = {
             defaultValue: { summary: checkboxArgs.block },
         },
     },
+    id: {
+        name: 'id',
+        description: 'De id van het veld.<br>Bij de switch variant moet je een id instellen.',
+        type: { name: 'boolean', required: true },
+        table: {
+            type: { summary: TYPES.STRING, required: true },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: formControlArgs.id },
+        },
+    },
     value: {
         name: 'value',
         description: 'De value van de checkbox.',

--- a/libs/form/src/next/checkbox/vl-checkbox.component.cy.ts
+++ b/libs/form/src/next/checkbox/vl-checkbox.component.cy.ts
@@ -107,7 +107,7 @@ describe('component - vl-checkbox-next', () => {
     });
 
     it('should be checked', () => {
-        cy.mount(html` <vl-checkbox-next value=${value} checked>Bevestig.</vl-checkbox-next> `);
+        cy.mount(html` <vl-checkbox-next id="cy-test-id" value=${value} checked>Bevestig.</vl-checkbox-next> `);
 
         shouldToggleCheckedWithClick('.vl-checkbox__label');
         cy.get('vl-checkbox-next')
@@ -145,7 +145,7 @@ describe('component - vl-checkbox-next', () => {
         cy.createStubForEvent('vl-checkbox-next', 'vl-change');
         cy.createStubForEvent('vl-checkbox-next', 'vl-input');
 
-        cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__toggle').click({ force: true });
+        cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__label').click({ force: true });
         cy.get('@vl-input')
             .should('have.been.calledOnce')
             .its('lastCall.args.0.detail')
@@ -154,7 +154,7 @@ describe('component - vl-checkbox-next', () => {
             .should('have.been.calledTwice')
             .its('lastCall.args.0.detail')
             .should('deep.equal', { checked: true, value });
-        cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__toggle').click({ force: true });
+        cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__label').click({ force: true });
         cy.get('@vl-change').its('callCount').should('eq', 3);
         cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { checked: false });
         cy.get('@vl-input').its('callCount').should('eq', 2);
@@ -266,7 +266,9 @@ describe('component - vl-checkbox-next - switch', () => {
 
     it('should be accessible', () => {
         cy.mount(
-            html` <vl-checkbox-next id="test-id" value=${value} switch label="test-label">Bevestig.</vl-checkbox-next> `
+            html`
+                <vl-checkbox-next id="cy-test-id" value=${value} switch label="test-label">Bevestig.</vl-checkbox-next>
+            `
         );
         cy.injectAxe();
 
@@ -274,7 +276,7 @@ describe('component - vl-checkbox-next - switch', () => {
     });
 
     it('should be checked', () => {
-        cy.mount(html` <vl-checkbox-next value=${value} switch checked>Bevestig.</vl-checkbox-next> `);
+        cy.mount(html` <vl-checkbox-next id="cy-test-id" value=${value} switch checked>Bevestig.</vl-checkbox-next> `);
 
         shouldToggleCheckedWithClick('.vl-checkbox__label');
         cy.get('vl-checkbox-next')
@@ -301,7 +303,7 @@ describe('component - vl-checkbox-next - switch', () => {
     });
 
     it('should dispatch vl-change & vl-input event on check and uncheck', () => {
-        cy.mount(html` <vl-checkbox-next value=${value} switch>Bevestig.</vl-checkbox-next> `);
+        cy.mount(html` <vl-checkbox-next id="cy-test-id" value=${value} switch>Bevestig.</vl-checkbox-next> `);
         cy.createStubForEvent('vl-checkbox-next', 'vl-change');
         cy.createStubForEvent('vl-checkbox-next', 'vl-input');
 
@@ -323,7 +325,7 @@ describe('component - vl-checkbox-next - switch', () => {
     });
 
     it('should dispatch vl-change but not vl-input event on programmatic check and uncheck', () => {
-        cy.mount(html` <vl-checkbox-next value=${value} switch>Bevestig.</vl-checkbox-next> `);
+        cy.mount(html` <vl-checkbox-next id="cy-test-id" value=${value} switch>Bevestig.</vl-checkbox-next> `);
         cy.createStubForEvent('vl-checkbox-next', 'vl-change');
         cy.createStubForEvent('vl-checkbox-next', 'vl-input');
 
@@ -341,7 +343,7 @@ describe('component - vl-checkbox-next - switch', () => {
     });
 
     it('should dispatch vl-valid event on valid input', () => {
-        cy.mount(html` <vl-checkbox-next value=${value} switch required>Bevestig.</vl-checkbox-next> `);
+        cy.mount(html` <vl-checkbox-next id="cy-test-id" value=${value} switch required>Bevestig.</vl-checkbox-next> `);
         cy.createStubForEvent('vl-checkbox-next', 'vl-valid');
 
         cy.get('vl-checkbox-next').shadow().find('.vl-checkbox__label').click({ force: true });

--- a/libs/form/src/next/checkbox/vl-checkbox.component.ts
+++ b/libs/form/src/next/checkbox/vl-checkbox.component.ts
@@ -122,8 +122,9 @@ export class VlCheckboxComponent extends FormControl {
                     ?error=${this.error}
                     .value=${this.value}
                     .checked=${this.checked}
+                    @click=${this.toggle}
                 />
-                <label for=${this.id} class="vl-checkbox__label" @click=${this.toggle}>
+                <label for=${this.id} class="vl-checkbox__label">
                     <span class="vl-checkbox--switch__label">
                         <span aria-hidden="true"></span>
                     </span>


### PR DESCRIPTION
Voorheen gaf de switch variant van de checkbox niet de juiste waarde wanneer die van staat veranderde. Door het opvangen de klik te doen op de input een associatie heeft met de label, wordt de value van de input nu wel juist ge-update, ook al is die niet zichtbaar.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3128)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC482)