### PR TITLE
feat: UIG-3156 - vl-modal - sluiten adhv 'Escape' key verbeterd

### DIFF
--- a/libs/components/src/modal/stories/vl-modal.stories-arg.ts
+++ b/libs/components/src/modal/stories/vl-modal.stories-arg.ts
@@ -1,4 +1,4 @@
-import { defaultArgs, defaultArgTypes } from '@domg-wc/common-storybook';
+import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@domg-wc/common-storybook';
 import { ArgTypes } from '@storybook/web-components';
 
 export const modalArgs = {
@@ -15,7 +15,8 @@ export const modalArgTypes: ArgTypes = {
     ...defaultArgTypes(),
     title: {
         name: 'data-vl-title',
-        description: 'Attribute used to add an heading 2 (h2) title. When empty there is no heading element created.',
+        description:
+            'Attribuut gebruikt om een `<h2>` titel toe te voegen. Indien leeg, wordt er geen titel element aangemaakt.',
         table: {
             type: { summary: 'String' },
             defaultValue: { summary: '' },
@@ -24,7 +25,7 @@ export const modalArgTypes: ArgTypes = {
     },
     open: {
         name: 'data-vl-open',
-        description: 'Attribute to immediately open up the modal after rendering.',
+        description: 'Attribuut om de modal onmiddellijk te openen na de rendering.',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
@@ -33,7 +34,8 @@ export const modalArgTypes: ArgTypes = {
     },
     closable: {
         name: 'data-vl-closable',
-        description: 'Attribute to make the modal closable through the close icon in the top right corner.',
+        description:
+            'Attribuut om de modal sluitbaar te maken via het "Sluit"-icoon in de rechterbovenhoek of door de "Escape"-toets te gebruiken.',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
@@ -42,7 +44,7 @@ export const modalArgTypes: ArgTypes = {
     },
     notCancellable: {
         name: 'data-vl-not-cancellable',
-        description: 'Attribute used to make the modal non cancellable',
+        description: 'Attribuut gebruikt om de modal niet annuleerbaar te maken.',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
@@ -51,7 +53,8 @@ export const modalArgTypes: ArgTypes = {
     },
     notAutoClosable: {
         name: 'data-vl-not-auto-closable',
-        description: 'Attribute to disable the closing of the modal when clicking the action in the button slot.',
+        description:
+            'Attribuut om het afsluiten van de modal uit te schakelen bij het klikken op de actie in het button-slot.',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
@@ -60,11 +63,27 @@ export const modalArgTypes: ArgTypes = {
     },
     allowOverflow: {
         name: 'data-vl-allow-overflow',
-        description: 'Attribute to allow the content of the modal to overflow.',
+        description: 'Attribuut om de afgesneden inhoud van de modal zichtbaar te maken.',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
             category: 'Attributes',
+        },
+    },
+    contentSlot: {
+        name: 'content',
+        description: 'Dit slot bevat de HTML inhoud van de modal.',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
+        },
+    },
+    buttonSlot: {
+        name: 'button',
+        description: 'Gebruik dit slot om de primaire actie mee te geven.',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
         },
     },
 };

--- a/libs/components/src/modal/vl-modal.component.cy.ts
+++ b/libs/components/src/modal/vl-modal.component.cy.ts
@@ -76,7 +76,11 @@ const clickCustomActionButton = () => {
 };
 
 const closeByPressingEscape = () => {
-    cy.get('body').type('{esc}');
+    // Dit zou moeten werken met `cy.get('body').type('{esc}')`,
+    // Cypress verwacht echter dat `.type()` uitgevoerd wordt op een "typeable" element.
+    // `{ force: true }` is nodig om in de shadow dom te kunnen typen.
+    // (https://github.com/cypress-io/cypress/issues/7741)
+    cy.getDataCy('modal').shadow().find('button').first().type('{esc}', { force: true });
 };
 
 describe('component - vl-modal', () => {
@@ -92,7 +96,7 @@ describe('component - vl-modal', () => {
         isDialogVisible();
     });
 
-    it('should contain a toggable modal by using the cancel button', () => {
+    it('should be able to close the modal by using the cancel button', () => {
         cy.mount(html`${renderOpenButton()} ${renderModal({})}`);
 
         isDialogHidden();
@@ -102,7 +106,7 @@ describe('component - vl-modal', () => {
         isDialogHidden();
     });
 
-    it('should contain a toggable modal by using the close button', () => {
+    it('should be able to close the modal by using the close button', () => {
         // Test met desktop viewport omdat de close button verborgen wordt op mobiel
         cy.viewport(1024, 768);
         cy.mount(html`${renderOpenButton()} ${renderModal({ closable: true })}`);
@@ -114,7 +118,19 @@ describe('component - vl-modal', () => {
         isDialogHidden();
     });
 
-    it('should contain a non closable modal when using the action button', () => {
+    it('should close the modal by pressing escape', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({ button: otherActionButton })}`);
+
+        isDialogHidden();
+        openModal();
+        isDialogVisible();
+        closeByPressingEscape();
+        isDialogHidden();
+    });
+});
+
+describe('component - vl-modal - notAutoClosable (true)', () => {
+    it('should NOT automatically close the modal when using the action button', () => {
         cy.mount(html`${renderOpenButton()} ${renderModal({ notAutoClosable: true })}`);
 
         isDialogHidden();
@@ -126,24 +142,37 @@ describe('component - vl-modal', () => {
         isDialogHidden();
     });
 
-    it('should contain an automatically closable modal by clicking the custom action link', () => {
-        cy.mount(html`${renderOpenButton()} ${renderModal({ button: otherActionButton })}`);
+    it('should NOT automatically close the modal when using a custom action', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({ notAutoClosable: true, button: otherActionButton })}`);
 
         isDialogHidden();
         openModal();
         isDialogVisible();
         clickCustomActionButton();
+        isDialogVisible();
+        closeWithCancelButton();
         isDialogHidden();
     });
+});
 
-    // TODO: deze test faalt
-    it.skip('should contain a closable modal by pressing escape', () => {
-        cy.mount(html`${renderOpenButton()} ${renderModal({ button: otherActionButton })}`);
+describe('component - vl-modal - notAutoClosable (false)', () => {
+    it('should automatically close the modal when using the action button', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({ notAutoClosable: false })}`);
 
         isDialogHidden();
         openModal();
         isDialogVisible();
-        closeByPressingEscape();
+        clickActionButton();
+        isDialogHidden();
+    });
+
+    it('should automatically close the modal when using a custom action', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({ notAutoClosable: false, button: otherActionButton })}`);
+
+        isDialogHidden();
+        openModal();
+        isDialogVisible();
+        clickCustomActionButton();
         isDialogHidden();
     });
 });

--- a/libs/components/src/modal/vl-modal.component.ts
+++ b/libs/components/src/modal/vl-modal.component.ts
@@ -66,6 +66,12 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
         super.connectedCallback();
 
         this.dress();
+
+        this._shadow.host.addEventListener('keyup', this._onEscape);
+    }
+
+    disconnectedCallback() {
+        this._shadow.host.removeEventListener('keyup', this._onEscape);
     }
 
     get _dialogElement(): HTMLDialogElement {
@@ -117,7 +123,6 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
         if (!this.isOpen()) {
             awaitUntil(() => this._dialogElement.isConnected).then(() => {
                 vl.modal.toggle(this._dialogElement);
-                this._dialogElement?.focus();
             });
         }
     }
@@ -208,8 +213,8 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
     }
 
     _closableChangedCallback(oldValue: string, newValue: string) {
-        if (newValue != undefined) {
-            this._dialogElement.setAttribute(VlModalComponent._closableAttribute, '');
+        if (newValue !== null) {
+            this._dialogElement.setAttribute(VlModalComponent._closableAttribute, newValue);
             if (!this._closeButtonElement) {
                 this._dialogElement.appendChild(this._getCloseButtonTemplate());
             }
@@ -226,6 +231,19 @@ export class VlModalComponent extends BaseElementOfType(HTMLElement) {
             this._slotButtonElement.removeAttribute(VlModalComponent._closeAttribute);
         }
     }
+
+    private _onEscape = (e: KeyboardEvent) => {
+        if (e.code.toLowerCase() === 'escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            const canEscape =
+                this._dialogElement.hasAttribute(VlModalComponent._closableAttribute) &&
+                this._dialogElement.getAttribute(VlModalComponent._closableAttribute) !== 'false';
+            if (canEscape) {
+                this.close();
+            }
+        }
+    };
 }
 
 declare global {


### PR DESCRIPTION
https://www.milieuinfo.be/jira/browse/UIG-3156
https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC532

`vl-modal` componenten met `closable` attribuut zijn sluitbaar met de "Escape"-key. Zonder `closable` of met `closable="false"` zijn deze niet sluitbaar met de "Escape"-key.
De focus wordt niet meer op de `dialog`-tag geplaatst bij het openen, maar blijft op het eerste interactieve element in de dialog.