### PR TITLE
fix: UIG-2929 - vl-search-filter-next - footer styling rechtgezet

### DIFF
--- a/libs/components/src/next/search-filter/stories/vl-search-filter.stories.ts
+++ b/libs/components/src/next/search-filter/stories/vl-search-filter.stories.ts
@@ -117,8 +117,8 @@ const searchFilterTemplate = story(
                     </section>
                 </div>
                 <footer>
-                    <vl-button-next type="submit" custom-css="button {flex:1}">Zoeken</vl-button-next>
-                    <vl-button-next type="reset" custom-css="button {flex:1}" secondary>Reset</vl-button-next>
+                    <vl-button-next type="submit">Zoeken</vl-button-next>
+                    <vl-button-next type="reset" secondary>Reset</vl-button-next>
                 </footer>
             </form>
         </vl-search-filter-next>

--- a/libs/components/src/next/search-filter/vl-search-filter.global.css.ts
+++ b/libs/components/src/next/search-filter/vl-search-filter.global.css.ts
@@ -89,6 +89,14 @@ export const searchFilterGlobalStyles: CSSResult = css`
             vl-button-next {
                 width: 100%;
             }
+
+            vl-button-next {
+                display: inline-flex;
+            }
+
+            vl-button-next::part(button) {
+                flex: 1;
+            }
         }
         .vl-search-filter-next--form:has(> section) {
             height: calc(120vh + 100px);


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-2929) (ticket gebruikt voor "vl-search-filter-next - introductie")
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC548)

Dit was niet juist:

<img width="364" alt="image" src="https://github.com/user-attachments/assets/26a2b3d9-8443-4c9d-a1b6-95ce94da8a1b" />

terug rechtgezet naar:

<img width="370" alt="image" src="https://github.com/user-attachments/assets/dfb9c565-00ec-47ba-bce1-c4463dc495dd" />
