### PR TITLE
feat: verschillende verbeteringen in context van wegwerken elementen

### DIFF
--- a/apps/storybook/docs/d_planning/3_2024-van-v1-naar-v2-beschikbaar.stories.mdx
+++ b/apps/storybook/docs/d_planning/3_2024-van-v1-naar-v2-beschikbaar.stories.mdx
@@ -569,7 +569,7 @@ gebruiken dit niet meer.
 
 ### Grid
 
-`Grid [next]` voorziet style-classes voor `Grid [legacy]` en `Grid Column [legacy]`.<br/>
+`Grid [next]` style-classes vervangen `Grid [legacy]` en `Grid Column [legacy]`.<br/>
 Zie [Section](#section) voor `Grid Region [legacy]`.<br/>
 Zie [Content block](#content-block) voor `Grid Layout [legacy]`.<br/>
 Zie [Stacked](#stacked) voor de vervanger van de vroegere `stacked` attributen.

--- a/libs/components/src/functional-header/vl-functional-header.uig-css.ts
+++ b/libs/components/src/functional-header/vl-functional-header.uig-css.ts
@@ -24,6 +24,10 @@ export const functionalHeaderUigStyle: CSSResult = css`
         max-width: 100%;
     }
 
+    a#title {
+        text-decoration: none;
+    }
+
     .sub-header-hidden slot {
         display: none;
     }

--- a/libs/components/src/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/next/side-navigation/vl-side-navigation.component.ts
@@ -25,11 +25,9 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
     connectedCallback(): void {
         super.connectedCallback();
-        document.adoptedStyleSheets = [
-            ...document.adoptedStyleSheets,
-            vlSideNavigationStyles.styleSheet as CSSStyleSheet,
-        ];
-        // retrieve first surrounding shadow dom & attach vlSideNavigationStyles on it
+
+        // Gezien dit component geen shadow dom heeft, moeten de styles van de children toegevoegd worden
+        // aan de adoptedStyleSheets van de omliggende shadow dom, anders zullen de styles niet toegepast worden
         const shadowRoot = this.shadowRoot || this.getRootNode();
         if (shadowRoot instanceof ShadowRoot) {
             shadowRoot.adoptedStyleSheets = [
@@ -38,6 +36,11 @@ export class VlSideNavigationComponent extends BaseLitElement {
                 vlGridStyles.styleSheet as CSSStyleSheet,
                 vlSectionStyles.styleSheet as CSSStyleSheet,
                 vlContentBlockStyles.styleSheet as CSSStyleSheet,
+            ];
+        } else {
+            document.adoptedStyleSheets = [
+                ...document.adoptedStyleSheets,
+                vlSideNavigationStyles.styleSheet as CSSStyleSheet,
             ];
         }
     }

--- a/libs/components/src/next/table/vl-table.component.ts
+++ b/libs/components/src/next/table/vl-table.component.ts
@@ -47,9 +47,14 @@ export class VlTableComponent extends LitElement {
     protected firstUpdated(changedProperties: PropertyValues) {
         super.firstUpdated(changedProperties);
 
-        // Deze stylesheet moet toegevoegd worden aan de adoptedStyleSheets van het document
-        // omdat deze styles betrekking hebben op de slotted content en dus niet op de shadow dom
-        document.adoptedStyleSheets = [...document.adoptedStyleSheets, tableStyles.styleSheet as CSSStyleSheet];
+        // Gezien dit component geen shadow dom heeft, moeten de styles van de children toegevoegd worden
+        // aan de adoptedStyleSheets van de omliggende shadow dom, anders zullen de styles niet toegepast worden
+        const shadowRoot = this.shadowRoot || this.getRootNode();
+        if (shadowRoot instanceof ShadowRoot) {
+            shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, tableStyles.styleSheet as CSSStyleSheet];
+        } else {
+            document.adoptedStyleSheets = [...document.adoptedStyleSheets, tableStyles.styleSheet as CSSStyleSheet];
+        }
 
         this.caption?.classList.add('vl-table-next__caption');
     }

--- a/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/form/src/next/datepicker/vl-datepicker.component.cy.ts
@@ -427,8 +427,7 @@ describe('component - vl-datepicker-next', () => {
             .should('contain', 'right');
     });
 
-    // TODO: slaagt ofwel lokaal, ofwel enkel op bamboo, maar niet op beide
-    it.skip('should open the calendar below the input when static is true', () => {
+    it('should open the calendar below the input when static is true', () => {
         cy.mount(
             html`
                 <div style="margin-top: calc(100vh - 50px); margin-left: calc(100vw - 250px)">
@@ -446,20 +445,22 @@ describe('component - vl-datepicker-next', () => {
             .should('not.have.attr', 'style');
     });
 
-    // TODO: slaagt ofwel lokaal, ofwel enkel op bamboo, maar niet op beide
-    it.skip('should pass the position property to Flatpickr', () => {
+    it('should pass the position property to Flatpickr', () => {
+        cy.viewport(1920, 1080);
+
         cy.mount(html`<vl-datepicker-next position="below left"></vl-datepicker-next>`);
-        cy.wait(2000);
+
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next')
             .shadow()
             .find('.flatpickr-calendar')
             .shouldHaveComputedStyle({ style: 'top', value: '37px' })
-            .shouldHaveComputedStyle({ style: 'left', value: '96px' });
+            .shouldHaveComputedStyle({ style: 'left', value: '188px' });
     });
 
-    // TODO: slaagt ofwel lokaal, ofwel enkel op bamboo, maar niet op beide
-    it.skip('should position the calendar correctly after adding HTML elements to the DOM', () => {
+    it('should position the calendar correctly after adding HTML elements to the DOM', () => {
+        cy.viewport(1920, 1080);
+
         cy.mount(
             html`<div>
                 <button
@@ -473,14 +474,14 @@ describe('component - vl-datepicker-next', () => {
         cy.get('vl-datepicker-next')
             .shadow()
             .find('#datepicker-calendar-placeholder')
-            .shouldHaveComputedStyle({ style: 'top', value: '-22px' });
+            .shouldHaveComputedStyle({ style: 'top', value: '-27px' });
         cy.get('#add-line').click();
         cy.get('#add-line').click();
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('vl-datepicker-next')
             .shadow()
             .find('#datepicker-calendar-placeholder')
-            .shouldHaveComputedStyle({ style: 'top', value: '-43.2656px' });
+            .shouldHaveComputedStyle({ style: 'top', value: '-54px' });
         cy.get('vl-datepicker-next').shadow().find('button#toggle-calendar').click();
         cy.get('#add-line').click();
         cy.get('#add-line').click();
@@ -488,7 +489,7 @@ describe('component - vl-datepicker-next', () => {
         cy.get('vl-datepicker-next')
             .shadow()
             .find('#datepicker-calendar-placeholder')
-            .shouldHaveComputedStyle({ style: 'top', value: '-85.7969px' });
+            .shouldHaveComputedStyle({ style: 'top', value: '-108px' });
     });
 });
 


### PR DESCRIPTION
1. `vl-side-navigation-next` en `vl-table-next`: Naiëf omgezette web components: leunen op global CSS, problematisch wanneer die binnen shadow doms worden gebruikt. We voegen CSS toe op shadow dom van eerste parent [Jira - UIG-3243](https://www.milieuinfo.be/jira/browse/UIG-3243). Uitgevoerd op `vl-side-navigation-next` en `vl-table-next`
2. `vl-functional-header` - link onderlijning verwijderd in `<h1>` tag conform styling vandaag
3. beschikbaar document: taal verduidelijking (in zelfde commit als functional-header)
4. `vl-datepicker-next` - positie testen terug rechtgezet (ze werken op bamboo maar niet lokaal)

[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC565)
