### PR TITLE
feat: UIG-3253 - vl-tab-section-next - grid-dependency weggewerkt

### DIFF
--- a/libs/components/src/next/tabs/vl-tab-section.component.cy.ts
+++ b/libs/components/src/next/tabs/vl-tab-section.component.cy.ts
@@ -27,12 +27,6 @@ describe('component vl-tab-section', () => {
 });
 
 describe('component vl-tab-section - classes', () => {
-    it('should have class vl-col--1-1', () => {
-        mountDefault();
-
-        cy.get('vl-tab-section-next').should('have.class', 'vl-col--1-1');
-    });
-
     it('should have class vl-tab__pane', () => {
         mountDefault();
 

--- a/libs/components/src/next/tabs/vl-tab-section.component.ts
+++ b/libs/components/src/next/tabs/vl-tab-section.component.ts
@@ -17,7 +17,6 @@ export class VlTabSectionComponent extends BaseLitElement {
     }
 
     private processClasses() {
-        this.classList.add('vl-col--1-1');
         this.classList.add('vl-tab__pane');
     }
 

--- a/libs/components/src/next/tabs/vl-tabs.uig-css.ts
+++ b/libs/components/src/next/tabs/vl-tabs.uig-css.ts
@@ -14,6 +14,11 @@ const styles: CSSResult = css`
         color: var(--vl-theme-fg-color);
     }
 
+    .vl-tab__pane {
+        max-width: 100%;
+        min-width: 100%;
+    }
+
     .vl-tab__pane[role='tabpanel']:focus {
         outline: none;
     }


### PR DESCRIPTION
Steunde vroeger op `vl-col--1-1`-klasse die naast flex-basis:1 ook max en min-width op 100% zette, echter is ons nieuw grid systeem nu gebaseerd op native CSS Grid API dus heeft flex-basis ook geen nut. Hier specifiek voor dit component op dezelfde plaats wel min & max width behouden.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3253)
[Bamboo](https://www.milieuinfo.be/bamboo/chain/viewChain.action?planKey=UIGOV-CUWC566)