### PR TITLE
feat: UIG-3199 - vl-button-next, vl-link-next - icon-placement verbeteringen doorgevoerd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/accordion/vl-accordion.stories-dom.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/accordion/vl-accordion.stories-dom.cy.ts
@@ -58,7 +58,7 @@ const shouldEmitEventOnToggle = () => {
 };
 
 describe('story vl-accordion default', () => {
-    it.only('should display story', () => {
+    it('should display story', () => {
         cy.visit(accordionDefaultUrl);
 
         cy.get('vl-accordion').shadow();

--- a/apps/storybook-e2e/src/e2e/components/next/link/vl-link.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/next/link/vl-link.stories.cy.ts
@@ -5,6 +5,7 @@ const linkNextLargeUrl = 'http://localhost:8080/iframe.html?id=components-next-l
 const linkNextErrorUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-error&viewMode=story';
 const linkNextExternalUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-external&viewMode=story';
 const linkNextIconUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-icon&viewMode=story';
+const linkNextIconOnlyUrl = 'http://localhost:8080/iframe.html?id=components-next-link--link-icon-only&viewMode=story';
 const linkButtonStyledAsLink =
     'http://localhost:8080/iframe.html?args=&id=components-next-link--button-styled-as-link&viewMode=story';
 
@@ -59,6 +60,14 @@ describe('story - vl-link-next - external', () => {
 describe('story - vl-link-next - icon', () => {
     it('should render', () => {
         cy.visit(linkNextIconUrl);
+
+        cy.get('vl-link-next').shadow().find('a');
+    });
+});
+
+describe('story - vl-link-next - icon only', () => {
+    it('should render', () => {
+        cy.visit(linkNextIconOnlyUrl);
 
         cy.get('vl-link-next').shadow().find('a');
     });

--- a/apps/storybook-e2e/src/e2e/styles/layout/grid/vl-grid.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/styles/layout/grid/vl-grid.stories.cy.ts
@@ -27,7 +27,7 @@ describe('story - grid-next - offset', () => {
     });
 });
 
-describe.only('story - grid-next - justify/align', () => {
+describe('story - grid-next - justify/align', () => {
     it('should render', () => {
         cy.visit(gridNextJustifyAlignUrl);
 

--- a/libs/common/utilities/src/css/base/icon/vl-icon.css.ts
+++ b/libs/common/utilities/src/css/base/icon/vl-icon.css.ts
@@ -5,10 +5,6 @@ import { vlIconMapping } from './vl-icon-mapping.css';
 export const vlIconStyles: CSSResult = css`
     ${unsafeCSS(vlIconMapping)}
 
-    :host {
-        display: inline-flex;
-    }
-
     /* Icon styles - gebaseerd op DV _icon.scss */
     .vl-icon {
         font-family: var(--vl-icon-font);

--- a/libs/components/src/next/button/stories/vl-button.stories-arg.ts
+++ b/libs/components/src/next/button/stories/vl-button.stories-arg.ts
@@ -8,7 +8,6 @@ import {
 } from '@domg-wc/common-storybook';
 // de import is bewust op deze manier om voor de web-types.generator 'binnen' de monorepo geen side-effect te geven
 import { ICON_PLACEMENT } from '@domg-wc/common-utilities/constants';
-import {inputFieldArgs} from "@domg-wc/form/next/input-field/stories/vl-input-field.stories-arg";
 import { action } from '@storybook/addon-actions';
 import { ArgTypes } from '@storybook/web-components';
 import { buttonDefaults } from '../vl-button.defaults';
@@ -128,13 +127,14 @@ export const buttonArgTypes: ArgTypes<ButtonArgs> = {
     },
     iconPlacement: {
         name: 'icon-placement',
-        description: 'De positie van het icoon ten opzichte van de tekst.',
+        description:
+            'De positie van het icoon ten opzichte van de tekst.<br>Voegt margin toe tussen het icoon en de tekst.',
         control: { type: CONTROLS.SELECT },
-        options: Object.values(ICON_PLACEMENT),
+        options: ['', ...Object.values(ICON_PLACEMENT)],
         table: {
             type: { summary: getSelectControlOptions(Object.values(ICON_PLACEMENT)) },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: buttonArgs.iconPlacement },
+            defaultArgs: { summary: buttonArgs.iconPlacement },
         },
     },
     toggle: {
@@ -193,6 +193,15 @@ export const buttonArgTypes: ArgTypes<ButtonArgs> = {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: buttonArgs.inputGroup },
+        },
+    },
+    label: {
+        name: 'label',
+        description: 'Stelt het aria-label attribuut van de button in.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: buttonArgs.label },
         },
     },
     defaultSlot: {

--- a/libs/components/src/next/button/stories/vl-button.stories.ts
+++ b/libs/components/src/next/button/stories/vl-button.stories.ts
@@ -43,6 +43,7 @@ const ButtonTemplate = story(
         controlled,
         external,
         inputGroup,
+        label,
         defaultSlot,
         onVlClick,
         onVlToggle,
@@ -58,6 +59,7 @@ const ButtonTemplate = story(
             ?secondary=${secondary}
             ?tertiary=${tertiary}
             ?loading=${loading}
+            label=${label}
             icon=${icon}
             cta-link=${ctaLink}
             icon-placement=${iconPlacement}
@@ -148,6 +150,7 @@ ButtonIcon.storyName = 'vl-button-next - icon';
 ButtonIcon.args = {
     defaultSlot: 'Klik op mij',
     icon: 'location',
+    iconPlacement: 'before',
 };
 
 export const ButtonIconOnly = ButtonTemplate.bind({});

--- a/libs/components/src/next/button/vl-button.component.cy.ts
+++ b/libs/components/src/next/button/vl-button.component.cy.ts
@@ -97,6 +97,14 @@ describe('component - vl-button-next', () => {
             .find('button')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-button-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-button-next')
+            .shadow()
+            .find('button')
+            .find('span.vl-icon')
             .should('have.class', 'vl-icon--right-margin');
     });
 
@@ -113,12 +121,10 @@ describe('component - vl-button-next', () => {
             .should('have.class', 'vl-icon--left-margin');
     });
 
-    it('should set empty-slot style when slot does not have content', () => {
+    it('should not set extra margin with icon-placement is not set', () => {
         cy.mount(html` <vl-button-next icon="pin"></vl-button-next>`);
 
         cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
-        cy.get('vl-button-next').shadow().find('slot').should('be.empty');
-        cy.get('vl-button-next').shadow().find('button').should('have.class', 'empty-slot');
         cy.get('vl-button-next')
             .shadow()
             .find('button')
@@ -131,6 +137,13 @@ describe('component - vl-button-next', () => {
 
         cy.get('vl-button-next').shadow().find('button').find('slot');
         cy.get('vl-button-next').contains('Klik op mij');
+    });
+
+    it('should set label', () => {
+        cy.mount(html`<vl-button-next label="test-label"></vl-button-next>`);
+
+        cy.get('vl-button-next').should('have.attr', 'label', 'test-label');
+        cy.get('vl-button-next').shadow().find('button').should('have.attr', 'aria-label', 'test-label');
     });
 
     it('should set class if displayed in map', () => {
@@ -274,7 +287,11 @@ describe('component - vl-button-next - cta-link', () => {
             .find('a')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
-            .should('have.class', 'vl-icon--right-margin');
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-button-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-button-next').shadow().find('a').find('span.vl-icon').should('have.class', 'vl-icon--right-margin');
     });
 
     it('should set icon-placement', () => {
@@ -294,21 +311,15 @@ describe('component - vl-button-next - cta-link', () => {
             .should('have.class', 'vl-icon--left-margin');
     });
 
-    it('should set icon-only', () => {
-        cy.mount(html` <vl-button-next icon="pin" icon-only cta-link="https://www.vlaanderen.be"></vl-button-next>`);
+    it('should not set extra margin with icon-placement is not set', () => {
+        cy.mount(html` <vl-button-next cta-link="https://www.vlaanderen.be" icon="pin"></vl-button-next>`);
 
-        it('should set empty-slot style when slot does not have content', () => {
-            cy.mount(html` <vl-button-next icon="pin"></vl-button-next>`);
-
-            cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
-            cy.get('vl-button-next').shadow().find('slot').should('be.empty');
-            cy.get('vl-button-next').shadow().find('button').should('have.class', 'empty-slot');
-            cy.get('vl-button-next')
-                .shadow()
-                .find('button')
-                .shouldHaveComputedStyle({ style: 'padding', value: '0px' })
-                .shouldHaveComputedStyle({ style: 'width', value: '35px' });
-        });
+        cy.get('vl-button-next').should('have.attr', 'icon', 'pin');
+        cy.get('vl-button-next')
+            .shadow()
+            .find('a')
+            .shouldHaveComputedStyle({ style: 'padding', value: '0px' })
+            .shouldHaveComputedStyle({ style: 'width', value: '31px' });
     });
 
     it('should set content', () => {
@@ -408,7 +419,7 @@ describe('component - vl-button-next - in form', () => {
     });
 });
 
-describe.only('component - vl-button-next - in input-group', () => {
+describe('component - vl-button-next - in input-group', () => {
     it('should have no radius depending on the side', () => {
         cy.mount(html` <style>
                 ${vlGroupStyles}

--- a/libs/components/src/next/button/vl-button.component.ts
+++ b/libs/components/src/next/button/vl-button.component.ts
@@ -1,7 +1,7 @@
 import { BaseLitElement, ICON_PLACEMENT, isSlotEmpty, webComponent } from '@domg-wc/common-utilities';
 import { vlIconStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
+import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { buttonStyles } from './vl-button.css';
 import { linkButtonStyles } from './vl-link-button.css';
 import { buttonDefaults } from './vl-button.defaults';
@@ -25,7 +25,7 @@ export class VlButtonComponent extends BaseLitElement {
     private external = buttonDefaults.external;
     private inputGroup = buttonDefaults.inputGroup;
     private label = buttonDefaults.label;
-    private hasEmptySlot = false;
+    private slotIsEmpty = true;
 
     public disabled = buttonDefaults.disabled;
     public on = buttonDefaults.on;
@@ -53,8 +53,8 @@ export class VlButtonComponent extends BaseLitElement {
             external: { type: Boolean },
             inputGroup: { type: Boolean, attribute: 'input-group' },
             label: { type: String },
-            hasEmptySlot: { type: Boolean },
             disabled: { type: Boolean, reflect: true },
+            slotIsEmpty: { type: Boolean, state: true },
             on: {
                 type: Boolean,
                 reflect: true,
@@ -69,12 +69,6 @@ export class VlButtonComponent extends BaseLitElement {
         };
     }
 
-    protected firstUpdated(_changedProperties: PropertyValues) {
-        super.firstUpdated(_changedProperties);
-
-        this.isSlotEmpty();
-    }
-
     updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
 
@@ -82,12 +76,6 @@ export class VlButtonComponent extends BaseLitElement {
             this.dispatchEvent(
                 new CustomEvent('vl-toggle', { detail: { on: this.on }, bubbles: true, composed: true })
             );
-        }
-
-        if (changedProperties.has('iconPlacement')) {
-            if (!this.iconPlacement) {
-                this.iconPlacement = buttonDefaults.iconPlacement;
-            }
         }
     }
 
@@ -118,66 +106,69 @@ export class VlButtonComponent extends BaseLitElement {
             'input-group-left': this.inputGroup && this.isInputGroupPosition('first'),
             'input-group-right': this.inputGroup && this.isInputGroupPosition('last'),
             'button-in-map': isInMap,
-            'empty-slot': this.hasEmptySlot,
+            'empty-slot': this.slotIsEmpty,
         };
 
-        return !this.ctaLink
-            ? html`
-                  <button
-                      part="button"
-                      class=${classMap(classes)}
-                      type=${this.type}
-                      ?disabled=${this.disabled}
-                      @click=${this.handleClick}
-                      aria-label=${this.label}
-                  >
-                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
-                      <slot @slotchange=${this.isSlotEmpty}></slot>
-                      ${this.renderIcon(ICON_PLACEMENT.AFTER)}
-                  </button>
-              `
-            : html`
-                  <a
-                      part="button"
-                      href=${this.disabled ? 'javascript:void(0);' : this.ctaLink}
-                      tabindex=${this.disabled ? '-1' : nothing}
-                      class=${classMap(classes)}
-                      role="button"
-                      target=${this.ctaLink && this.external ? '_blank' : nothing}
-                      @click=${this.handleLinkClick}
-                      aria-label=${this.label}
-                      ?aria-pressed=${this.on}
-                      ?aria-disabled=${this.disabled}
-                  >
-                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
-                      <slot @slotchange=${this.isSlotEmpty}></slot>
-                      ${this.renderIcon(ICON_PLACEMENT.AFTER)}
-                  </a>
-              `;
+        return !this.ctaLink ? this.renderButton(classes) : this.renderCtaLink(classes);
     }
 
-    renderIcon(iconPlacement: ICON_PLACEMENT): TemplateResult | typeof nothing {
-        if (!this.icon) {
-            return nothing;
-        }
+    private renderButton(classes: ClassInfo): TemplateResult {
+        const positionIconBefore = this.iconPlacement !== ICON_PLACEMENT.AFTER;
 
-        if (iconPlacement !== this.iconPlacement) {
-            return nothing;
-        }
+        return html`
+            <button
+                part="button"
+                class=${classMap(classes)}
+                type=${this.type}
+                ?disabled=${this.disabled}
+                @click=${this.handleClick}
+                aria-label=${this.label ?? nothing}
+            >
+                ${positionIconBefore ? this.renderIcon() : nothing}
+                <slot @slotchange=${this.handleSlotChange}></slot>
+                ${!positionIconBefore ? this.renderIcon() : nothing}
+            </button>
+        `;
+    }
 
+    private renderCtaLink(classes: ClassInfo): TemplateResult {
+        const positionIconBefore = this.iconPlacement !== ICON_PLACEMENT.AFTER;
+
+        return html`
+            <a
+                part="button"
+                href=${this.disabled ? 'javascript:void(0);' : this.ctaLink}
+                tabindex=${this.disabled ? '-1' : nothing}
+                class=${classMap(classes)}
+                role="button"
+                target=${this.ctaLink && this.external ? '_blank' : nothing}
+                @click=${this.handleLinkClick}
+                aria-label=${this.label ?? nothing}
+                ?aria-pressed=${this.on}
+                ?aria-disabled=${this.disabled}
+            >
+                ${positionIconBefore ? this.renderIcon() : nothing}
+                <slot @slotchange=${this.handleSlotChange}></slot>
+                ${!positionIconBefore ? this.renderIcon() : nothing}
+                ${this.external ? html`<span class="vl-icon vl-icon--external vl-icon--after"></span>` : nothing}
+            </a>
+        `;
+    }
+
+    private renderIcon(): TemplateResult | typeof nothing {
         const classes = {
             'vl-icon': true,
             [`vl-icon--${this.icon}`]: true,
-            'vl-icon--right-margin': !this.hasEmptySlot && this.iconPlacement === 'before',
-            'vl-icon--left-margin': !this.hasEmptySlot && this.iconPlacement === 'after',
+            'vl-icon--right-margin': this.iconPlacement === 'before',
+            'vl-icon--left-margin': this.iconPlacement === 'after',
         };
 
-        return html`<span class=${classMap(classes)}></span>`;
+        return this.icon ? html`<span class=${classMap(classes)}></span>` : nothing;
     }
 
-    isSlotEmpty() {
+    handleSlotChange() {
         const slot = this.shadowRoot?.querySelector('slot');
-        this.hasEmptySlot = Boolean(slot && isSlotEmpty(slot!));
+        this.slotIsEmpty = Boolean(slot && isSlotEmpty(slot!));
     }
 
     protected handleClick() {

--- a/libs/components/src/next/button/vl-button.css.ts
+++ b/libs/components/src/next/button/vl-button.css.ts
@@ -261,11 +261,10 @@ export const buttonStyles: CSSResult = css`
             width: 3.5rem;
             padding: 0;
             &.tertiary {
-                padding: 0;
-            }
-            .vl-icon {
-                margin-left: 0;
-                margin-right: 0;
+                &:hover,
+                &:active {
+                    padding: 0;
+                }
             }
         }
 

--- a/libs/components/src/next/button/vl-button.defaults.ts
+++ b/libs/components/src/next/button/vl-button.defaults.ts
@@ -12,7 +12,7 @@ export const buttonDefaults = {
     tertiary: false as boolean,
     loading: false as boolean,
     icon: '' as string,
-    iconPlacement: 'before' as ICON_PLACEMENT,
+    iconPlacement: '' as ICON_PLACEMENT,
     toggle: false as boolean,
     controlled: false as boolean,
     ctaLink: '' as string,

--- a/libs/components/src/next/button/vl-link-button.css.ts
+++ b/libs/components/src/next/button/vl-link-button.css.ts
@@ -23,16 +23,17 @@ export const linkButtonStyles: CSSResult = css`
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        min-height: 2.5rem; /* verschilt van button styling */
+        min-height: 2.1rem; /* verschilt van button styling */
         font-family: inherit;
         font-size: var(--vl-font-size--small);
         font-weight: 500;
         padding: var(--vl-spacing--xxsmall) var(--vl-spacing--normal);
         background-color: var(--vl-color--action);
-        border: 0 solid var(--vl-color--action);
+        border: 0.2rem  solid var(--vl-color--action);
         border-radius: var(--vl-border--radius);
         color: var(--vl-color--white);
         max-width: 100%;
+        line-height: normal;
 
         /* link-button styles */
         text-decoration: none;
@@ -263,23 +264,15 @@ export const linkButtonStyles: CSSResult = css`
 
         /* Empty slot styles */
         &.empty-slot {
-            width: 3.5rem;
+            width: 3.1rem;
             padding: 0;
-            min-height: 3.5rem;
+            min-height: 3.1rem;
 
             &.secondary {
-                width: 3.1rem;
-                min-height: 3.1rem;
                 padding: 0;
             }
             &.tertiary {
-                width: 3.1rem;
-                min-height: 3.1rem;
                 padding: 0.1rem;
-            }
-            .vl-icon {
-                margin-left: 0;
-                margin-right: 0;
             }
         }
     }

--- a/libs/components/src/next/icon/vl-icon.component.ts
+++ b/libs/components/src/next/icon/vl-icon.component.ts
@@ -2,6 +2,7 @@ import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
 import { vlIconStyles } from '@domg-wc/common-utilities/css';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { vlIconWebComponentStyles } from './vl-icon.css';
 import { iconDefaults } from './vl-icon.defaults';
 
 @webComponent('vl-icon-next')
@@ -15,7 +16,7 @@ export class VlIconComponent extends BaseLitElement {
     private clickable = iconDefaults.clickable;
 
     static get styles(): CSSResult[] {
-        return [vlIconStyles];
+        return [vlIconStyles, vlIconWebComponentStyles];
     }
 
     static get properties(): PropertyDeclarations {

--- a/libs/components/src/next/icon/vl-icon.css.ts
+++ b/libs/components/src/next/icon/vl-icon.css.ts
@@ -1,0 +1,7 @@
+import { css } from 'lit';
+
+export const vlIconWebComponentStyles = css`
+    :host {
+        display: inline-flex;
+    }
+`;

--- a/libs/components/src/next/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/next/link/stories/vl-link.stories-arg.ts
@@ -86,13 +86,14 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     },
     iconPlacement: {
         name: 'icon-placement',
-        description: 'De positie van het icoon ten opzichte van de tekst.',
+        description:
+            'De positie van het icoon ten opzichte van de tekst.<br>Voegt margin toe tussen het icoon en de tekst.',
         control: { type: CONTROLS.SELECT },
-        options: Object.values(ICON_PLACEMENT),
+        options: ['', ...Object.values(ICON_PLACEMENT)],
         table: {
             type: { summary: getSelectControlOptions(Object.values(ICON_PLACEMENT)) },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: linkArgs.iconPlacement },
+            defaultArgs: { summary: linkArgs.iconPlacement },
         },
     },
     buttonAsLink: {

--- a/libs/components/src/next/link/stories/vl-link.stories.ts
+++ b/libs/components/src/next/link/stories/vl-link.stories.ts
@@ -94,6 +94,14 @@ LinkIcon.args = {
     href: 'https://www.vlaanderen.be',
     defaultSlot: 'Vlaanderen',
     icon: 'arrow-right-fat',
+    iconPlacement: 'before',
+};
+
+export const LinkIconOnly = LinkTemplate.bind({});
+LinkIconOnly.storyName = 'vl-link-next - icon only';
+LinkIconOnly.args = {
+    href: 'https://www.vlaanderen.be',
+    icon: 'arrow-right-fat',
 };
 
 export const ButtonStyledAsLink = LinkTemplate.bind({});

--- a/libs/components/src/next/link/vl-link.component.cy.ts
+++ b/libs/components/src/next/link/vl-link.component.cy.ts
@@ -69,7 +69,11 @@ describe('component - vl-link-next - default', () => {
             .find('a')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
-            .should('have.class', 'vl-icon--right-margin');
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-link-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-link-next').shadow().find('a').find('span.vl-icon').should('have.class', 'vl-icon--right-margin');
     });
 
     it('should set icon-placement', () => {
@@ -82,7 +86,11 @@ describe('component - vl-link-next - default', () => {
             .find('a')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
-            .should('have.class', 'vl-icon--left-margin');
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-link-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-link-next').shadow().find('a').find('span.vl-icon').should('have.class', 'vl-icon--right-margin');
     });
 
     it('should not render icon when no icon value is set', () => {
@@ -164,6 +172,14 @@ describe('component - vl-link-next - button as link', () => {
             .find('button')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-link-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-link-next')
+            .shadow()
+            .find('button')
+            .find('span.vl-icon')
             .should('have.class', 'vl-icon--right-margin');
     });
 
@@ -181,7 +197,15 @@ describe('component - vl-link-next - button as link', () => {
             .find('button')
             .find('span.vl-icon')
             .should('have.class', 'vl-icon--pin')
-            .should('have.class', 'vl-icon--left-margin');
+            .should('not.have.class', 'vl-icon--right-margin');
+
+        cy.get('vl-link-next').invoke('attr', 'icon-placement', 'before');
+
+        cy.get('vl-link-next')
+            .shadow()
+            .find('button')
+            .find('span.vl-icon')
+            .should('have.class', 'vl-icon--right-margin');
     });
 
     it('should not render icon when no icon value is set', () => {

--- a/libs/components/src/next/link/vl-link.component.ts
+++ b/libs/components/src/next/link/vl-link.component.ts
@@ -31,19 +31,9 @@ export class VlLinkComponent extends BaseLitElement {
             large: { type: Boolean },
             external: { type: Boolean },
             icon: { type: String },
-            iconPlacement: { type: String, attribute: 'icon-placement', reflect: true },
+            iconPlacement: { type: String, attribute: 'icon-placement' },
             buttonAsLink: { type: Boolean, attribute: 'button-as-link' },
         };
-    }
-
-    updated(changedProperties: Map<string, unknown>) {
-        super.updated(changedProperties);
-
-        if (changedProperties.has('iconPlacement')) {
-            if (!this.iconPlacement) {
-                this.iconPlacement = linkDefaults.iconPlacement;
-            }
-        }
     }
 
     render(): TemplateResult {
@@ -54,29 +44,27 @@ export class VlLinkComponent extends BaseLitElement {
             large: this.large,
         };
         const target = this.external ? '_blank' : nothing;
-
+        const positionIconBefore = this.iconPlacement !== ICON_PLACEMENT.AFTER;
         return !this.buttonAsLink
             ? html`
                   <a class=${classMap(classes)} href=${this.href} target=${target}>
-                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
+                      ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
-                      ${this.renderIcon(ICON_PLACEMENT.AFTER)} ${this.external ? this.renderExternalIcon() : ''}
+                      ${!positionIconBefore ? this.renderIcon() : nothing}
+                      ${this.external ? this.renderExternalIcon() : ''}
                   </a>
               `
             : html`
                   <button class="vl-button-as-link ${classMap(classes)}">
-                      ${this.renderIcon(ICON_PLACEMENT.BEFORE)}
+                      ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
-                      ${this.renderIcon(ICON_PLACEMENT.AFTER)} ${this.external ? this.renderExternalIcon() : ''}
+                      ${!positionIconBefore ? this.renderIcon() : nothing}
+                      ${this.external ? this.renderExternalIcon() : ''}
                   </button>
               `;
     }
 
-    renderIcon(iconPlacement: ICON_PLACEMENT): TemplateResult | typeof nothing {
-        if (iconPlacement !== this.iconPlacement) {
-            return nothing;
-        }
-
+    private renderIcon(): TemplateResult | typeof nothing {
         const classes = {
             'vl-icon': true,
             [`vl-icon--${this.icon}`]: true,
@@ -87,7 +75,7 @@ export class VlLinkComponent extends BaseLitElement {
         return this.icon ? html`<span class=${classMap(classes)}></span>` : nothing;
     }
 
-    renderExternalIcon(): TemplateResult {
+    private renderExternalIcon(): TemplateResult {
         return html`<span class="vl-icon vl-icon--external vl-icon--after"></span>`;
     }
 }

--- a/libs/components/src/next/link/vl-link.defaults.ts
+++ b/libs/components/src/next/link/vl-link.defaults.ts
@@ -8,6 +8,6 @@ export const linkDefaults = {
     error: false as boolean,
     external: false as boolean,
     icon: '' as string,
-    iconPlacement: 'before' as ICON_PLACEMENT,
+    iconPlacement: '' as ICON_PLACEMENT,
     buttonAsLink: false as boolean,
 } as const;

--- a/libs/components/src/next/table/vl-table.component.ts
+++ b/libs/components/src/next/table/vl-table.component.ts
@@ -125,7 +125,6 @@ export class VlTableComponent extends LitElement {
         button.setAttribute('narrow', '');
         button.setAttribute('secondary', '');
         button.setAttribute('icon', 'arrow-down-fat');
-        button.setAttribute('icon-only', '');
 
         button.addEventListener('vl-click', (e: Event) => {
             e.preventDefault();


### PR DESCRIPTION
Vroeger werd er standaard margin links of rechts van de icon ingesteld, nu wordt er enkel margin ingesteld als icon-placement attribuut expliciet ingesteld wordt.

Storybook verbeterd & cypress testen uitgebreid.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3199)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC516)