### PR TITLE
fix: UIG-3120 - vl-select-next - placeholder werking verbeterd

### DIFF
--- a/libs/form/src/next/select/vl-select.component.cy.ts
+++ b/libs/form/src/next/select/vl-select.component.cy.ts
@@ -409,8 +409,15 @@ describe('component - vl-select-next - in form', () => {
                     e.preventDefault();
                 }}
             >
-                <vl-select-next id="geboorteplaats" name="geboorteplaats" .options=${options} required></vl-select-next>
+                <vl-select-next
+                    id="geboorteplaats"
+                    name="geboorteplaats"
+                    placeholder="Selecteer je geboorteplaats"
+                    .options=${options}
+                    required
+                ></vl-select-next>
                 <button class="vl-button" type="submit">Verstuur</button>
+                <button class="vl-button" type="reset">Reset</button>
             </form>
         `);
     });
@@ -429,6 +436,32 @@ describe('component - vl-select-next - in form', () => {
             const formData = Object.fromEntries(new FormData($el.get(0) as HTMLFormElement));
             expect(formData).to.deep.equal(submittedFormData);
         });
+    });
+
+    it('should reset value', () => {
+        cy.createStubForEvent('form', 'reset');
+
+        cy.get('vl-select-next').shadow().find('select').select('hasselt').trigger('change');
+        cy.get('form').find('button[type="reset"]').click();
+        cy.get('@reset').should('have.been.calledOnce');
+        cy.get('form').then(($el) => {
+            const formData = Object.fromEntries(new FormData($el.get(0) as HTMLFormElement));
+            expect(formData).to.deep.equal({});
+        });
+        cy.get('vl-select-next')
+            .shadow()
+            .find('select')
+            .find('option:selected')
+            .should('contain', 'Selecteer je geboorteplaats');
+
+        // we resetten een lege select; in dat geval moet de placeholder hetzelfde blijven
+        cy.get('form').find('button[type="reset"]').click();
+
+        cy.get('vl-select-next')
+            .shadow()
+            .find('select')
+            .find('option:selected')
+            .should('contain', 'Selecteer je geboorteplaats');
     });
 
     it('should prevent form submission on validation error', () => {

--- a/libs/form/src/next/select/vl-select.component.ts
+++ b/libs/form/src/next/select/vl-select.component.ts
@@ -158,8 +158,11 @@ export class VlSelectComponent extends FormControl {
             this.options.pop();
         }
         this.initialOptions.forEach((option) => this.options.push({ ...option }));
-        // Aangezien we de referentie van de array niet veranderen, moeten we expliciet een update aanvragen voor de options array.
-        this.requestUpdate('options');
+        // We renderen enkel de options opnieuw als de value niet leeg is.
+        if (this.value) {
+            // Aangezien we de referentie van de array niet veranderen, moeten we expliciet een update aanvragen voor de options array.
+            this.requestUpdate('options');
+        }
     }
 
     private onChange(event: Event & { target: HTMLSelectElement }) {


### PR DESCRIPTION
Vroeger werd bij het resetten de select met een lege value, de placeholder value niet meer getoond. Nu blijft die zichtbaar wanneer er geen value is geselecteerd. Cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3120)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC485)