### PR TITLE
fix: UIG-3277 - vl-form-label-next - label overschrijft default slot content

### DIFF
--- a/libs/form/src/next/form-label/stories/vl-form-label.stories-arg.ts
+++ b/libs/form/src/next/form-label/stories/vl-form-label.stories-arg.ts
@@ -23,7 +23,7 @@ export const formLabelArgTypes: ArgTypes<FormLabelArgs> = {
     },
     label: {
         name: 'label',
-        description: 'De tekst van het label.',
+        description: 'De tekst van het label. Overschrijft de waarde van het default slot.',
         table: {
             category: CATEGORIES.ATTRIBUTES,
             type: { summary: TYPES.STRING },
@@ -50,7 +50,7 @@ export const formLabelArgTypes: ArgTypes<FormLabelArgs> = {
     },
     defaultSlot: {
         name: '[default]',
-        description: 'De content van het label. Overschrijft de waarde van het label attribuut.',
+        description: 'De content van het label. Wordt overschreven door de waarde van het label attribuut.',
         table: {
             type: { summary: TYPES.HTML },
             category: CATEGORIES.SLOTS,

--- a/libs/form/src/next/form-label/vl-form-label.component.cy.ts
+++ b/libs/form/src/next/form-label/vl-form-label.component.cy.ts
@@ -8,44 +8,58 @@ registerWebComponents([VlFormLabelComponent, VlInputFieldComponent]);
 
 describe('component - vl-form-label-next', () => {
     it('should mount', () => {
-        cy.mount(html`<vl-form-label-next>Naam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next>Naam</vl-form-label-next>`);
 
         cy.get('vl-form-label-next');
     });
 
     it('should be accessible', () => {
-        cy.mount(html`<vl-form-label-next>Naam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next>Naam</vl-form-label-next>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-form-label-next');
     });
 
     it('should set for', () => {
-        cy.mount(html`<vl-form-label-next for="test-input">Naam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next for="test-input">Naam</vl-form-label-next>`);
 
         cy.get('vl-form-label-next').shadow().find('label').should('have.attr', 'for', 'test-input');
     });
 
     it('should set label', () => {
-        cy.mount(html`<vl-form-label-next label="Naam"></vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next label="Naam"></vl-form-label-next>`);
 
         cy.get('vl-form-label-next').shadow().find('label').contains('Naam');
     });
 
+    it('should set label with default slot', () => {
+        cy.mount(html` <vl-form-label-next>Adres</vl-form-label-next>`);
+
+        cy.get('vl-form-label-next').contains('Adres');
+        cy.get('vl-form-label-next').shadow().find('label').should('contain.html', 'slot');
+    });
+
+    it('should prioritise label-attribute when slotted content', () => {
+        cy.mount(html` <vl-form-label-next label="Naam">Adres</vl-form-label-next>`);
+
+        cy.get('vl-form-label-next').shadow().find('label').contains('Naam');
+        cy.get('vl-form-label-next').shadow().find('label').should('not.contain.html', 'slot');
+    });
+
     it('should set default slot', () => {
-        cy.mount(html`<vl-form-label-next label="Naam">Voornaam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next label="Naam">Voornaam</vl-form-label-next>`);
 
         cy.get('vl-form-label-next').contains('Voornaam');
     });
 
     it('should set block', () => {
-        cy.mount(html`<vl-form-label-next block>Naam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next block>Naam</vl-form-label-next>`);
 
         cy.get('vl-form-label-next').shadow().find('label').should('have.class', 'vl-form__label--block');
     });
 
     it('should set light', () => {
-        cy.mount(html`<vl-form-label-next light>Naam</vl-form-label-next>`);
+        cy.mount(html` <vl-form-label-next light>Naam</vl-form-label-next>`);
 
         cy.get('vl-form-label-next').shadow().find('label').should('have.class', 'vl-form__label--light');
     });

--- a/libs/form/src/next/form-label/vl-form-label.component.ts
+++ b/libs/form/src/next/form-label/vl-form-label.component.ts
@@ -56,7 +56,7 @@ export class VlFormLabelComponent extends BaseLitElement {
 
         return html`
             <label for=${this.for} class=${classMap(classList)} part="label">
-                <slot>${this.label}</slot>
+                ${this.label ? this.label : html` <slot></slot>`}
             </label>
         `;
     }


### PR DESCRIPTION
Vroeger werd de tekst van het label overschreven door de default slotted content, nu is het omgekeerd.

[Jira](https://www.milieuinfo.be/jira/browse/UIG-3277)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC612)