### PR TITLE
fix: UIG-3290 - vl-properties-next - container query verwijderd

### DIFF
--- a/libs/components/src/next/properties/vl-properties.css.ts
+++ b/libs/components/src/next/properties/vl-properties.css.ts
@@ -41,31 +41,11 @@ export const sizeQueryStyles = css`
             grid-template-columns: 100%;
         }
     }
-
-    @container (max-width: ${vlMediaScreenSmall}px) {
-        .column {
-            ${columnWidth(100)};
-        }
-
-        dd {
-            ${collapsedDd()}
-        }
-
-        dt {
-            ${collapsedDt()}
-        }
-
-        dl,
-        dl .item {
-            grid-template-columns: 100%;
-        }
-    }
 `;
 
 export const propertiesStyles: CSSResult = css`
     :host {
         display: block;
-        container-type: size;
     }
 
     .column {


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3290)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC643)