### PR TITLE
feat: UIG-3175 - global-styles - registratie van global styles verbeterd


### DIFF
--- a/apps/playground-lit/src/main.ts
+++ b/apps/playground-lit/src/main.ts
@@ -1,3 +1,2 @@
 import './preferences';
-import './app/form/form.component';
 import './app/app.component';

--- a/apps/playground-react/src/declare-module.d.ts
+++ b/apps/playground-react/src/declare-module.d.ts
@@ -1,2 +1,1 @@
-declare module '*.mdx';
 declare module '*.css';

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import { filterOutClasses, filterOutDataCy, formatHTML } from '@domg-wc/common-storybook';
 import { registerWebComponents } from '@domg-wc/common-utilities';
 import { VlAlert } from '@domg-wc/components';
-import { RegisterGlobalStyles } from '@domg-wc/common-utilities/css';
+import { GlobalStyles } from '@domg-wc/common-utilities/css';
 import { VlIconElement } from '@domg-wc/elements';
 import './styles.css';
 import 'reflect-metadata';
@@ -35,4 +35,4 @@ export const parameters = {
 registerWebComponents([VlIconElement, VlAlert]);
 
 // zonder deze register() missen initieel de global-styles, ze verschijnen dan wel maar pas na 30 seconden - onduidelijk waarom
-RegisterGlobalStyles.register();
+GlobalStyles.register();

--- a/libs/common/utilities/src/base/base.lit.element.ts
+++ b/libs/common/utilities/src/base/base.lit.element.ts
@@ -1,9 +1,16 @@
+import { GlobalStyles } from '../css';
 import { LitElement, PropertyDeclarations } from 'lit';
 
 export class BaseLitElement extends LitElement {
     protected allowCustomCSS = true;
     private customCSS: string | null = null;
     private customCSSPrefix: string | null = null;
+
+    constructor() {
+        super();
+
+        GlobalStyles.register();
+    }
 
     static get properties(): PropertyDeclarations {
         return {

--- a/libs/common/utilities/src/css/base/body/vl-body.css.cy.ts
+++ b/libs/common/utilities/src/css/base/body/vl-body.css.cy.ts
@@ -1,9 +1,9 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 
 describe('body styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html` <div class="cy-div">een div</div> `);
     });
 

--- a/libs/common/utilities/src/css/base/font/vl-font.css.cy.ts
+++ b/libs/common/utilities/src/css/base/font/vl-font.css.cy.ts
@@ -1,9 +1,9 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 
 describe('font styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
                 .cy-font {

--- a/libs/common/utilities/src/css/base/icon/vl-icon.css.cy.ts
+++ b/libs/common/utilities/src/css/base/icon/vl-icon.css.cy.ts
@@ -1,11 +1,11 @@
 import { html } from 'lit';
 import { hexToString } from '../../../util/utils';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlIconStyles } from '../icon/vl-icon.css';
 
 describe('outline styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
                 ${vlIconStyles}

--- a/libs/common/utilities/src/css/base/link/vl-link.css.cy.ts
+++ b/libs/common/utilities/src/css/base/link/vl-link.css.cy.ts
@@ -1,12 +1,12 @@
 import { html } from 'lit';
 import { hexToString } from '../../../util/utils';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlIconStyles } from '../icon/vl-icon.css';
 import { vlLinkStyles } from './vl-link.css';
 
 describe('link styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
                 ${vlLinkStyles()}

--- a/libs/common/utilities/src/css/base/mixin/vl-outlines.css.cy.ts
+++ b/libs/common/utilities/src/css/base/mixin/vl-outlines.css.cy.ts
@@ -1,10 +1,10 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlFocusOutlineMixin } from './vl-outlines.css';
 
 describe('outline styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
                 .cy-outline-focus {

--- a/libs/common/utilities/src/css/base/paragraph/vl-paragraph.css.cy.ts
+++ b/libs/common/utilities/src/css/base/paragraph/vl-paragraph.css.cy.ts
@@ -1,10 +1,10 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlParagraphStyles } from './vl-paragraph.css';
 
 describe('paragraph styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
                 ${vlParagraphStyles}

--- a/libs/common/utilities/src/css/global-styles.ts
+++ b/libs/common/utilities/src/css/global-styles.ts
@@ -24,7 +24,7 @@ const globalStyles = [
     vlPaddingStyles,
 ];
 
-export class RegisterGlobalStyles {
+export class GlobalStyles {
     static registered = false;
 
     static register() {
@@ -34,14 +34,7 @@ export class RegisterGlobalStyles {
                 ...(globalStyles.map((style) => style.styleSheet) as CSSStyleSheet[]),
             ];
             this.registered = true;
-            console.log('RegisterGlobalStyles: global styling toegevoegd aan het document');
+            console.log('GlobalStyles: global styling toegevoegd aan het document');
         }
     }
 }
-
-export const globalStylesNext =
-    () =>
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    (constructor: Function) => {
-        RegisterGlobalStyles.register();
-    };

--- a/libs/common/utilities/src/css/index.ts
+++ b/libs/common/utilities/src/css/index.ts
@@ -1,5 +1,5 @@
 export { vlColorStyles } from './base/var/vl-color.css';
-export { globalStylesNext, RegisterGlobalStyles } from './global-styles-decorator';
+export { GlobalStyles } from './global-styles';
 export { iconFontLocation } from './base/font/vl-font.css';
 export { vlFocusOutlineMixin } from './base/mixin/vl-outlines.css';
 export { vlWaveAnimationMixin } from './base/mixin/vl-animations.css';

--- a/libs/common/utilities/src/css/layout/grid/vl-grid.css.cy.ts
+++ b/libs/common/utilities/src/css/layout/grid/vl-grid.css.cy.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 
 describe('grid styles', () => {
     const gridResponsive = html`
@@ -60,7 +60,7 @@ describe('grid styles', () => {
     `;
 
     it('should be responsive on a large screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridResponsive);
         const cellWidth = 84.5;
         const borderWidth = 2;
@@ -136,7 +136,7 @@ describe('grid styles', () => {
     });
 
     it('should be responsive on a medium screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridResponsive);
         const cellWidth = 60;
         const borderWidth = 2;
@@ -208,7 +208,7 @@ describe('grid styles', () => {
     });
 
     it('should be responsive on a small screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridResponsive);
         const cellWidth = 50;
         const borderWidth = 2;
@@ -280,7 +280,7 @@ describe('grid styles', () => {
     });
 
     it('should be responsive on an extra-small screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridResponsive);
         const cellWidth = 30;
         const borderWidth = 2;
@@ -365,86 +365,86 @@ describe('grid styles', () => {
         </style>
         <div class="vl-grid-next vl-grid-offset">
             <div
-                    class="vl-column-next vl-column-next--1 vl-column-next--offset-12 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-1"
+                class="vl-column-next vl-column-next--1 vl-column-next--offset-12 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-1"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--2 vl-column-next--offset-11 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-2"
+                class="vl-column-next vl-column-next--2 vl-column-next--offset-11 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-2"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--3 vl-column-next--offset-10 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-3"
+                class="vl-column-next vl-column-next--3 vl-column-next--offset-10 vl-column-next--m-4 vl-column-next--m-offset-9 cy-row-3"
             ></div>
             <div class="vl-column-next vl-column-next--4 vl-column-next--offset-9 cy-row-4"></div>
             <div
-                    class="vl-column-next vl-column-next--5 vl-column-next--offset-8 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-5"
+                class="vl-column-next vl-column-next--5 vl-column-next--offset-8 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-5"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--6 vl-column-next--offset-7 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-6"
+                class="vl-column-next vl-column-next--6 vl-column-next--offset-7 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-6"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--7 vl-column-next--offset-6 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-7"
+                class="vl-column-next vl-column-next--7 vl-column-next--offset-6 vl-column-next--m-8 vl-column-next--m-offset-5 cy-row-7"
             ></div>
             <div class="vl-column-next vl-column-next--8 vl-column-next--offset-5 cy-row-8"></div>
             <div
-                    class="vl-column-next vl-column-next--9 vl-column-next--offset-4 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-9"
+                class="vl-column-next vl-column-next--9 vl-column-next--offset-4 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-9"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--10 vl-column-next--offset-3 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-10"
+                class="vl-column-next vl-column-next--10 vl-column-next--offset-3 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-10"
             ></div>
             <div
-                    class="vl-column-next vl-column-next--11 vl-column-next--offset-2 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-11"
+                class="vl-column-next vl-column-next--11 vl-column-next--offset-2 vl-column-next--m-offset-1 vl-column-next--m-12 cy-row-11"
             ></div>
             <div class="vl-column-next vl-column-next--12 vl-column-next--offset-1 cy-row-12"></div>
         </div>
     `;
 
     it('should offset on a large screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridOffset);
         cy.viewport(1100, 800);
-        for(let x=0; x<12; x++) {
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+        for (let x = 0; x < 12; x++) {
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-start',
-                value: `${12-x}`,
+                value: `${12 - x}`,
             });
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-end',
-                value: `span ${x+1}`,
+                value: `span ${x + 1}`,
             });
         }
     });
 
     it('should offset on a medium screen', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridOffset);
         const cellWidth = 84.5;
         const borderWidth = 2;
         cy.viewport(1000, 800);
-        for(let x=0; x<4; x++) {
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+        for (let x = 0; x < 4; x++) {
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-start',
                 value: `9`,
             });
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-end',
                 value: `span 4`,
             });
         }
-        for(let x=4; x<8; x++) {
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+        for (let x = 4; x < 8; x++) {
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-start',
                 value: `5`,
             });
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-end',
                 value: `span 8`,
             });
         }
-        for(let x=8; x<12; x++) {
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+        for (let x = 8; x < 12; x++) {
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-start',
                 value: `1`,
             });
-            cy.get(`.cy-row-${x+1}`).shouldHaveComputedStyle({
+            cy.get(`.cy-row-${x + 1}`).shouldHaveComputedStyle({
                 style: 'grid-column-end',
                 value: `span 12`,
             });
@@ -474,7 +474,9 @@ describe('grid styles', () => {
             >
                 &nbsp;justify-self-center&nbsp;
             </div>
-            <div class="vl-column-next vl-column-next--8 vl-column-next--offset-5 vl-column-next--justify-self-end cy-cell-3-1">
+            <div
+                class="vl-column-next vl-column-next--8 vl-column-next--offset-5 vl-column-next--justify-self-end cy-cell-3-1"
+            >
                 &nbsp;justify-self-end&nbsp;
             </div>
             <div
@@ -502,7 +504,7 @@ describe('grid styles', () => {
     `;
 
     it('should justify and align', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(gridJustifyAndAlign);
         cy.get('.cy-cell-1-1').shouldHaveComputedStyle({
             style: 'justify-self',

--- a/libs/common/utilities/src/css/layout/margin/vl-margin.css.cy.ts
+++ b/libs/common/utilities/src/css/layout/margin/vl-margin.css.cy.ts
@@ -1,15 +1,13 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlMarginStyles } from './vl-margin.css';
 
 describe('margin styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
-                ${vlMarginStyles}
-
-                div {
+                ${vlMarginStyles} div {
                     margin: 10px;
                 }
             </style>
@@ -75,5 +73,4 @@ describe('margin styles', () => {
             value: '10px',
         });
     });
-
 });

--- a/libs/common/utilities/src/css/layout/padding/vl-padding.css.cy.ts
+++ b/libs/common/utilities/src/css/layout/padding/vl-padding.css.cy.ts
@@ -1,15 +1,13 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 import { vlPaddingStyles } from './vl-padding.css';
 
 describe('padding styles', () => {
     beforeEach(() => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <style>
-                ${vlPaddingStyles}
-
-                div {
+                ${vlPaddingStyles} div {
                     padding: 10px;
                 }
             </style>
@@ -75,5 +73,4 @@ describe('padding styles', () => {
             value: '10px',
         });
     });
-
 });

--- a/libs/common/utilities/src/css/layout/section/vl-section.css.cy.ts
+++ b/libs/common/utilities/src/css/layout/section/vl-section.css.cy.ts
@@ -1,9 +1,9 @@
 import { html } from 'lit';
-import { RegisterGlobalStyles } from '../../global-styles-decorator';
+import { GlobalStyles } from '../../global-styles';
 
 describe('section styles', () => {
     it('should style the defaults', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <section class="vl-section-next vl-section-next--alt cy-section-first">
                 <p>vl-section-next vl-section-next--alt</p>
@@ -73,7 +73,7 @@ describe('section styles', () => {
     });
 
     it('should style with overlap', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <section class="vl-section-next vl-section-next--overlap cy-section-overlap">
                 <p class="vl-section-next__centered cy-section-centered">vl-section-next__centered</p>
@@ -136,7 +136,7 @@ describe('section styles', () => {
     });
 
     it('should style centered', () => {
-        cy.then(() => RegisterGlobalStyles.register());
+        cy.then(() => GlobalStyles.register());
         cy.mount(html`
             <section class="vl-section-next cy-section">
                 <p class="vl-section-next__centered cy-section-centered">vl-section-next__centered</p>

--- a/libs/components/src/declare-module.d.ts
+++ b/libs/components/src/declare-module.d.ts
@@ -1,3 +1,4 @@
 declare module '@govflanders/vl-ui-progress-bar/src/js/progress-bar.js';
 declare module 'swipe-detect/dist/';
 declare module '*.mdx';
+declare module '*.css';

--- a/libs/components/src/next/button/vl-button.component.ts
+++ b/libs/components/src/next/button/vl-button.component.ts
@@ -1,12 +1,11 @@
 import { BaseLitElement, ICON_PLACEMENT, isSlotEmpty, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext, vlIconStyles } from '@domg-wc/common-utilities/css';
+import { vlIconStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { buttonStyles } from './vl-button.css';
 import { linkButtonStyles } from './vl-link-button.css';
 import { buttonDefaults } from './vl-button.defaults';
 
-@globalStylesNext()
 @webComponent('vl-button-next')
 export class VlButtonComponent extends BaseLitElement {
     private type = buttonDefaults.type;

--- a/libs/components/src/next/doormat/vl-doormat.component.ts
+++ b/libs/components/src/next/doormat/vl-doormat.component.ts
@@ -1,12 +1,10 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { vlLinkStyles } from '@domg-wc/common-utilities/css';
 import { doormatDefaults } from './vl-doormat.defaults';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import doormatStyle from './vl-doormat.css';
 
-@globalStylesNext()
 @webComponent('vl-doormat-next')
 export class VlDoormatComponent extends BaseLitElement {
     private href = doormatDefaults.href;

--- a/libs/components/src/next/icon/vl-icon.component.ts
+++ b/libs/components/src/next/icon/vl-icon.component.ts
@@ -1,10 +1,9 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext, vlIconStyles } from '@domg-wc/common-utilities/css';
+import { vlIconStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { iconDefaults } from './vl-icon.defaults';
 
-@globalStylesNext()
 @webComponent('vl-icon-next')
 export class VlIconComponent extends BaseLitElement {
     private icon = iconDefaults.icon;

--- a/libs/components/src/next/infotext/vl-infotext.component.ts
+++ b/libs/components/src/next/infotext/vl-infotext.component.ts
@@ -1,11 +1,9 @@
 import { BaseLitElement, throttle, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import infotextStyle from './vl-infotext.css';
 import { infotextDefaults } from './vl-infotext.defaults';
 
-@globalStylesNext()
 @webComponent('vl-infotext-next')
 export class VlInfotextComponent extends BaseLitElement {
     // Attribute(s)

--- a/libs/components/src/next/link/vl-link.component.ts
+++ b/libs/components/src/next/link/vl-link.component.ts
@@ -1,11 +1,10 @@
 import { BaseLitElement, ICON_PLACEMENT, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext, vlIconStyles, vlLinkStyles } from '@domg-wc/common-utilities/css';
+import { vlIconStyles, vlLinkStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { buttonAsLinkStyles } from './vl-button-as-link.css';
 import { linkDefaults } from './vl-link.defaults';
 
-@globalStylesNext()
 @webComponent('vl-link-next')
 export class VlLinkComponent extends BaseLitElement {
     private href = linkDefaults.href;

--- a/libs/components/src/next/paragraph/vl-paragraph.component.ts
+++ b/libs/components/src/next/paragraph/vl-paragraph.component.ts
@@ -1,10 +1,9 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext, vlParagraphStyles } from '@domg-wc/common-utilities/css';
+import { vlParagraphStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { paragraphDefaults } from './vl-paragraph.defaults';
 
-@globalStylesNext()
 @webComponent('vl-paragraph-next')
 export class VlParagraphComponent extends BaseLitElement {
     private bold = paragraphDefaults.bold;

--- a/libs/components/src/next/properties/vl-properties.component.ts
+++ b/libs/components/src/next/properties/vl-properties.component.ts
@@ -1,5 +1,4 @@
 import { BaseLitElement, onChildListChange, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { vlElementsStyle } from '@domg-wc/elements';
 import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { buildProperties } from './vl-properties.builder';
@@ -7,7 +6,6 @@ import propertiesStyles, { labelWidthRem } from './vl-properties.css';
 import { propertiesDefaults } from './vl-properties.defaults';
 import { Column, Item, Props } from './vl-properties.model';
 
-@globalStylesNext()
 @webComponent('vl-properties-next')
 export class VlPropertiesComponent extends BaseLitElement {
     private attributeProps: Props = propertiesDefaults.props;

--- a/libs/components/src/next/text/vl-text.component.ts
+++ b/libs/components/src/next/text/vl-text.component.ts
@@ -1,11 +1,9 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { vlTextStyles } from './vl-text.css';
 import { textDefaults } from './vl-text.defaults';
 
-@globalStylesNext()
 @webComponent('vl-text-next')
 export class VlTextComponent extends BaseLitElement {
     private bold = textDefaults.bold;

--- a/libs/components/src/next/title/vl-title.component.ts
+++ b/libs/components/src/next/title/vl-title.component.ts
@@ -1,5 +1,4 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { CSSResult, PropertyDeclarations } from 'lit';
 import { html } from 'lit-element';
 import { choose } from 'lit/directives/choose.js';
@@ -7,7 +6,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import titleStyle from './vl-title.css';
 import { titleDefaults } from './vl-title.defaults';
 
-@globalStylesNext()
 @webComponent('vl-title-next')
 export class VlTitleComponent extends BaseLitElement {
     private type = titleDefaults.type;

--- a/libs/components/src/next/video-player/vl-video-player.component.ts
+++ b/libs/components/src/next/video-player/vl-video-player.component.ts
@@ -1,5 +1,4 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
-import { globalStylesNext } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, PropertyDeclarations, PropertyValues } from 'lit';
 import { TextTrackInit } from 'vidstack';
 import { MediaPlayerElement } from 'vidstack/elements';
@@ -7,7 +6,6 @@ import { PlyrLayout, VidstackPlayer } from 'vidstack/global/player';
 import videoPlayerStyles from './vl-video-player.css';
 import { plyrTranslations } from './vl-video-player.translations';
 
-@globalStylesNext()
 @webComponent('vl-video-player-next')
 export class VlVideoPlayerComponent extends BaseLitElement {
     private playerInstance: MediaPlayerElement | undefined;

--- a/libs/form/src/declare-module.d.ts
+++ b/libs/form/src/declare-module.d.ts
@@ -1,3 +1,4 @@
 declare module 'cleave.js';
 declare module 'dropzone';
 declare module '*.mdx';
+declare module '*.css';

--- a/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
@@ -191,10 +191,8 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-select__item.has-no-results')
             .contains('Geen geboorteplaatsen gevonden');
 
-        // Hack om de select dropdown te sluiten zodat de a11y check slaagt
-        // TODO: Dit komt omdat Choices.js het aria-activedescendant attribuut niet weghaalt van het input veld als er geen opties zijn, kijk of er een betere oplossing is.
-        cy.get('body').click(0, 0);
-        cy.checkA11y('vl-select-rich-next');
+        // het is niet accessible als de dropdown open is
+        // cy.checkA11y('vl-select-rich-next');
     });
 
     it('should set no choices text', () => {
@@ -215,10 +213,8 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-select__item.has-no-choices')
             .contains('Geen resterende geboorteplaatsen gevonden');
 
-        // Hack om de select dropdown te sluiten zodat de a11y check slaagt
-        // TODO: Dit komt omdat Choices.js het aria-activedescendant attribuut niet weghaalt van het input veld als er geen opties zijn, kijk of er een betere oplossing is.
-        cy.get('body').click(0, 0);
-        cy.checkA11y('vl-select-rich-next');
+        // het is niet accessible als de dropdown open is
+        // cy.checkA11y('vl-select-rich-next');
     });
 
     it('should set search placeholder', () => {
@@ -339,10 +335,8 @@ describe('component - vl-select-rich-next - single', () => {
             .find('.vl-select__item')
             .contains('Rio Piedras');
 
-        // Hack om de select dropdown te sluiten zodat de a11y check slaagt
-        // TODO: Dit komt omdat Choices.js het role="treeitem" attribuut zet op opties bij het gebruik van groups ipv role="option", kijk of er een betere oplossing is.
-        cy.get('body').click(0, 0);
-        cy.checkA11y('vl-select-rich-next');
+        // het is niet accessible als de dropdown open is
+        // cy.checkA11y('vl-select-rich-next');
     });
 
     it('should dispatch vl-change event on select and delete option', () => {

--- a/libs/map/src/declare-module.d.ts
+++ b/libs/map/src/declare-module.d.ts
@@ -1,1 +1,2 @@
 declare module '*.mdx';
+declare module '*.css';

--- a/libs/qlik/src/declare-module.d.ts
+++ b/libs/qlik/src/declare-module.d.ts
@@ -1,1 +1,2 @@
 declare module '*.mdx';
+declare module '*.css';

--- a/libs/sections/src/declare-module.d.ts
+++ b/libs/sections/src/declare-module.d.ts
@@ -1,1 +1,2 @@
 declare module '*.mdx';
+declare module '*.css';

--- a/resources/utils-fat-lib/declare-module.d.ts
+++ b/resources/utils-fat-lib/declare-module.d.ts
@@ -1,2 +1,1 @@
-declare module '*.mdx';
 declare module '*.css';


### PR DESCRIPTION
Vroeger gebruikten we expliciet de globalStylesNext decorator om globale styles te injecteren op Document niveau, nu wordt dit gedaan in het BaseLitElement.
Storybook verbeterd & Cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3175)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC487)