### PR TITLE
fix: UIG-3284 - vl-properties-next - column--full-width werking verbeterd

### DIFF
--- a/libs/components/src/next/properties/vl-properties.component.ts
+++ b/libs/components/src/next/properties/vl-properties.component.ts
@@ -2,7 +2,7 @@ import { BaseLitElement, onChildListChange, webComponent } from '@domg-wc/common
 import { vlElementsStyle } from '@domg-wc/elements';
 import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { buildProperties } from './vl-properties.builder';
-import propertiesStyles, { labelWidthRem } from './vl-properties.css';
+import propertiesStyles, { labelWidthPercentage } from './vl-properties.css';
 import { propertiesDefaults } from './vl-properties.defaults';
 import { Column, Item, Props } from './vl-properties.model';
 
@@ -54,7 +54,7 @@ export class VlPropertiesComponent extends BaseLitElement {
         super.updated(changedProperties);
 
         if (changedProperties.has('labelWidth') && this.labelWidth) {
-            this.labelWidthSheet.replace(labelWidthRem(this.labelWidth).toString());
+            this.labelWidthSheet.replace(labelWidthPercentage(this.labelWidth).toString());
         }
     }
 

--- a/libs/components/src/next/properties/vl-properties.css.ts
+++ b/libs/components/src/next/properties/vl-properties.css.ts
@@ -20,10 +20,16 @@ const collapsedDd = (): CSSResult => {
     `;
 };
 
-export const labelWidthRem = (labelWidth: number): CSSResult => {
+export const labelWidthPercentage = (labelWidth: number): CSSResult => {
     return css`
+        dl,
         dl .item {
             grid-template-columns: [labels] ${labelWidth}% [data] auto;
+        }
+
+        dl .column--full-width,
+        dl .column--full-width .item {
+            grid-template-columns: [labels] ${labelWidth / 2}% [data] auto;
         }
 
         @media screen and (max-width: ${vlMediaScreenSmall}px) {
@@ -88,6 +94,10 @@ const styles: CSSResult = css`
     }
 
     @media screen and (max-width: ${vlMediaScreenSmall}px) {
+        .column {
+            ${columnWidth(100)};
+        }
+
         dd {
             ${collapsedDd()}
         }


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3284)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC621)

### Voor de fix:

<img width="659" alt="image" src="https://github.com/user-attachments/assets/ade4214e-e9f0-4b09-aca7-6e3bd6b9c233" />

< viewport 767px :

<img width="478" alt="image" src="https://github.com/user-attachments/assets/95acbc3f-3ecc-4ee8-95cd-0ca6d290e42b" />



### Na de fix:

<img width="653" alt="image" src="https://github.com/user-attachments/assets/b4fb77e1-9f1b-428e-8ffe-1c0ec8199c31" />

< viewport 767px :

<img width="132" alt="image" src="https://github.com/user-attachments/assets/a5595a07-ac8c-4749-9e22-bd9ee0ccca74" />
