### PR TITLE
fix: UIG-3263 - vl-side-sheet - vl-content-block min-width rechtgezet

### DIFF
--- a/libs/components/src/side-sheet/vl-side-sheet.uig-css.ts
+++ b/libs/components/src/side-sheet/vl-side-sheet.uig-css.ts
@@ -74,7 +74,7 @@ const styles: CSSResult = css`
         overflow: auto;
         box-shadow: 0 0 6px rgba(0, 0, 0, 0.15);
     }
-    :host #vl-side-sheet [is='vl-layout'] {
+    :host #vl-side-sheet .vl-content-block-next {
         min-width: auto;
     }
     :host #vl-side-sheet-backdrop {


### PR DESCRIPTION
Vroeger werd min-width van `is="vl-layout"` in de side-sheet overschreven met `min-width: auto`, dit is nu ook doorgetrokken voor de vervangende klasse `vl-content-block-next`

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3263)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC580)