### PR TITLE
fix: UIG-3222 - vl-error-message-next - pre-line wordt nu enkel met attribuut gestuurd

### DIFF
--- a/libs/form/src/next/error-message/stories/vl-error-message.stories-arg.ts
+++ b/libs/form/src/next/error-message/stories/vl-error-message.stories-arg.ts
@@ -40,6 +40,15 @@ export const errorMessageArgTypes: ArgTypes<ErrorMessageArgs> = {
             defaultValue: { summary: errorMessageArgs.show },
         },
     },
+    preLine: {
+        name: 'preLine',
+        description: 'Duidt aan of de nieuwe lijnen (`\n`) in de  error message behouden worden.',
+        table: {
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: TYPES.BOOLEAN },
+            defaultValue: { summary: errorMessageArgs.preLine },
+        },
+    },
     defaultSlot: {
         name: '[default]',
         description: 'De inhoud van de error message.',

--- a/libs/form/src/next/error-message/stories/vl-error-message.stories.ts
+++ b/libs/form/src/next/error-message/stories/vl-error-message.stories.ts
@@ -22,11 +22,15 @@ export default {
     },
 } as Meta<typeof errorMessageArgs>;
 
-export const ErrorMessageDefault = story(errorMessageArgs, ({ for: forValue, state, show, defaultSlot }) => {
+export const ErrorMessageDefault = story(errorMessageArgs, ({ for: forValue, state, show, preLine, defaultSlot }) => {
     return html`
-        <vl-error-message-next for=${forValue} state=${state} ?show=${show}
-            >${unsafeHTML(defaultSlot)}</vl-error-message-next
-        >
+        <vl-error-message-next
+            for=${forValue}
+            state=${state}
+            ?show=${show}
+            ?pre-line=${preLine}
+            validation-message=${defaultSlot}
+        ></vl-error-message-next>
     `;
 });
 ErrorMessageDefault.storyName = 'vl-error-message-next - default';

--- a/libs/form/src/next/error-message/vl-error-message.component.cy.ts
+++ b/libs/form/src/next/error-message/vl-error-message.component.cy.ts
@@ -32,6 +32,15 @@ describe('component - vl-error-message-next', () => {
         cy.get('vl-error-message-next').shadow().find('.vl-form__error').should('be.visible');
     });
 
+    it('should set pre-line attribute', () => {
+        cy.mount(html`<vl-error-message-next pre-line>Test error message</vl-error-message-next>`);
+
+        cy.get('vl-error-message-next').shadow().find('p').should('have.css', 'white-space', 'pre-line');
+
+        cy.get('vl-error-message-next').invoke('removeAttr', 'pre-line');
+        cy.get('vl-error-message-next').shadow().find('p').should('not.have.css', 'white-space', 'pre-line');
+    });
+
     it('should set for', () => {
         cy.mount(html`<vl-error-message-next for="test-input">Test error message</vl-error-message-next>`);
 

--- a/libs/form/src/next/error-message/vl-error-message.component.ts
+++ b/libs/form/src/next/error-message/vl-error-message.component.ts
@@ -2,6 +2,7 @@ import { BaseLitElement, webComponent } from '@domg-wc/common-utilities';
 import { resetStyle } from '@domg/govflanders-style/common';
 import { formMessageStyle } from '@domg/govflanders-style/component';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { errorMessageDefaults } from './vl-error-message.defaults';
 import errorMessageUigStyle from './vl-error-message.uig-css';
 
@@ -11,6 +12,7 @@ export const ERROR_MESSAGE_CUSTOM_TAG = 'vl-error-message-next';
 export class VlErrorMessageComponent extends BaseLitElement {
     // Attributes
     private show = errorMessageDefaults.show;
+    private preLine = errorMessageDefaults.preLine;
     private for = errorMessageDefaults.for; // Wordt enkel gebruikt in de form-control basis klasse
     private state = errorMessageDefaults.state; // Wordt enkel gebruikt in de form-control basis klasse
     private validationMessage = '';
@@ -22,6 +24,7 @@ export class VlErrorMessageComponent extends BaseLitElement {
     static get properties(): PropertyDeclarations {
         return {
             show: { type: Boolean, reflect: true },
+            preLine: { type: Boolean, attribute: 'pre-line' },
             for: { type: String },
             state: { type: String },
             validationMessage: { type: String, attribute: 'validation-message' },
@@ -29,10 +32,12 @@ export class VlErrorMessageComponent extends BaseLitElement {
     }
 
     render(): TemplateResult {
+        const classes = {
+            'vl-form__error': true,
+            'vl-pre-line': this.preLine,
+        };
         return html`
-            <p class="vl-form__error" ?hidden=${!this.show}>
-                <slot>${this.validationMessage}</slot>
-            </p>
+            <p class=${classMap(classes)} part="text" ?hidden=${!this.show}><slot>${this.validationMessage}</slot></p>
         `;
     }
 }

--- a/libs/form/src/next/error-message/vl-error-message.defaults.ts
+++ b/libs/form/src/next/error-message/vl-error-message.defaults.ts
@@ -1,5 +1,6 @@
 export const errorMessageDefaults = {
     show: false as boolean,
+    preLine: false as boolean,
     for: null as string | null,
     state: null as keyof ValidityState | null,
 } as const;

--- a/libs/form/src/next/error-message/vl-error-message.uig-css.ts
+++ b/libs/form/src/next/error-message/vl-error-message.uig-css.ts
@@ -3,6 +3,9 @@ import { css, CSSResult } from 'lit';
 const styles: CSSResult = css`
     .vl-form__error {
         margin-top: 0.2rem;
+    }
+
+    .vl-pre-line {
         white-space: pre-line;
     }
 `;


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3222)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC545)