### PR TITLE
feat: UIG-3225 - vl-group-next - bij `vl-group-next--baseline` worden links met icoon nu ook op de baseline uitgelijnd

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { registerWebComponents } from '@domg-wc/common-utilities';
 import { vlGroupStyles } from '@domg-wc/common-utilities/css';
 import { VlModalComponent, VlPillComponent, VlSideSheet, VlTabsComponent } from '@domg-wc/components';
 import { VlButtonComponent } from '@domg-wc/components/next/button';
+import { VlLinkComponent } from '@domg-wc/components/next/link';
 import { VlParagraphComponent } from '@domg-wc/components/next/paragraph';
 import { VlTitleComponent } from '@domg-wc/components/next/title';
 import { vlElementsStyle } from '@domg-wc/elements';
@@ -18,15 +19,16 @@ export class AppComponent extends LitElement {
         registerWebComponents([
             VlTabsComponent,
             VlSelectRichComponent,
-            VlSelectComponent,
+            VlTitleComponent,
+            VlLinkComponent,
             VlButtonComponent,
+            VlParagraphComponent,
+            VlSelectComponent,
             VlDatepickerComponent,
             VlModalComponent,
             VlSideSheet,
             VlFormDemoComponent,
             VlPillComponent,
-            VlParagraphComponent,
-            VlTitleComponent,
         ]);
     }
 
@@ -155,6 +157,36 @@ export class AppComponent extends LitElement {
                         <vl-side-sheet id="sidesheet">
                             <vl-form-demo></vl-form-demo>
                         </vl-side-sheet>
+                    </vl-tabs-pane>
+                    <vl-tabs-pane data-vl-id="vl-group-next--baseline" data-vl-title="vl-group-next--baseline">
+                        <div class="vl-stacked-next-small">
+                            <vl-title-next type="h2">vl-group-next--baseline</vl-title-next>
+                            <vl-paragraph-next>Baseline alignering test voor links in vl-group-next.</vl-paragraph-next>
+                            <vl-title-next type="h3">Gerelateerd aan:</vl-title-next>
+                            <vl-pill
+                                data-vl-clickable
+                                @click=${() => window.open('https://www.milieuinfo.be/jira/browse/UIG-3225')}
+                                >UIG-3225</vl-pill
+                            >
+                            <div class="vl-group-next vl-group-next--baseline">
+                                <vl-title-next type="h1">Pagina titel</vl-title-next>
+                                <vl-link-next href="#" icon="pencil" icon-placement="before">Link</vl-link-next>
+                            </div>
+                            <div class="vl-group-next vl-group-next--baseline">
+                                <vl-title-next type="h2">Pagina titel</vl-title-next>
+                                <vl-link-next href="#">Link</vl-link-next>
+                            </div>
+                            <div class="vl-group-next vl-group-next--baseline">
+                                <vl-title-next type="h3">Pagina titel</vl-title-next>
+                                <vl-link-next href="#" external>Link</vl-link-next>
+                            </div>
+                            <div class="vl-group-next vl-group-next--baseline">
+                                <vl-title-next type="h3">Pagina titel</vl-title-next>
+                                <vl-link-next href="#" button-as-link icon="pencil" icon-placement="before"
+                                    >Link as button</vl-link-next
+                                >
+                            </div>
+                        </div>
                     </vl-tabs-pane>
                 </vl-tabs>
             </main>

--- a/libs/common/utilities/src/css/layout/group/vl-group.css.ts
+++ b/libs/common/utilities/src/css/layout/group/vl-group.css.ts
@@ -33,6 +33,14 @@ export const vlGroupStyles: CSSResult = css`
 
         &.vl-group-next--baseline {
             align-items: baseline;
+
+            vl-link-next::part(link),
+            vl-link-next::part(button) {
+                align-items: baseline;
+            }
+            vl-link-next::part(icon) {
+                align-self: center;
+            }
         }
 
         &.vl-group-next--separator-row {

--- a/libs/components/src/next/link/vl-link.component.ts
+++ b/libs/components/src/next/link/vl-link.component.ts
@@ -47,7 +47,7 @@ export class VlLinkComponent extends BaseLitElement {
         const positionIconBefore = this.iconPlacement !== ICON_PLACEMENT.AFTER;
         return !this.buttonAsLink
             ? html`
-                  <a class=${classMap(classes)} href=${this.href} target=${target}>
+                  <a class=${classMap(classes)} href=${this.href} target=${target} part="link">
                       ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
                       ${!positionIconBefore ? this.renderIcon() : nothing}
@@ -55,7 +55,7 @@ export class VlLinkComponent extends BaseLitElement {
                   </a>
               `
             : html`
-                  <button class="vl-button-as-link ${classMap(classes)}">
+                  <button class="vl-button-as-link ${classMap(classes)}" part="button">
                       ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
                       ${!positionIconBefore ? this.renderIcon() : nothing}
@@ -72,11 +72,11 @@ export class VlLinkComponent extends BaseLitElement {
             'vl-icon--left-margin': this.iconPlacement === 'after',
         };
 
-        return this.icon ? html`<span class=${classMap(classes)}></span>` : nothing;
+        return this.icon ? html`<span class=${classMap(classes)} part="icon"></span>` : nothing;
     }
 
     private renderExternalIcon(): TemplateResult {
-        return html`<span class="vl-icon vl-icon--external vl-icon--after"></span>`;
+        return html`<span class="vl-icon vl-icon--external vl-icon--after" part="icon"></span>`;
     }
 }
 


### PR DESCRIPTION
https://www.milieuinfo.be/jira/browse/UIG-3225
https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC555
