### PR TITLE
fix: UIG-3301 - vl-properties-next - collapsed-styling in mobile view verbeterd

### DIFF
--- a/libs/components/src/next/properties/vl-properties.css.ts
+++ b/libs/components/src/next/properties/vl-properties.css.ts
@@ -40,6 +40,18 @@ export const sizeQueryStyles = css`
         dl .item {
             grid-template-columns: 100%;
         }
+
+        .column {
+            ${columnWidth(100)};
+        }
+
+        dd {
+            ${collapsedDd()}
+        }
+
+        dt {
+            ${collapsedDt()}
+        }
     }
 `;
 


### PR DESCRIPTION
[Jira](https://www.milieuinfo.be/jira/browse/UIG-3301)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/UIGOV-CUWC666)

<img width="822" alt="image" src="https://github.com/user-attachments/assets/9d068e49-6b35-4af5-ab5a-1a5d0f054885" />
