### PR TITLE
fix: UIG-3256 - vl-properties-next - styling verbeteringen

### DIFF
--- a/libs/components/src/next/properties/stories/vl-properties.stories-arg.ts
+++ b/libs/components/src/next/properties/stories/vl-properties.stories-arg.ts
@@ -13,7 +13,7 @@ export const propertiesArgTypes: ArgTypes<PropertiesArgs> = {
     ...defaultArgTypes(true),
     labelWidth: {
         name: 'label-width',
-        description: "De breedte van de labels, in REM. Heeft geen impact als de properties 'collapsed' worden.",
+        description: "De breedte van de labels, in %. Heeft geen impact als de properties 'collapsed' worden.",
         table: {
             type: { summary: TYPES.NUMBER },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/next/properties/vl-properties.css.ts
+++ b/libs/components/src/next/properties/vl-properties.css.ts
@@ -22,12 +22,8 @@ const collapsedDd = (): CSSResult => {
 
 export const labelWidthRem = (labelWidth: number): CSSResult => {
     return css`
-        dl {
-            grid-template-columns: [labels] ${labelWidth}rem [data] auto;
-        }
-
         dl .item {
-            grid-template-columns: [labels] ${labelWidth}rem [data] auto;
+            grid-template-columns: [labels] ${labelWidth}% [data] auto;
         }
 
         @media screen and (max-width: ${vlMediaScreenSmall}px) {
@@ -59,6 +55,7 @@ const styles: CSSResult = css`
 
     dl {
         display: grid;
+        word-break: break-word;
     }
 
     dl:has(.item) {

--- a/libs/components/src/next/properties/vl-properties.defaults.ts
+++ b/libs/components/src/next/properties/vl-properties.defaults.ts
@@ -1,6 +1,6 @@
 import { Props } from './vl-properties.model';
 
 export const propertiesDefaults = {
-    labelWidth: 17,
+    labelWidth: 25,
     props: [] as Props,
 } as const;


### PR DESCRIPTION
In het `is="vl-properties"`-element neemt het label standaard 25% van de breedte in, dit is nu gelijkgetrokken voor het `vl-properties-next` component en de eenheid van de label breedte is nu `%` (procentueel) in plaats van `rem`. Daarnaast ook `word-break: break-word`-styling overgenomen.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3256)
[Bamboo](https://www.milieuinfo.be/bamboo/chain/viewChain.action?planKey=UIGOV-CUWC578)