### PR TITLE
fix: UIG-3244, UIG-3245 - vl-side-navigation - verbeteringen

### DIFF
--- a/libs/components/src/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -341,6 +341,23 @@ describe('component - vl-side-navigation-next', () => {
         cy.get('vl-side-navigation-reference-next').should('have.class', 'js-vl-scrollspy__content');
     });
 
+    it('should show child links on scroll', () => {
+        cy.viewport(1920, 1080);
+        const target = '#content-2';
+        const shouldHaveExpandedToggle = (href: string, expanded: boolean) => {
+            const haveOrNotHave = expanded ? 'have' : 'not.have';
+            cy.get('vl-side-navigation-next')
+                .find(`vl-side-navigation-toggle-next[href="${href}"]`)
+                .should(`${haveOrNotHave}.attr`, 'aria-expanded', `${expanded}`);
+        };
+
+        shouldHaveExpandedToggle(target, false);
+
+        cy.get(`${target}`).scrollIntoView();
+
+        shouldHaveExpandedToggle(target, true);
+    });
+
     it('should open mobile menu', () => {
         cy.viewport(320, 480);
 

--- a/libs/components/src/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -341,8 +341,7 @@ describe('component - vl-side-navigation-next', () => {
         cy.get('vl-side-navigation-reference-next').should('have.class', 'js-vl-scrollspy__content');
     });
 
-    // TODO deze test werkt niet meer
-    it.skip('should open mobile menu', () => {
+    it('should open mobile menu', () => {
         cy.viewport(320, 480);
 
         cy.get('vl-side-navigation-next').should('have.attr', 'sticky-dressed', 'true');
@@ -353,8 +352,7 @@ describe('component - vl-side-navigation-next', () => {
         cy.get('vl-side-navigation-next').should('be.visible');
     });
 
-    // TODO deze test werkt niet meer
-    it.skip('should switch between mobile & desktop', () => {
+    it('should switch between mobile & desktop', () => {
         cy.get('vl-side-navigation-next').find('button.vl-button.js-vl-scrollspy__toggle').should('not.exist');
         cy.get('vl-side-navigation-next').should('be.visible');
 

--- a/libs/components/src/next/side-navigation/vl-side-navigation.scrollspy.lib.js
+++ b/libs/components/src/next/side-navigation/vl-side-navigation.scrollspy.lib.js
@@ -23,6 +23,7 @@ const ssClass = `js-vl-scrollspy`,
     ssContentClass = `js-vl-scrollspy__content`,
     ssContentAtt = `scrollspy-content`,
     regionClass = `vl-region`,
+    sectionClass = `vl-section-next`,
     snItemClass = `vl-side-navigation-next__item`,
     globalHvisibleClass = 'js-iwgh3-bc--visible',
     body = document.body,
@@ -273,7 +274,7 @@ class ScrollSpy {
 
     dress(wrapper) {
         let id = vl.util.uniqueId(),
-            correspondingRegion = wrapper.closest(`.${regionClass}`),
+            correspondingRegion = wrapper.closest(`.${regionClass}, .${sectionClass}`),
             scrollSpyContentWrapper = correspondingRegion && correspondingRegion.querySelector(`[${ssContentAtt}]`);
 
         if (!vl.util.exists(scrollSpyContentWrapper)) {

--- a/libs/sections/src/privacy/child/content.section.ts
+++ b/libs/sections/src/privacy/child/content.section.ts
@@ -742,7 +742,7 @@ export const privacyContentSection = () => html`
                                     Het Departement Omgeving en uw privacy
                                 </vl-side-navigation-toggle-next>
                             </vl-side-navigation-item-next>
-                            <vl-side-navigation-item-next parent>
+                            <vl-side-navigation-item-next parent="privacy-declaration">
                                 <vl-side-navigation-toggle-next
                                     href="#privacy-declaration"
                                     child="privacy-declaration"

--- a/libs/sections/src/privacy/vl-privacy.section.cy.ts
+++ b/libs/sections/src/privacy/vl-privacy.section.cy.ts
@@ -88,17 +88,17 @@ describe('vl-privacy component - properties functionality', () => {
         cy.get('vl-privacy').shadow().find('vl-functional-header').shadow().find('a#back-link').click();
         cy.get('@vl-click-back').should('have.been.calledOnce');
     });
-
-    // TODO: bekijken waarom aria-expanded niet correct meer op vl-side-navigation-toggle-next word gezet
-    it.skip('should show child links on scroll', () => {
+    it('should show child links on scroll', () => {
+        cy.viewport(1920, 1080);
         mountDefault(defaultProps);
 
         const shouldHaveExpandedToggle = (href: string, expanded: boolean) => {
+            const have = expanded ? 'have' : 'not.have';
             cy.get('vl-privacy')
                 .shadow()
                 .find('vl-side-navigation-next')
                 .find(`vl-side-navigation-toggle-next[href="${href}"]`)
-                .should('have.attr', 'aria-expanded', `${expanded}`);
+                .should(`${have}.attr`, 'aria-expanded', `${expanded}`);
         };
 
         shouldHaveExpandedToggle('#privacy-declaration', false);


### PR DESCRIPTION
- fix: UIG-3244 - vl-side-navigation-next - scroll testen verbeterd ( https://www.milieuinfo.be/jira/browse/UIG-3244 )
- fix: UIG-3245 - vl-side-navigation-next - selector uitgebreid met `vl-section-next` in scrollspy.lib ( https://www.milieuinfo.be/jira/browse/UIG-3245 )

[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC568)
