### PR TITLE
fix: UIG-3291 - vl-button-next - "gap" waarde werd niet toegepast op cta-link

### DIFF
--- a/libs/components/src/next/button/vl-link-button.css.ts
+++ b/libs/components/src/next/button/vl-link-button.css.ts
@@ -38,6 +38,8 @@ export const linkButtonStyles: CSSResult = css`
         /* link-button styles */
         text-decoration: none;
 
+        gap: 0.5em; /* waarde van vl-icon.css.ts */
+
         @media screen and (max-width: ${vlMediaScreenSmall}px) {
             padding: var(--vl-spacing--xsmall);
         }


### PR DESCRIPTION
https://www.milieuinfo.be/jira/browse/UIG-3291
https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC645