### PR TITLE
feat: UIG-3188 - vl-error-message-next - validator message wordt nu fallback foutboodschap

### DIFF
--- a/libs/form/src/next/error-message/stories/vl-error-message.stories-doc.mdx
+++ b/libs/form/src/next/error-message/stories/vl-error-message.stories-doc.mdx
@@ -32,18 +32,28 @@ import { VlErrorMessageComponent } from '@domg-wc/form/next/error-message';
 ### Volgorde
 
 We raden aan 1 error message per validatie te tonen. Als er meerdere validaties zijn, toon de belangrijkste eerst.
-De volgorde waarin de error messages getoond worden volgt dezelfde volgorde van `vl-error-message-next` componenten in de DOM. Een voorbeeld hiervan kan je vinden in onze [form demo](/docs/ontwerp-form-demo--documentatie).
+De volgorde waarin de error messages getoond worden volgt dezelfde volgorde van `vl-error-message-next` componenten in
+de DOM. Een voorbeeld hiervan kan je vinden in onze [form demo](/docs/ontwerp-form-demo--documentatie).
 
 ### Success
 
-Als je expliciet wil aantonen dat de form-control correct is ingevuld, kan je het `success` attribuut gebruiken op de gerelateerde form-control.
+Als je expliciet wil aantonen dat de form-control correct is ingevuld, kan je het `success` attribuut gebruiken op de
+ gerelateerde form-control.
 
 
 ## Validatie
 > Meer info over validatie binnen onze form componenten vind je hier: [Form - Validatie](/docs/ontwerp-form-validation--documentatie)
 
-De `vl-error-message` componenten worden getoond afhankelijk van de validatie status van onze form controls. De validatie status wordt bepaald door de `validity` property die afhangt van gebruikersinteractie.
+De `vl-error-message` componenten worden getoond afhankelijk van de validatie status van onze form controls. De
+validatie status wordt bepaald door de `validity` property die afhangt van gebruikersinteractie.
 
+## validationMessage
+
+Het `validation-message` attribuut komt overeen met de `validationMessage` property van de `ValidityState` interface.
+Dit attribuut wordt automatisch ingevuld door de form control op basis van de validatie status.
+
+Als er geen boodschap in het default slot wordt ingesteld, wordt de `validation-message` als inhoud van de
+`vl-error-message` weergegeven.
 
 ## Referenties
 

--- a/libs/form/src/next/error-message/vl-error-message.component.cy.ts
+++ b/libs/form/src/next/error-message/vl-error-message.component.cy.ts
@@ -56,4 +56,47 @@ describe('component - vl-error-message-next', () => {
         cy.get('vl-error-message-next').shadow().find('slot');
         cy.get('vl-error-message-next').should('have.text', 'Test error message');
     });
+
+    it('should display validation message without slotted content', () => {
+        cy.mount(
+            html` <vl-error-message-next validation-message="Test validation message" show></vl-error-message-next> `
+        );
+
+        cy.get('vl-error-message-next')
+            .shadow()
+            .find('slot')
+            .then((slot) => {
+                const assignedNodes = slot[0].assignedNodes();
+                expect(assignedNodes.length).to.equal(0);
+            })
+            .invoke('text')
+            .should('equal', 'Test validation message');
+
+        cy.get('vl-error-message-next')
+            .shadow()
+            .find('p')
+            .should('contain.text', 'Test validation message')
+            .and('be.visible');
+    });
+
+    it('should not show validation message with slotted content', () => {
+        cy.mount(
+            html`
+                <vl-error-message-next validation-message="Test validation message" show>
+                    custom validation message
+                </vl-error-message-next>
+            `
+        );
+
+        cy.get('vl-error-message-next').should('contain.text', 'custom validation message');
+
+        cy.get('vl-error-message-next')
+            .shadow()
+            .find('slot')
+            .then((slot) => {
+                const assignedNodes = slot[0].assignedNodes();
+                expect(assignedNodes.length).to.equal(1);
+                expect(assignedNodes[0].textContent).to.contain('custom validation message');
+            });
+    });
 });

--- a/libs/form/src/next/error-message/vl-error-message.component.ts
+++ b/libs/form/src/next/error-message/vl-error-message.component.ts
@@ -13,6 +13,7 @@ export class VlErrorMessageComponent extends BaseLitElement {
     private show = errorMessageDefaults.show;
     private for = errorMessageDefaults.for; // Wordt enkel gebruikt in de form-control basis klasse
     private state = errorMessageDefaults.state; // Wordt enkel gebruikt in de form-control basis klasse
+    private validationMessage = '';
 
     static get styles(): CSSResult[] {
         return [resetStyle, formMessageStyle, errorMessageUigStyle];
@@ -23,13 +24,14 @@ export class VlErrorMessageComponent extends BaseLitElement {
             show: { type: Boolean, reflect: true },
             for: { type: String },
             state: { type: String },
+            validationMessage: { type: String, attribute: 'validation-message' },
         };
     }
 
     render(): TemplateResult {
         return html`
             <p class="vl-form__error" ?hidden=${!this.show}>
-                <slot></slot>
+                <slot>${this.validationMessage}</slot>
             </p>
         `;
     }

--- a/libs/form/src/next/form-control/form-control.ts
+++ b/libs/form/src/next/form-control/form-control.ts
@@ -121,6 +121,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
             errorMessage = this.form?.querySelector(`${ERROR_MESSAGE_CUSTOM_TAG}[for="${this.id}"]:not([state])`);
         }
 
+        errorMessage?.setAttribute('validation-message', this.validationMessage);
         errorMessage?.setAttribute('show', '');
     }
 


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3188)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC503)