### PR TITLE
fix: UIG-3266 - vl-alert - close-icon zichtbaar gemaakt

### DIFF
--- a/libs/components/src/alert/vl-alert.component.ts
+++ b/libs/components/src/alert/vl-alert.component.ts
@@ -71,7 +71,7 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
                 ${this.closable
                     ? html`
                           <button id="close" class="vl-alert__close" type="button" @click=${this.removeAlert}>
-                              <i class="vl-vi vl-vi-cross" aria-hidden="true"></i>
+                              <span class="vl-icon vl-icon--cross" aria-hidden="true"></span>
                               <span class="vl-u-visually-hidden">Melding sluiten</span>
                           </button>
                       `


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3266)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC583)

in 1.46:

<img width="858" alt="image" src="https://github.com/user-attachments/assets/ceb1812f-11f1-4233-b3af-a6c3859048f0" />

na deze fix:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/a7f14a7b-a735-43a5-8881-3005aa092d8b" />
