### PR TITLE
feature/UIG-3236-properties-omzetting

### DIFF
--- a/apps/storybook-e2e/src/e2e/map/controls/action-control/vl-map-action-control.stories-dom.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/controls/action-control/vl-map-action-control.stories-dom.cy.ts
@@ -108,7 +108,7 @@ describe('story vl-map-action-control multiple', () => {
             .find('vl-map-action-control[data-vl-action-id="delete-action"]');
     });
 
-    it.only('should deactivate toggle button when activating another toggle button', () => {
+    it('should deactivate toggle button when activating another toggle button', () => {
         cy.visit(mapActionControlMultipleUrl);
 
         const drawActionId = 'draw-action';

--- a/libs/components/src/contact-card/stories/vl-contact-card.stories.ts
+++ b/libs/components/src/contact-card/stories/vl-contact-card.stories.ts
@@ -1,4 +1,6 @@
 import { defaultArgs, defaultArgTypes, story } from '@domg-wc/common-storybook';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlPropertiesComponent } from '@domg-wc/components/next/properties';
 import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 import '../../infoblock/vl-infoblock.component';
@@ -15,51 +17,54 @@ export default {
     },
 } as Meta<typeof defaultArgs>;
 
+registerWebComponents([VlPropertiesComponent]);
+
 export const contactCardDefault = story(
     {},
-    () => html` <vl-contact-card>
-        <vl-infoblock
-            slot="info"
-            data-vl-title="Departement Onderwijs en Vorming"
-            data-vl-type="contact"
-        ></vl-infoblock>
-        <vl-properties slot="properties">
-            <dl is="vl-properties-list">
-                <dt is="vl-property-term">Adres</dt>
-                <dd is="vl-property-value">
-                    Hendrik Consciencegebouw<br />Koning Albert II-laan 15<br />1210 Brussel<br /><vl-link-next href="#"
-                        >Routeplanner</vl-link-next
-                    >
-                </dd>
-                <dt is="vl-property-term">Telefoon</dt>
-                <dd is="vl-property-value">
+    () => html`
+        <vl-contact-card>
+            <vl-infoblock
+                    slot="info"
+                    data-vl-title="Departement Onderwijs en Vorming"
+                    data-vl-type="contact"
+            ></vl-infoblock>
+            <vl-properties-next slot="properties">
+                <label>Adres</label>
+                <data>
+                    <div>Hendrik Consciencegebouw</div>
+                    <div>Koning Albert II-laan 15</div>
+                    <div>1210 Brussel</div>
+                    <vl-link-next href="#">Routeplanner</vl-link-next>
+                </data>
+                <label>Telefoon</label>
+                <data>
                     <p>
-                        <vl-link-next href="#"
-                            >02 553 72 02<span is="vl-icon" data-vl-icon="phone" data-vl-after></span
-                        ></vl-link-next>
+                        <vl-link-next href="#" icon-placement="after" icon="phone">
+                            02 553 72 02
+                        </vl-link-next>
                         (Onthaal Consciencegebouw)
                     </p>
                     <p>
-                        <vl-link-next href="#"
-                            >1700<span is="vl-icon" data-vl-icon="phone" data-vl-after></span
-                        ></vl-link-next>
+                        <vl-link-next href="#" icon-placement="after" icon="phone">
+                            1700
+                        </vl-link-next>
                         (Infolijn Onderwijs)
                     </p>
-                </dd>
-                <dt is="vl-property-term">E-mail</dt>
-                <dd is="vl-property-value">
-                    <vl-link-next href="#"
-                        >onderwijs.vlaanderen@vlaanderen.be<span is="vl-icon" data-vl-icon="mail" data-vl-after></span
-                    ></vl-link-next>
-                </dd>
-                <dt is="vl-property-term">Website</dt>
-                <dd is="vl-property-value">
-                    <vl-link-next href="#"
-                        >http://onderwijs.vlaanderen.be<span is="vl-icon" data-vl-icon="external" data-vl-after></span
-                    ></vl-link-next>
-                </dd>
-            </dl>
-        </vl-properties>
-    </vl-contact-card>`
+                </data>
+                <label>E-mail</label>
+                <data>
+                    <vl-link-next href="#" icon-placement="after" icon="mail">
+                        onderwijs.vlaanderen@vlaanderen.be
+                    </vl-link-next>
+                </data>
+                <label>Website</label>
+                <data>
+                    <vl-link-next href="#" external>
+                        http://onderwijs.vlaanderen.be
+                    </vl-link-next>
+                </data>
+            </vl-properties-next>
+        </vl-contact-card>
+    `
 );
 contactCardDefault.storyName = 'vl-contact-card - default';

--- a/libs/components/src/next/properties/vl-properties.css.ts
+++ b/libs/components/src/next/properties/vl-properties.css.ts
@@ -29,6 +29,16 @@ export const labelWidthRem = (labelWidth: number): CSSResult => {
         dl .item {
             grid-template-columns: [labels] ${labelWidth}rem [data] auto;
         }
+
+        @media screen and (max-width: ${vlMediaScreenSmall}px) {
+            dl {
+                grid-template-columns: 100%;
+            }
+
+            dl .item {
+                grid-template-columns: 100%;
+            }
+        }
     `;
 };
 
@@ -81,10 +91,6 @@ const styles: CSSResult = css`
     }
 
     @media screen and (max-width: ${vlMediaScreenSmall}px) {
-        .column {
-            ${columnWidth(100)};
-        }
-
         dd {
             ${collapsedDd()}
         }

--- a/libs/components/src/next/search-result/vl-search-result.css.ts
+++ b/libs/components/src/next/search-result/vl-search-result.css.ts
@@ -3,6 +3,7 @@ import { css, CSSResult } from 'lit';
 
 export const vlSearchResultStyles: CSSResult = css`
     :host {
+        display: block;
         margin-bottom: 3.5rem;
 
         > * {

--- a/libs/components/src/rich-data/stories/vl-rich-data.stories-util.ts
+++ b/libs/components/src/rich-data/stories/vl-rich-data.stories-util.ts
@@ -21,22 +21,28 @@ export const richDataPaginationImplementation = () => {
                 const manager = project.manager;
                 const medewerker = project.medewerkers[0];
                 const html = `
-                    <li is="vl-search-result">
-                      <a href="#">${project.name}</a>
-                      <time>Gestart op ${now}</time>
-                      <dl>
-                        <dt>ID</dt>
-                        <dd>${project.id}</dd>
-                        <dt>Naam manager</dt>
-                        <dd>${manager.lastName}</dd>
-                        <dt>Eerste medewerker</dt>
-                        <dd>${medewerker.lastName}</dd>
-                        <dt>Project o.l.v. <b>manager</b></dt>
-                        <dd>${project.name} o.l.v. <b>${manager.firstName} ${manager.lastName}</b></dd>
-                      </dl>
-                    </li>
+                        <vl-search-result-title-next>
+                            <a href="#">${project.name}</a>
+                        </vl-search-result-title-next>
+                        <vl-search-result-text-next>
+                            <time>Gestart op ${now}</time>
+                        </vl-search-result-text-next>
+                        <vl-search-result-properties-next>
+                            <label>ID</label>
+                            <data>${project.id}</data>
+                            <label>Naam manager</label>
+                            <data>${manager.lastName}</data>
+                            <label>Eerste medewerker</label>
+                            <data>${medewerker.lastName}</data>
+                            <label>
+                                <span>Project o.l.v. <strong>manager</strong></span>
+                            </label>
+                            <data>
+                                <span>${project.name} o.l.v. <strong>${manager.firstName} ${manager.lastName}</strong></span>
+                            </data>
+                        </vl-search-result-properties-next>
                   `;
-                content.insertAdjacentHTML('beforeend', html);
+                content.insertAdjacentHTML('beforeend', `<vl-search-result-next>${html}</vl-search-result-next>`);
             });
         };
 

--- a/libs/components/src/rich-data/stories/vl-rich-data.stories.ts
+++ b/libs/components/src/rich-data/stories/vl-rich-data.stories.ts
@@ -1,11 +1,14 @@
 import { story } from '@domg-wc/common-storybook';
+import { registerWebComponents } from '@domg-wc/common-utilities';
 import { Meta } from '@storybook/web-components';
 import { html } from 'lit-html';
 import '../../rich-data-table/vl-rich-data-field.component';
 import '../vl-rich-data.component';
+import { VlSearchResultComponent } from '../../next/search-result';
+import { VlRichData } from '../vl-rich-data.component';
 import { richDataArgs, richDataArgTypes } from './vl-rich-data.stories-arg';
-import { richDataPaginationImplementation } from './vl-rich-data.stories-util';
 import richDataDoc from './vl-rich-data.stories-doc.mdx';
+import { richDataPaginationImplementation } from './vl-rich-data.stories-util';
 
 export default {
     id: 'components-rich-data',
@@ -20,24 +23,24 @@ export default {
     },
 } as Meta<typeof richDataArgs>;
 
+registerWebComponents([VlRichData, VlSearchResultComponent]);
+
 export const RichDataDefault = ({ filterClosable, filterClosed }: typeof richDataArgs) => {
-    return html` <vl-rich-data ?data-vl-filter-closable=${filterClosable} ?data-vl-filter-closed=${filterClosed}>
-        <span slot="no-content">Geen resultaten gevonden</span>
-        <vl-search-results slot="content"></vl-search-results>
-    </vl-rich-data>`;
+    return html`
+        <vl-rich-data ?data-vl-filter-closable=${filterClosable} ?data-vl-filter-closed=${filterClosed}>
+            <span slot="no-content">Geen resultaten gevonden</span>
+            <vl-search-result-next slot="content"></vl-search-result-next>
+        </vl-rich-data>
+    `;
 };
 RichDataDefault.storyName = 'vl-rich-data - default';
 
 export const RichDataPager = story(richDataArgs, ({ filterClosable, filterClosed }: typeof richDataArgs) => {
     richDataPaginationImplementation();
     return html`
-        <vl-rich-data
-            id="rich-data"
-            ?data-vl-filter-closable=${filterClosable}
-            ?data-vl-filter-closed=${filterClosed}
-        >
+        <vl-rich-data id="rich-data" ?data-vl-filter-closable=${filterClosable} ?data-vl-filter-closed=${filterClosed}>
             <span slot="no-content">Geen resultaten</span>
-            <ul is="vl-search-results" slot="content"></ul>
+            <div slot="content"></div>
             <select is="vl-select" slot="sorter" aria-label="Sorteer">
                 <option value="id">ID</option>
                 <option value="manager.lastName">Naam manager</option>

--- a/libs/components/src/rich-data/vl-rich-data.component.ts
+++ b/libs/components/src/rich-data/vl-rich-data.component.ts
@@ -159,7 +159,7 @@ export class VlRichData extends BaseElementOfType(HTMLElement) {
     }
 
     get __filterOpenButton(): HTMLElement {
-        return this.shadowRoot.querySelector('#open-filter-button');
+        return this.shadowRoot.querySelector('#open-toggle-filter-button');
     }
 
     get __filterToggleContainer(): HTMLElement {

--- a/libs/components/src/rich-data/vl-rich-data.uig-css.ts
+++ b/libs/components/src/rich-data/vl-rich-data.uig-css.ts
@@ -7,9 +7,18 @@ const styles: CSSResult = css`
         line-height: 2em;
     }
 
+    #search-results {
+        margin-bottom: 2.4rem;
+    }
+
+    #content {
+        margin-left: 2rem;
+    }
+
     #sorter {
         text-align: right;
     }
+
     #sorter vl-form-label-next::part(label) {
         margin-right: 10px;
     }

--- a/libs/sections/src/accessibility/child/content.section.cy.ts
+++ b/libs/sections/src/accessibility/child/content.section.cy.ts
@@ -63,9 +63,9 @@ describe('component content', () => {
 });
 
 describe('component content - helper function <contentChildElements()> ', () => {
-    it('should return an array of WebComponents with a length of 14', () => {
+    it('should return an array of WebComponents with a length of 11', () => {
         const elements = contentElements();
         expect(elements).to.be.an('array');
-        expect(elements).to.have.length(14);
+        expect(elements).to.have.length(11);
     });
 });

--- a/libs/sections/src/accessibility/child/content.section.ts
+++ b/libs/sections/src/accessibility/child/content.section.ts
@@ -1,4 +1,5 @@
 import { VlContactCardComponent, VlInfoblockComponent } from '@domg-wc/components';
+import { VlPropertiesComponent } from '@domg-wc/components/next/properties';
 import {
     VlColumnElement,
     VlGridElement,
@@ -6,10 +7,6 @@ import {
     VlIconElement,
     VlLayoutElement,
     VlLinkElement,
-    VlPropertiesComponent,
-    VlPropertiesListElement,
-    VlPropertyTermElement,
-    VlPropertyValueElement,
     VlRegionElement,
     VlSideNavigationReferenceElement,
 } from '@domg-wc/elements';
@@ -30,9 +27,6 @@ export const contentElements = () => [
     VlContactCardComponent,
     VlInfoblockComponent,
     VlPropertiesComponent,
-    VlPropertiesListElement,
-    VlPropertyTermElement,
-    VlPropertyValueElement,
     VlIconElement,
     VlH2Element,
 ];
@@ -101,34 +95,30 @@ export const content = ({
                                     <vl-infoblock slot="info" data-vl-type="contact">
                                         <h3 slot="title">Departement Omgeving</h3>
                                     </vl-infoblock>
-                                    <vl-properties slot="properties">
-                                        <dl is="vl-properties-list">
-                                            <dt is="vl-property-term">Adres</dt>
-                                            <dd is="vl-property-value">Havenlaan 88<br />1000 Brussel<br />België</dd>
-                                            <dt is="vl-property-term">Telefoon</dt>
-                                            <dd is="vl-property-value">
-                                                <p>
-                                                    <vl-link-next href="tel:02 553 80 11"
-                                                        >02 553 80 11<span
-                                                            is="vl-icon"
-                                                            data-vl-icon="phone"
-                                                            data-vl-after
-                                                        ></span
-                                                    ></vl-link-next>
-                                                </p>
-                                            </dd>
-                                            <dt is="vl-property-term">E-mail</dt>
-                                            <dd is="vl-property-value">
-                                                <vl-link-next href="mailto:omgeving@vlaanderen.be"
-                                                    >omgeving@vlaanderen.be<span
-                                                        is="vl-icon"
-                                                        data-vl-icon="mail"
-                                                        data-vl-after
-                                                    ></span
-                                                ></vl-link-next>
-                                            </dd>
-                                        </dl>
-                                    </vl-properties>
+                                    <vl-properties-next slot="properties">
+                                        <label>Adres</label>
+                                        <data>
+                                            <div>Havenlaan 88</div>
+                                            <div>1000 Brussel</div>
+                                            <div>België</div>
+                                        </data>
+                                        <label>Telefoon</label>
+                                        <data>
+                                            <vl-link-next href="tel:02 553 80 11" icon-placement="after" icon="phone">
+                                                02 553 80 11
+                                            </vl-link-next>
+                                        </data>
+                                        <label>E-mail</label>
+                                        <data>
+                                            <vl-link-next
+                                                href="mailto:omgeving@vlaanderen.be"
+                                                icon-placement="after"
+                                                icon="mail"
+                                            >
+                                                omgeving@vlaanderen.be
+                                            </vl-link-next>
+                                        </data>
+                                    </vl-properties-next>
                                 </vl-contact-card>
                             </div>
                             <div
@@ -146,22 +136,24 @@ export const content = ({
                                     <vl-infoblock slot="info" data-vl-type="contact">
                                         <h3 slot="title">Klachtenbehandelaar</h3>
                                     </vl-infoblock>
-                                    <vl-properties slot="properties">
-                                        <dl is="vl-properties-list">
-                                            <dt is="vl-property-term">Adres</dt>
-                                            <dd is="vl-property-value">Havenlaan 88<br />1000 Brussel<br />België</dd>
-                                            <dt is="vl-property-term">E-mail</dt>
-                                            <dd is="vl-property-value">
-                                                <vl-link-next href="mailto:klachten.omgeving@vlaanderen.be"
-                                                    >klachten.omgeving@vlaanderen.be<span
-                                                        is="vl-icon"
-                                                        data-vl-icon="mail"
-                                                        data-vl-after
-                                                    ></span
-                                                ></vl-link-next>
-                                            </dd>
-                                        </dl>
-                                    </vl-properties>
+                                    <vl-properties-next slot="properties">
+                                        <label>Adres</label>
+                                        <data>
+                                            <div>Havenlaan 88</div>
+                                            <div>1000 Brussel</div>
+                                            <div>België</div>
+                                        </data>
+                                        <label>E-mail</label>
+                                        <data>
+                                            <vl-link-next
+                                                href="mailto:klachten.omgeving@vlaanderen.be"
+                                                icon-placement="after"
+                                                icon="mail"
+                                            >
+                                                klachten.omgeving@vlaanderen.be
+                                            </vl-link-next>
+                                        </data>
+                                    </vl-properties-next>
                                 </vl-contact-card>
                                 <br />
                                 <p>
@@ -174,44 +166,36 @@ export const content = ({
                                     <vl-infoblock slot="info" data-vl-type="contact">
                                         <h3 slot="title">Vlaamse ombudsdienst</h3>
                                     </vl-infoblock>
-                                    <vl-properties slot="properties">
-                                        <dl is="vl-properties-list">
-                                            <dt is="vl-property-term">Adres</dt>
-                                            <dd is="vl-property-value">Leuvenseweg 86<br />1000 Brussel<br />België</dd>
-                                            <dt is="vl-property-term">Telefoon</dt>
-                                            <dd is="vl-property-value">
-                                                <p>
-                                                    <vl-link-next href="tel:08 002 40 50"
-                                                        >08 002 40 50<span
-                                                            is="vl-icon"
-                                                            data-vl-icon="phone"
-                                                            data-vl-after=""
-                                                        ></span
-                                                    ></vl-link-next>
-                                                </p>
-                                            </dd>
-                                            <dt is="vl-property-term">E-mail</dt>
-                                            <dd is="vl-property-value">
-                                                <vl-link-next href="mailto:klachten@vlaamseombudsdienst.be"
-                                                    >klachten@vlaamseombudsdienst.be<span
-                                                        is="vl-icon"
-                                                        data-vl-icon="mail"
-                                                        data-vl-after
-                                                    ></span
-                                                ></vl-link-next>
-                                            </dd>
-                                            <dt is="vl-property-term">Website</dt>
-                                            <dd is="vl-property-value">
-                                                <vl-link-next href="http://www.vlaamseombudsdienst.be" external
-                                                    >http://www.vlaamseombudsdienst.be<span
-                                                        is="vl-icon"
-                                                        data-vl-icon="external"
-                                                        data-vl-after
-                                                    ></span
-                                                ></vl-link-next>
-                                            </dd>
-                                        </dl>
-                                    </vl-properties>
+                                    <vl-properties-next slot="properties">
+                                        <label>Adres</label>
+                                        <data>
+                                            <div>Leuvenseweg 86</div>
+                                            <div>1000 Brussel</div>
+                                            <div>België</div>
+                                        </data>
+                                        <label>Telefoon</label>
+                                        <data>
+                                            <vl-link-next href="tel:08 002 40 50" icon-placement="after" icon="phone">
+                                                08 002 40 50
+                                            </vl-link-next>
+                                        </data>
+                                        <label>E-mail</label>
+                                        <data>
+                                            <vl-link-next
+                                                href="mailto:klachten@vlaamseombudsdienst.be"
+                                                icon-placement="after"
+                                                icon="mail"
+                                            >
+                                                klachten@vlaamseombudsdienst.be
+                                            </vl-link-next>
+                                        </data>
+                                        <label>Website</label>
+                                        <data>
+                                            <vl-link-next href="http://www.vlaamseombudsdienst.be" external>
+                                                http://www.vlaamseombudsdienst.be
+                                            </vl-link-next>
+                                        </data>
+                                    </vl-properties-next>
                                 </vl-contact-card>
                             </div>
                         </div>

--- a/libs/sections/src/cookie-statement/cookie/vl-authentication-cookie.section.cy.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-authentication-cookie.section.cy.ts
@@ -4,7 +4,7 @@ import { VlAuthenticationCookie } from './vl-authentication-cookie.section';
 
 registerWebComponents([VlAuthenticationCookie]);
 
-const mountDefault = () => cy.mount(html` <vl-authentication-cookie> </vl-authentication-cookie> `);
+const mountDefault = () => cy.mount(html` <vl-authentication-cookie></vl-authentication-cookie> `);
 
 describe('vl-authentication-cookie component - default', () => {
     beforeEach(() => {
@@ -31,19 +31,21 @@ describe('vl-authentication-cookie component - props', () => {
     it('should render the correct <title>', () => {
         cy.get('vl-authentication-cookie')
             .shadow()
-            .find('h3')
+            .find('vl-title-next')
             .should('contain.text', 'Departement Omgeving toegangsbeheer cookies');
     });
 
     it('should render the correct <names>', () => {
         const expectedNames = ['KEYCLOAK_SESSION', 'KEYCLOAK_SESSION_LEGACY'];
         expectedNames.forEach((name) => {
-            cy.get('vl-authentication-cookie').shadow().find('dd').contains(name);
+            cy.get('vl-authentication-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains(name);
         });
     });
 
     it('should render the correct <purpose>', () => {
         cy.get('vl-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
             .shadow()
             .find('dd')
             .contains(
@@ -52,14 +54,24 @@ describe('vl-authentication-cookie component - props', () => {
     });
 
     it('should render the correct <domain>', () => {
-        cy.get('vl-authentication-cookie').shadow().find('dd').contains(window.location.hostname);
+        cy.get('vl-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains(window.location.hostname);
     });
 
     it('should render the correct <processor>', () => {
-        cy.get('vl-authentication-cookie').shadow().find('dd').contains('Departement Omgeving');
+        cy.get('vl-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Departement Omgeving');
     });
 
     it('should render the correct <validity>', () => {
-        cy.get('vl-authentication-cookie').shadow().find('dd').contains('10 uur');
+        cy.get('vl-authentication-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains('10 uur');
     });
 });

--- a/libs/sections/src/cookie-statement/cookie/vl-cookie.section.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-cookie.section.ts
@@ -1,13 +1,7 @@
-import { BaseElementOfType, webComponent } from '@domg-wc/common-utilities';
+import { BaseElementOfType, registerWebComponents, webComponent } from '@domg-wc/common-utilities';
+import { VlPropertiesComponent } from '@domg-wc/components/next/properties';
+import { VlTitleComponent } from '@domg-wc/components/next/title';
 import styles from '../vl-cookie-statement.uig-css';
-import { registerWebComponents } from '@domg-wc/common-utilities';
-import {
-    VlPropertiesComponent,
-    VlPropertiesListElement,
-    VlPropertyTermElement,
-    VlPropertyValueElement,
-} from '@domg-wc/elements';
-import { VlTypography } from '@domg-wc/components';
 
 export interface VlCookieProps {
     title?: string;
@@ -17,37 +11,30 @@ export interface VlCookieProps {
     processor?: string;
     validity?: string;
 }
+
 @webComponent('vl-cookie')
 export class VlCookie extends BaseElementOfType(HTMLElement) {
     static {
-        registerWebComponents([
-            // elements
-            VlPropertiesComponent,
-            VlPropertiesListElement,
-            VlPropertyTermElement,
-            VlPropertyValueElement,
-            // components
-            VlTypography,
-        ]);
+        registerWebComponents([VlPropertiesComponent, VlTitleComponent]);
     }
 
     constructor({ title, name, purpose, domain, processor, validity }: VlCookieProps = {}) {
         super(`
-        <style>
-          ${styles}
-        </style>
+            <style>
+              ${styles}
+            </style>
     `);
 
         const nameTemplate = () => {
             const _name = name || this.dataset.vlName;
             if (Array.isArray(_name)) {
                 return `
-            <vl-typography>
-                <ul>
-                    ${_name.map((name) => `<li>${name}</li>`).join('')}
-                </ul>
-            </vl-typography>
-          `;
+                    <vl-typography>
+                        <ul>
+                            ${_name.map((name) => `<li>${name}</li>`).join('')}
+                        </ul>
+                    </vl-typography>
+                `;
             } else {
                 return _name;
             }
@@ -56,24 +43,22 @@ export class VlCookie extends BaseElementOfType(HTMLElement) {
         this._element.insertAdjacentHTML(
             'afterend',
             `
-        <vl-properties>
-            <h3>${title || this.dataset.vlTitle}</h3>
-            <dl is="vl-properties-list">
-                <dt is="vl-property-term">Naam</dt>
-                <dd is="vl-property-value">${nameTemplate()}</dd>
-                <dt is="vl-property-term">Doel</dt>
-                <dd is="vl-property-value">${purpose || this.dataset.vlPurpose}</dd>
-                <dt is="vl-property-term">Type</dt>
-                <dd is="vl-property-value">Cookie</dd>
-                <dt is="vl-property-term">Domein</dt>
-                <dd is="vl-property-value">${domain || this.dataset.vlDomain}</dd>
-                <dt is="vl-property-term">Verwerker</dt>
-                <dd is="vl-property-value">${processor || this.dataset.vlProcessor}</dd>
-                <dt is="vl-property-term">Geldigheid</dt>
-                <dd is="vl-property-value">${validity || this.dataset.vlValidity}</dd>
-            </dl>
-        </vl-properties>
-    `
+                <vl-title-next type="h3">${title || this.dataset.vlTitle}</vl-title-next>
+                <vl-properties-next slot="properties">
+                    <label>Naam</label>
+                    <data>${nameTemplate()}</data>
+                    <label>Doel</label>
+                    <data>${purpose || this.dataset.vlPurpose}</data>
+                    <label>Type</label>
+                    <data>Cookie</data>
+                    <label>Domein</label>
+                    <data>${domain || this.dataset.vlDomain}</data>
+                    <label>Verwerker</label>
+                    <data>${processor || this.dataset.vlProcessor}</data>
+                    <label>Geldigheid</label>
+                    <data>${validity || this.dataset.vlValidity}</data>
+                </vl-properties-next>
+            `
         );
     }
 }

--- a/libs/sections/src/cookie-statement/cookie/vl-header-authentication-cookie.section.cy.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-header-authentication-cookie.section.cy.ts
@@ -4,7 +4,7 @@ import { VlHeaderAuthenticationCookie } from './vl-header-authentication-cookie.
 
 registerWebComponents([VlHeaderAuthenticationCookie]);
 
-const mountDefault = () => cy.mount(html`<vl-header-authentication-cookie> </vl-header-authentication-cookie> `);
+const mountDefault = () => cy.mount(html` <vl-header-authentication-cookie></vl-header-authentication-cookie> `);
 
 describe('vl-header-authentication-cookie component - default', () => {
     beforeEach(() => {
@@ -31,7 +31,7 @@ describe('vl-authentication-cookie component - props', () => {
     it('should render the correct <title>', () => {
         cy.get('vl-header-authentication-cookie')
             .shadow()
-            .find('h3')
+            .find('vl-title-next')
             .should('contain.text', 'Vlaams toegangsbeheer cookies');
     });
 
@@ -44,12 +44,19 @@ describe('vl-authentication-cookie component - props', () => {
             'tbsession',
         ];
         expectedNames.forEach((name) => {
-            cy.get('vl-header-authentication-cookie').shadow().find('dd').contains(name);
+            cy.get('vl-header-authentication-cookie')
+                .shadow()
+                .find('vl-properties-next')
+                .shadow()
+                .find('dd')
+                .contains(name);
         });
     });
 
     it('should render the correct <purpose>', () => {
         cy.get('vl-header-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
             .shadow()
             .find('dd')
             .contains(
@@ -58,14 +65,29 @@ describe('vl-authentication-cookie component - props', () => {
     });
 
     it('should render the correct <domain>', () => {
-        cy.get('vl-header-authentication-cookie').shadow().find('dd').contains('authenticatie.vlaanderen.be');
+        cy.get('vl-header-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('authenticatie.vlaanderen.be');
     });
 
     it('should render the correct <processor>', () => {
-        cy.get('vl-header-authentication-cookie').shadow().find('dd').contains('Vlaamse overheid');
+        cy.get('vl-header-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Vlaamse overheid');
     });
 
     it('should render the correct <validity>', () => {
-        cy.get('vl-header-authentication-cookie').shadow().find('dd').contains('Sessie');
+        cy.get('vl-header-authentication-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Sessie');
     });
 });

--- a/libs/sections/src/cookie-statement/cookie/vl-header-cookie.section.cy.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-header-cookie.section.cy.ts
@@ -4,7 +4,7 @@ import { VlHeaderCookie } from './vl-header-cookie.section';
 
 registerWebComponents([VlHeaderCookie]);
 
-const mountDefault = () => cy.mount(html` <vl-header-cookie> </vl-header-cookie> `);
+const mountDefault = () => cy.mount(html` <vl-header-cookie></vl-header-cookie> `);
 
 describe('vl-header-cookie component - default', () => {
     beforeEach(() => {
@@ -29,18 +29,21 @@ describe('vl-header-cookie component - props', () => {
     });
 
     it('should render the correct <title>', () => {
-        cy.get('vl-header-cookie').shadow().find('h3').should('contain.text', 'Vlaanderen header cookie');
+        cy.get('vl-header-cookie')
+            .shadow().find('vl-title-next').should('contain.text', 'Vlaanderen header cookie');
     });
 
     it('should render the correct <names>', () => {
         const expectedNames = ['VOGANONUSER'];
         expectedNames.forEach((name) => {
-            cy.get('vl-header-cookie').shadow().find('dd').contains(name);
+            cy.get('vl-header-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains(name);
         });
     });
 
     it('should render the correct <purpose>', () => {
         cy.get('vl-header-cookie')
+            .shadow()
+            .find('vl-properties-next')
             .shadow()
             .find('dd')
             .contains(
@@ -49,15 +52,18 @@ describe('vl-header-cookie component - props', () => {
     });
 
     it('should render the correct <domain>', () => {
-        cy.get('vl-header-cookie').shadow().find('dd').contains('vlaanderen.be');
+        cy.get('vl-header-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains('vlaanderen.be');
     });
 
     it('should render the correct <processor>', () => {
-        cy.get('vl-header-cookie').shadow().find('dd').contains('Vlaamse overheid');
+        cy.get('vl-header-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains('Vlaamse overheid');
     });
 
     it('should render the correct <validity>', () => {
         cy.get('vl-header-cookie')
+            .shadow()
+            .find('vl-properties-next')
+
             .shadow()
             .find('dd')
             .contains('Permanente cookies met een geldigheid van maximaal 24 uur');

--- a/libs/sections/src/cookie-statement/cookie/vl-jsessionid-cookie.section.cy.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-jsessionid-cookie.section.cy.ts
@@ -4,7 +4,7 @@ import { VlJSessionIdCookie } from './vl-jsessionid-cookie.section';
 
 registerWebComponents([VlJSessionIdCookie]);
 
-const mountDefault = () => cy.mount(html`<vl-jsessionid-cookie> </vl-jsessionid-cookie> `);
+const mountDefault = () => cy.mount(html` <vl-jsessionid-cookie></vl-jsessionid-cookie> `);
 
 describe('vl-jsessionid-cookie component - default', () => {
     beforeEach(() => {
@@ -31,19 +31,21 @@ describe('vl-jsessionid-cookie component - props', () => {
     it('should render the correct <title>', () => {
         cy.get('vl-jsessionid-cookie')
             .shadow()
-            .find('h3')
+            .find('vl-title-next')
             .should('contain.text', 'Sessie cookie voor betere gebruikerservaring');
     });
 
     it('should render the correct <names>', () => {
         const expectedNames = ['JSESSIONID', 'KEYCLOAK_IDENTITY', 'KEYCLOAK_IDENTITY_LEGACY'];
         expectedNames.forEach((name) => {
-            cy.get('vl-jsessionid-cookie').shadow().find('dd').contains(name);
+            cy.get('vl-jsessionid-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains(name);
         });
     });
 
     it('should render the correct <purpose>', () => {
         cy.get('vl-jsessionid-cookie')
+            .shadow()
+            .find('vl-properties-next')
             .shadow()
             .find('dd')
             .contains(
@@ -52,14 +54,29 @@ describe('vl-jsessionid-cookie component - props', () => {
     });
 
     it('should render the correct <domain>', () => {
-        cy.get('vl-jsessionid-cookie').shadow().find('dd').contains(window.location.hostname);
+        cy.get('vl-jsessionid-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains(window.location.hostname);
     });
 
     it('should render the correct <processor>', () => {
-        cy.get('vl-jsessionid-cookie').shadow().find('dd').contains('Departement Omgeving');
+        cy.get('vl-jsessionid-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Departement Omgeving');
     });
 
     it('should render the correct <validity>', () => {
-        cy.get('vl-jsessionid-cookie').shadow().find('dd').contains('Beperkt tot de duur van de sessie');
+        cy.get('vl-jsessionid-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Beperkt tot de duur van de sessie');
     });
 });

--- a/libs/sections/src/cookie-statement/cookie/vl-sticky-session-cookie.section.cy.ts
+++ b/libs/sections/src/cookie-statement/cookie/vl-sticky-session-cookie.section.cy.ts
@@ -4,7 +4,7 @@ import { VlStickySessionCookie } from './vl-sticky-session-cookie.section';
 
 registerWebComponents([VlStickySessionCookie]);
 
-const mountDefault = () => cy.mount(html`<vl-sticky-session-cookie> </vl-sticky-session-cookie> `);
+const mountDefault = () => cy.mount(html` <vl-sticky-session-cookie></vl-sticky-session-cookie> `);
 
 describe('vl-sticky-session-cookie component - default', () => {
     beforeEach(() => {
@@ -17,7 +17,6 @@ describe('vl-sticky-session-cookie component - default', () => {
 
     it('should be accessible', () => {
         cy.get('vl-sticky-session-cookie');
-
         cy.injectAxe();
         cy.checkA11y('vl-sticky-session-cookie');
     });
@@ -31,7 +30,7 @@ describe('vl-sticky-session-cookie component - props', () => {
     it('should render the correct <title>', () => {
         cy.get('vl-sticky-session-cookie')
             .shadow()
-            .find('h3')
+            .find('vl-title-next')
             .should('contain.text', 'Persistentie sessie cookie voor betere gebruikerservaring');
     });
 
@@ -41,12 +40,14 @@ describe('vl-sticky-session-cookie component - props', () => {
             'BIGipServerPool-sso-pr-* (vb. "BIGipServerPOOL-sso-pr-app=2016879114.37407.0000")',
         ];
         expectedNames.forEach((name) => {
-            cy.get('vl-sticky-session-cookie').shadow().find('dd').contains(name);
+            cy.get('vl-sticky-session-cookie').shadow().find('vl-properties-next').shadow().find('dd').contains(name);
         });
     });
 
     it('should render the correct <purpose>', () => {
         cy.get('vl-sticky-session-cookie')
+            .shadow()
+            .find('vl-properties-next')
             .shadow()
             .find('dd')
             .contains(
@@ -55,14 +56,29 @@ describe('vl-sticky-session-cookie component - props', () => {
     });
 
     it('should render the correct <domain>', () => {
-        cy.get('vl-sticky-session-cookie').shadow().find('dd').contains(window.location.hostname);
+        cy.get('vl-sticky-session-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains(window.location.hostname);
     });
 
     it('should render the correct <processor>', () => {
-        cy.get('vl-sticky-session-cookie').shadow().find('dd').contains('Departement Omgeving');
+        cy.get('vl-sticky-session-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Departement Omgeving');
     });
 
     it('should render the correct <validity>', () => {
-        cy.get('vl-sticky-session-cookie').shadow().find('dd').contains('Beperkt tot de duur van de sessie');
+        cy.get('vl-sticky-session-cookie')
+            .shadow()
+            .find('vl-properties-next')
+            .shadow()
+            .find('dd')
+            .contains('Beperkt tot de duur van de sessie');
     });
 });

--- a/libs/sections/src/cookie-statement/vl-cookie-statement.section.ts
+++ b/libs/sections/src/cookie-statement/vl-cookie-statement.section.ts
@@ -1,9 +1,9 @@
 import { vlContentBlockStyles, vlGridStyles, vlSectionStyles } from '@domg-wc/common-utilities/css';
 import { VlLinkComponent } from '@domg-wc/components/next/link';
 import { VlParagraphComponent } from '@domg-wc/components/next/paragraph';
+import { VlPropertiesComponent } from '@domg-wc/components/next/properties';
 import { VlSideNavigationComponent } from '@domg-wc/components/next/side-navigation';
 import { VlTitleComponent } from '@domg-wc/components/next/title';
-import { css } from 'lit';
 import { render } from 'lit-html';
 import { BaseElementOfType, registerWebComponents, webComponent } from '@domg-wc/common-utilities';
 import {
@@ -20,10 +20,6 @@ import {
     VlIntroductionElement,
     VlLayoutElement,
     VlLinkElement,
-    VlPropertiesComponent,
-    VlPropertiesListElement,
-    VlPropertyTermElement,
-    VlPropertyValueElement,
     VlRegionElement,
 } from '@domg-wc/elements';
 import { cookieStatementHeaderElements, header } from './child/header.section';
@@ -47,14 +43,11 @@ export class VlCookieStatement extends BaseElementOfType(HTMLElement) {
             VlIntroductionElement,
             VlLayoutElement,
             VlLinkElement,
-            VlPropertiesComponent,
-            VlPropertiesListElement,
-            VlPropertyTermElement,
-            VlPropertyValueElement,
             VlRegionElement,
             // components
             VlContactCardComponent,
             VlInfoblockComponent,
+            VlPropertiesComponent,
             VlTypography,
             VlSideNavigationComponent,
             VlTitleComponent,
@@ -199,23 +192,41 @@ export class VlCookieStatement extends BaseElementOfType(HTMLElement) {
             <div class="vl-content-block-next">
                 <div class="vl-grid-next vl-stacked-next-medium">
                     <div class="vl-column-next vl-column-next--12 vl-column-next--m-12">
-                    <vl-contact-card>
-                        <vl-infoblock slot="info" data-vl-type="contact">
-                            <h3 slot="title">Departement Omgeving</h3>
-                        </vl-infoblock>
-                        <vl-properties slot="properties">
-                            <dl is="vl-properties-list">
-                                <dt is="vl-property-term">Adres</dt>
-                                <dd is="vl-property-value">Herman Teirlinckgebouw<br/>Havenlaan 88<br/>1000 Brussel, België</dd>
-                                <dt is="vl-property-term">Telefoon</dt>
-                                <dd is="vl-property-value"><vl-link-next href="tel:02 553 80 11" icon="phone" icon-placement="after">02 553 80 11</vl-link-next></dd>
-                                <dt is="vl-property-term">E-mail</dt>
-                                <dd is="vl-property-value"><vl-link-next href="mailto:omgeving@vlaanderen.be" icon="mail" icon-placement="after">omgeving@vlaanderen.be</vl-link-next></dd>
-                                <dt is="vl-property-term">Website</dt>
-                                <dd is="vl-property-value"><vl-link-next href="https://omgeving.vlaanderen.be" external>https://omgeving.vlaanderen.be</vl-link-next></dd>
-                            </dl>
-                        </vl-properties>
-                    </vl-contact-card>
+                        <vl-contact-card>
+                            <vl-infoblock slot="info" data-vl-type="contact">
+                                <h3 slot="title">Departement Omgeving</h3>
+                            </vl-infoblock>
+                            <vl-properties-next slot="properties">
+                                <label>Adres</label>
+                                <data>
+                                    <div>Herman Teirlinckgebouw</div>
+                                    <div>Havenlaan 88</div>
+                                    <div>1000 Brussel, België</div>
+                                </data>
+                                <label>Telefoon</label>
+                                <data>
+                                    <vl-link-next href="tel:02 553 80 11"
+                                                  icon-placement="after"
+                                                  icon="phone">
+                                        02 553 80 11
+                                    </vl-link-next>
+                                </data>
+                                <label>E-mail</label>
+                                <data>
+                                    <vl-link-next href="mailto:omgeving@vlaanderen.be"
+                                                  icon-placement="after"
+                                                  icon="mail">
+                                        omgeving@vlaanderen.be
+                                    </vl-link-next>
+                                </data>
+                                <label>Website</label>
+                                <data>
+                                    <vl-link-next href="http://www.omgevingvlaanderen.be" external>
+                                        http://www.omgevingvlaanderen.be
+                                    </vl-link-next>
+                                </data>
+                            </vl-properties-next>
+                        </vl-contact-card>
                     </div>
                 </div>
             </div>

--- a/libs/sections/src/privacy/child/bottom.section.ts
+++ b/libs/sections/src/privacy/child/bottom.section.ts
@@ -8,20 +8,22 @@ export const privacyBottomSection = () => html`
                     <vl-infoblock slot="info" data-vl-type="contact">
                         <h2 slot="title">DPO van Departement Omgeving</h2>
                     </vl-infoblock>
-                    <vl-properties slot="properties">
-                        <dl is="vl-properties-list">
-                            <dt is="vl-property-term">Adres</dt>
-                            <dd is="vl-property-value">
-                                Herman Teirlinckgebouw<br />Havenlaan 88<br />1000 Brussel, België
-                            </dd>
-                            <dt is="vl-property-term">E-mail</dt>
-                            <dd is="vl-property-value">
-                                <vl-link-next href="mailto:dpo@omgevingvlaanderen.be" icon-placement="after" icon="mail"
-                                    >dpo@omgevingvlaanderen.be
-                                </vl-link-next>
-                            </dd>
-                        </dl>
-                    </vl-properties>
+                    <vl-properties-next slot="properties">
+                        <label>Adres</label>
+                        <data>
+                            <div>Herman Teirlinckgebouw</div>
+                            <div>Havenlaan 88</div>
+                            <div>1000 Brussel, België</div>
+                        </data>
+                        <label>E-mail</label>
+                        <data>
+                            <vl-link-next href="mailto:dpo@omgevingvlaanderen.be"
+                                          icon-placement="after"
+                                          icon="mail">
+                                dpo@omgevingvlaanderen.be
+                            </vl-link-next>
+                        </data>
+                    </vl-properties-next>
                 </vl-contact-card>
             </div>
         </div>

--- a/libs/sections/src/privacy/child/content.section.ts
+++ b/libs/sections/src/privacy/child/content.section.ts
@@ -23,7 +23,9 @@ export const privacyContentSection = () => html`
                             <vl-title-next type="h2" id="privacy-declaration">Privacyverklaring</vl-title-next>
                             <div class="vl-grid-next vl-stacked-next-medium">
                                 <div class="vl-column-next vl-column-next--12 vl-column-next--m-12">
-                                    <vl-title-next type="h3" id="privacy-declaration-who">Wie is verantwoordelijk voor de verwerking van mijn persoonsgegevens?</vl-title-next>
+                                    <vl-title-next type="h3" id="privacy-declaration-who">Wie is verantwoordelijk voor
+                                        de verwerking van mijn persoonsgegevens?
+                                    </vl-title-next>
                                     <div class="vl-grid-next vl-stacked-next-medium">
                                         <div class="vl-column-next vl-column-next--12 vl-column-next--m-12">
                                             <vl-typography>
@@ -74,45 +76,46 @@ export const privacyContentSection = () => html`
                                         <div class="vl-column-next vl-column-next--12 vl-column-next--m-12">
                                             <vl-contact-card>
                                                 <vl-infoblock slot="info" data-vl-type="contact">
-                                                    <h4 type="h4" slot="title">Departement Omgeving</h4>
+                                                    <vl-title-next type="h4" slot="title">
+                                                        Departement Omgeving
+                                                    </vl-title-next>
                                                 </vl-infoblock>
-                                                <vl-properties slot="properties">
-                                                    <dl is="vl-properties-list">
-                                                        <dt is="vl-property-term">Adres</dt>
-                                                        <dd is="vl-property-value">
-                                                            Herman Teirlinckgebouw<br />Havenlaan 88<br />1000 Brussel,
-                                                            België
-                                                        </dd>
-                                                        <dt is="vl-property-term">Telefoon</dt>
-                                                        <dd is="vl-property-value">
-                                                            <vl-link-next href="tel:02 553 80 11"
-                                                                          icon-placement="after"
-                                                                          icon="phone"
-                                                            >02 553 80 11
-                                                            </vl-link-next>
-                                                        </dd>
-                                                        <dt is="vl-property-term">E-mail</dt>
-                                                        <dd is="vl-property-value">
-                                                            <vl-link-next href="mailto:omgeving@vlaanderen.be"
-                                                                          icon-placement="after"
-                                                                          icon="mail"
-                                                            >omgeving@vlaanderen.be
-                                                            </vl-link-next>
-                                                        </dd>
-                                                        <dt is="vl-property-term">Website</dt>
-                                                        <dd is="vl-property-value">
-                                                            <vl-link-next
-                                                                href="http://www.omgevingvlaanderen.be"
-                                                                external
-                                                            >http://www.omgevingvlaanderen.be
-                                                            </vl-link-next>
-                                                        </dd>
-                                                        <dt is="vl-property-term">KBO-nummer</dt>
-                                                        <dd is="vl-property-value">
-                                                            0316.380.841 (ondernemingsnummer van de Vlaamse Overheid)
-                                                        </dd>
-                                                    </dl>
-                                                </vl-properties>
+                                                <vl-properties-next slot="properties">
+                                                    <label>Adres</label>
+                                                    <data>
+                                                        <div>Herman Teirlinckgebouw</div>
+                                                        <div>Havenlaan 88</div>
+                                                        <div>1000 Brussel, België</div>
+                                                    </data>
+                                                    <label>Telefoon</label>
+                                                    <data>
+                                                        <vl-link-next href="tel:02 553 80 11"
+                                                                      icon-placement="after"
+                                                                      icon="phone">
+                                                            02 553 80 11
+                                                        </vl-link-next>
+                                                    </data>
+                                                    <label>E-mail</label>
+                                                    <data>
+                                                        <vl-link-next href="mailto:omgeving@vlaanderen.be"
+                                                                      icon-placement="after"
+                                                                      icon="mail">
+                                                            omgeving@vlaanderen.be
+                                                        </vl-link-next>
+                                                    </data>
+                                                    <label>Website</label>
+                                                    <data>
+                                                        <vl-link-next
+                                                            href="http://www.omgevingvlaanderen.be"
+                                                            external>
+                                                            http://www.omgevingvlaanderen.be
+                                                        </vl-link-next>
+                                                    </data>
+                                                    <label>KBO-nummer</label>
+                                                    <data>
+                                                        0316.380.841 (ondernemingsnummer van de Vlaamse Overheid)
+                                                    </data>
+                                                </vl-properties-next>
                                             </vl-contact-card>
                                         </div>
                                     </div>
@@ -177,12 +180,12 @@ export const privacyContentSection = () => html`
                                                     <vl-side-navigation-item-next>
                                                         Om aan wettelijke verplichtingen en beleidsmatig toegewezen
                                                         taken als overheidsinstelling te voldoen;
-                                                        <br /><br />
+                                                        <br/><br/>
                                                         In Vlaamse Regelgeving worden aan het Departement Omgeving een
                                                         aantal taken opgelegd waarbij de verwerking van persoonsgegevens
                                                         expliciet verplicht wordt. De verwerking is in dat geval beperkt
                                                         tot wat door die wettelijke verplichting bepaald wordt.
-                                                        <br /><br />
+                                                        <br/><br/>
                                                         Voor andere verwerkingen bestaat geen expliciete verplichting in
                                                         een wettekst, maar is de verwerking van persoonsgegevens een
                                                         noodzaak voor de uitvoering van beleidstaken die aan het
@@ -191,7 +194,7 @@ export const privacyContentSection = () => html`
                                                     <vl-side-navigation-item-next>
                                                         Om te voldoen aan contractuele verplichtingen of administratieve
                                                         handelingen te kunnen verrichten;
-                                                        <br /><br />
+                                                        <br/><br/>
                                                         Bij de uitvoering van haar taken neemt het Departement ook
                                                         contractuele verbintenissen op zich. Sommige van deze
                                                         verbintenissen vereisen de verwerking van persoonsgegevens. Ook
@@ -204,7 +207,7 @@ export const privacyContentSection = () => html`
                                                     <vl-side-navigation-item-next>
                                                         Om u te informeren over nieuwe ontwikkelingen in thema’s
                                                         waarvoor het Departement Omgeving verantwoordelijkheden draagt.
-                                                        <br /><br />
+                                                        <br/><br/>
                                                         Het Departement Omgeving geeft een aantal nieuwsbrieven uit over
                                                         thema's die nauw verbonden zijn met haar taken. Het informeren
                                                         van burgers kadert in de beleidstaken van de overheid. Gezien
@@ -740,6 +743,7 @@ export const privacyContentSection = () => html`
                             <vl-side-navigation-item-next parent>
                                 <vl-side-navigation-toggle-next href="#privacy-department">
                                     Het Departement Omgeving en uw privacy
+                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
                                 </vl-side-navigation-toggle-next>
                             </vl-side-navigation-item-next>
                             <vl-side-navigation-item-next parent="privacy-declaration">
@@ -748,12 +752,13 @@ export const privacyContentSection = () => html`
                                     child="privacy-declaration"
                                 >
                                     Privacyverklaring
+                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
                                 </vl-side-navigation-toggle-next>
-                                    <ul>
+                                <ul>
                                     <vl-side-navigation-item-next>
                                         <div>
                                             <a href="#privacy-declaration-who"
-                                                                            parent="privacy-declaration">
+                                               parent="privacy-declaration">
                                                 Wie is verantwoordelijk voor de verwerking van mijn persoonsgegevens?
                                             </a>
                                         </div>
@@ -761,7 +766,7 @@ export const privacyContentSection = () => html`
                                     <vl-side-navigation-item-next>
                                         <div>
                                             <a href="#privacy-declaration-process"
-                                                                            parent="privacy-declaration">
+                                               parent="privacy-declaration">
                                                 Verwerking van persoonsgegevens
                                             </a>
                                         </div>
@@ -779,7 +784,7 @@ export const privacyContentSection = () => html`
                                     <vl-side-navigation-item-next>
                                         <div>
                                             <a href="#privacy-declaration-rights"
-                                                                            parent="privacy-declaration">
+                                               parent="privacy-declaration">
                                                 Uw rechten als betrokkene
                                             </a>
                                         </div>
@@ -787,20 +792,21 @@ export const privacyContentSection = () => html`
                                     <vl-side-navigation-item-next>
                                         <div>
                                             <a href="#privacy-declaration-aplpy"
-                                                                            parent="privacy-declaration">
+                                               parent="privacy-declaration">
                                                 Toepassing van deze Privacyverklaring
                                             </a>
                                         </div>
                                     </vl-side-navigation-item-next>
-                                    </ul>
+                                </ul>
                             </vl-side-navigation-item-next>
                             <vl-side-navigation-item-next parent>
-                                    <vl-side-navigation-toggle-next
-                                        href="#privacy-permissions-protocols"
-                                    >
-                                        Machtigingen en protocollen
-                                    </vl-side-navigation-toggle-next>
-                                    <ul>
+                                <vl-side-navigation-toggle-next
+                                    href="#privacy-permissions-protocols"
+                                >
+                                    Machtigingen en protocollen
+                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
+                                </vl-side-navigation-toggle-next>
+                                <ul>
                                     <vl-side-navigation-item-next>
                                         <div>
                                             <a
@@ -812,8 +818,7 @@ export const privacyContentSection = () => html`
                                             </a>
                                         </div>
                                     </vl-side-navigation-item-next>
-                                    </ul>
-                                </vl-side-navigation-group-next>
+                                </ul>
                             </vl-side-navigation-item-next>
                         </vl-side-navigation-group-next>
                     </vl-side-navigation-content-next>

--- a/libs/sections/src/privacy/vl-privacy.section.cy.ts
+++ b/libs/sections/src/privacy/vl-privacy.section.cy.ts
@@ -22,6 +22,7 @@ const defaultProps = privacyDefaults;
 describe('vl-privacy component', () => {
     beforeEach(() => {
         mountDefault(defaultProps);
+        cy.viewport(960, 1440);
     });
 
     it('should mount', () => {

--- a/libs/sections/src/privacy/vl-privacy.section.ts
+++ b/libs/sections/src/privacy/vl-privacy.section.ts
@@ -2,6 +2,7 @@ import { BaseLitElement, registerWebComponents } from '@domg-wc/common-utilities
 import { vlContentBlockStyles, vlGridStyles, vlSectionStyles, vlStackedStyles } from '@domg-wc/common-utilities/css';
 import { VlContactCardComponent, VlDocumentComponent, VlInfoblockComponent, VlTypography } from '@domg-wc/components';
 import { VlParagraphComponent } from '@domg-wc/components/next/paragraph';
+import { VlPropertiesComponent } from '@domg-wc/components/next/properties';
 import { VlSideNavigationComponent } from '@domg-wc/components/next/side-navigation';
 import { VlTitleComponent } from '@domg-wc/components/next/title';
 import {
@@ -16,10 +17,6 @@ import {
     VlIntroductionElement,
     VlLayoutElement,
     VlLinkElement,
-    VlPropertiesComponent,
-    VlPropertiesListElement,
-    VlPropertyTermElement,
-    VlPropertyValueElement,
     VlRegionElement,
     VlSideNavigation,
     VlSideNavigationContentElement,
@@ -57,10 +54,6 @@ export class VlPrivacy extends BaseLitElement {
             VlIntroductionElement,
             VlLayoutElement,
             VlLinkElement,
-            VlPropertiesComponent,
-            VlPropertiesListElement,
-            VlPropertyTermElement,
-            VlPropertyValueElement,
             VlRegionElement,
             VlSideNavigation,
             VlSideNavigationContentElement,
@@ -76,6 +69,7 @@ export class VlPrivacy extends BaseLitElement {
             VlTypography,
             VlTitleComponent,
             VlSideNavigationComponent,
+            VlPropertiesComponent,
             VlParagraphComponent,
             // child components
             ...privacyHeaderElements(),


### PR DESCRIPTION
feat: UIG-3236 - vl-properties-next - is="vl-properties-list" weggewerkt, omgezet naar <vl-properties-next>

de vl-properties css aangepast zodat mobiel de volledige breedte gebruikt wordt
vl-rich-data aangepast

https://www.milieuinfo.be/jira/browse/UIG-3236
https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC554