### PR TITLE
feat: UIG-3272 - vl-table-next - barrel file toegevoegd

### DIFF
--- a/libs/components/src/next/table/index.ts
+++ b/libs/components/src/next/table/index.ts
@@ -1,0 +1,1 @@
+export { VlTableComponent } from './vl-table.component';


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3272)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC602)

---

Hiervoor geen `develop-v2`-PR voor nodig, gezien dit al reeds uitgevoerd is in de commit voor `--next`-suffix verwijdering.