### PR TITLE
feat: UIG-3254 - vl-side-navigation - toggle sub component verbeterd [v2]

### DIFF
--- a/libs/components/src/side-navigation/vl-side-navigation-toggle.component.ts
+++ b/libs/components/src/side-navigation/vl-side-navigation-toggle.component.ts
@@ -22,19 +22,14 @@ export class VlSideNavigationToggleComponent extends BaseLitElement {
         return this;
     }
 
-    updated() {
-        // TODO in vl-side-navigation(oude v1), komt het arrow icon binnen de a-tag
-        // TODO hier komt dit erbuiten, dit heeft gevolgen naar de styling toe
+    firstUpdated() {
         const childNodes = this.childNodes;
         const aNode = document.createElement('a');
-        // aNode.classList.add('vl-side-navigation__toggle');
         aNode.setAttribute('href', this.href);
-        // aNode.setAttribute('child', this.child);
-        aNode.append(...childNodes);
-        this.appendChild(aNode);
         const iconNode = document.createElement('i');
-        iconNode.setAttribute('class', 'vl-vi vl-vi-arrow-right-fat');
-        this.appendChild(iconNode);
+        iconNode.setAttribute('class', 'vl-icon vl-icon--arrow-right-fat');
+        aNode.append(...childNodes, iconNode);
+        this.appendChild(aNode);
     }
 }
 

--- a/libs/components/src/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/side-navigation/vl-side-navigation.component.ts
@@ -1,7 +1,7 @@
 import { BaseLitElement, unwrap, VL, webComponent } from '@domg-wc/common';
 import '@govflanders/vl-ui-util/dist/js/util.js';
 import './vl-side-navigation.lib.js';
-import { legacyGlobalStyles, vlContentBlockStyles, vlGridStyles, vlSectionStyles } from '@domg-wc/styles';
+import { legacyGlobalStyles, vlContentBlockStyles, vlGridStyles, vlIconStyles, vlSectionStyles } from '@domg-wc/styles';
 import { vlSideNavigationStyles } from './vl-side-navigation.css';
 
 declare const vl: VL;
@@ -35,11 +35,13 @@ export class VlSideNavigationComponent extends BaseLitElement {
                 vlGridStyles.styleSheet as CSSStyleSheet,
                 vlSectionStyles.styleSheet as CSSStyleSheet,
                 vlContentBlockStyles.styleSheet as CSSStyleSheet,
+                vlIconStyles.styleSheet as CSSStyleSheet,
             ];
         } else {
             document.adoptedStyleSheets = [
                 ...document.adoptedStyleSheets,
                 vlSideNavigationStyles.styleSheet as CSSStyleSheet,
+                vlIconStyles.styleSheet as CSSStyleSheet,
             ];
         }
     }

--- a/libs/components/src/side-navigation/vl-side-navigation.css.ts
+++ b/libs/components/src/side-navigation/vl-side-navigation.css.ts
@@ -168,7 +168,7 @@ export const vlSideNavigationStyles: CSSResult = css`
         margin: 13px 0;
     }
 
-    .vl-side-navigation__toggle[aria-expanded='true'] .vl-vi::before {
+    .vl-side-navigation__toggle[aria-expanded='true'] .vl-icon::before {
         transform: rotate(90deg);
     }
 
@@ -181,7 +181,7 @@ export const vlSideNavigationStyles: CSSResult = css`
         margin-top: 0;
     }
 
-    .vl-side-navigation__toggle .vl-vi {
+    .vl-side-navigation__toggle .vl-icon {
         font-size: 1.6rem;
         position: absolute;
         top: 50%;
@@ -189,7 +189,7 @@ export const vlSideNavigationStyles: CSSResult = css`
         transform: translateY(-50%);
     }
 
-    .vl-side-navigation__toggle .vl-vi::before {
+    .vl-side-navigation__toggle .vl-icon::before {
         transition: transform 0.1s ease-in-out;
     }
 

--- a/libs/sections/src/privacy/child/content.section.ts
+++ b/libs/sections/src/privacy/child/content.section.ts
@@ -729,13 +729,11 @@ export const privacyContentSection = () => html`
                             <vl-side-navigation-item parent>
                                 <vl-side-navigation-toggle href="#privacy-department">
                                     Het Departement Omgeving en uw privacy
-                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
                                 </vl-side-navigation-toggle>
                             </vl-side-navigation-item>
                             <vl-side-navigation-item parent="privacy-declaration">
                                 <vl-side-navigation-toggle href="#privacy-declaration" child="privacy-declaration">
                                     Privacyverklaring
-                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
                                 </vl-side-navigation-toggle>
                                 <ul>
                                     <vl-side-navigation-item>
@@ -778,7 +776,6 @@ export const privacyContentSection = () => html`
                             <vl-side-navigation-item parent>
                                 <vl-side-navigation-toggle href="#privacy-permissions-protocols">
                                     Machtigingen en protocollen
-                                    <i class="vl-vi vl-vi-arrow-right-fat"></i>
                                 </vl-side-navigation-toggle>
                                 <ul>
                                     <vl-side-navigation-item>


### PR DESCRIPTION
Opbouw side-navigation-toggle component verbeterd & side-navigation styles verbeterd
Privacy content.section aangepast en icons voor side-navigation-reference verwijderd
vlIconStyles opgesplitst

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3254)
[Bamboo]