### PR TITLE
feat: FLUX-77 - vl-select-rich - choices.js bijgewerkt

### DIFF
--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
@@ -54,7 +54,8 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
     search: {
         name: 'search',
         description:
-            'Duidt aan dat je kan zoeken in de opties.<br>De zoekfunctie staat standaard aan als je de multiple select gebruikt.<br>Dit attribuut is niet reactief.',
+            'Duidt aan dat je kan zoeken in de opties.<br>De zoekfunctie staat standaard ' +
+            'aan als je de multiple select gebruikt.<br>Dit attribuut is niet reactief.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
@@ -109,9 +110,22 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
             defaultValue: { summary: selectRichArgs.searchPlaceholder },
         },
     },
+    initialOptions: {
+        name: 'initial-options',
+        description:
+            'De standaard opties die geselecteerd kunnen worden. Bij een reset van de form worden deze opties ' +
+            'getoond.<br>Niet dynamisch.<br>Zie de documentatie pagina voor meer info.',
+        table: {
+            type: { summary: 'SelectRichOption' },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: selectRichArgs.initialOptions },
+        },
+    },
     options: {
         name: 'options',
-        description: 'De opties die geselecteerd kunnen worden.<br>Zie de documentatie pagina voor meer info.',
+        description:
+            'De opties die geselecteerd kunnen worden.<br>Zal de opties van de select-rich dynamisch bijwerken.' +
+            '<br>Zie de documentatie pagina voor meer info.',
         table: {
             type: { summary: 'SelectRichOption' },
             category: CATEGORIES.PROPERTIES,
@@ -121,7 +135,9 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
     onVlChange: {
         name: 'vl-change',
         description:
-            'Event dat afgevuurd wordt als er een optie selecteerd of verwijderd wordt.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
+            'Event dat afgevuurd wordt als er een optie selecteerd of verwijderd wordt.' +
+            '<br>Het detail object van het event bevat de waarde van de geselecteerde optie.' +
+            '<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
         table: {
             type: { summary: '{ value: string | string[] }' },
             category: CATEGORIES.EVENTS,
@@ -130,7 +146,9 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
     onVlInput: {
         name: 'vl-input',
         description:
-            'Event dat enkel afgevuurd wordt als de gebruiker een optie selecteert of verwijdert.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
+            'Event dat enkel afgevuurd wordt als de gebruiker een optie selecteert of verwijdert.' +
+            '<br>Het detail object van het event bevat de waarde van de geselecteerde optie.' +
+            '<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
         table: {
             type: { summary: '{ value: string | string[] }' },
             category: CATEGORIES.EVENTS,
@@ -147,7 +165,9 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
     onVlValid: {
         name: 'vl-valid',
         description:
-            'Event dat afgevuurd wordt als de select valid is.<br>Het detail object van het event bevat de waarde van de geselecteerde optie.<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
+            'Event dat afgevuurd wordt als de select valid is.' +
+            '<br>Het detail object van het event bevat de waarde van de geselecteerde optie.' +
+            '<br>Bij de multiselect bevat het detail object een array van waarden van de geselecteerde opties.',
         table: {
             type: { summary: '{ value: string | string[] }' },
             category: CATEGORIES.EVENTS,

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
@@ -50,6 +50,17 @@ import { VlSelectRichComponent } from '@domg-wc/components/form';
 Geeft de geselecteerde values terug.<br/>
 Bij de single select geeft deze methode een string terug, bij de multi select een array van strings.
 
+### selectByValue(value: string | string[]): void
+
+Vinkt 1 of meerdere opties aan op basis van de value.
+
+### removeSelectionByValue(value: string | string[]): void
+
+Vinkt 1 of meerdere opties uit op basis van de value.
+
+### removeAllSelections(): void
+
+Vinkt alle opties uit.
 
 ## Styles
 
@@ -57,29 +68,64 @@ De styles van DV zijn lokaal gezet en aangepast omdat deze niet CSP compliant wa
 Er werd gebruik gemaakt van een `data:` attribuut om een SVG op te halen van w3.org.
 Hierdoor breekt de CSP compliance tenzij je alle `data:` attributen whitelist, wat niet de bedoeling is.
 
+## Events
 
-## Change event
+### Change event
 
-Bij het selecteren of verwijderen van een optie (zowel programmatorisch als door de gebruiker) wordt het `vl-change` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
-Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de multi select een array van strings.
+Bij het selecteren of verwijderen van een optie (zowel programmatorisch als door de gebruiker) wordt het `vl-change`
+event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
+Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de
+multi select een array van strings.
 
-## Input event
+### Input event
 
-Wanneer de gebruiker een optie verwijdert of selecteert, wordt het `vl-input` event afgevuurd, het detail object van dit event bevat de value van de geselecteerde opties.<br/>
-Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de multi select een array van strings.
+Wanneer de gebruiker een optie verwijdert of selecteert, wordt het `vl-input` event afgevuurd, het detail object van
+dit event bevat de value van de geselecteerde opties.<br/>
+Gelijkaardig aan de `getSelected()` methode, bevat de value bij de single select 1 string en bij de multi select
+een array van strings.
 
+### Search Event
+
+Wanneer de gebruiker een zoekopdracht uitvoert, wordt het `vl-search` event afgevuurd,
+het detail object van dit event bevat de zoekterm die de gebruiker heeft ingegeven.<br/>
 
 ## Select opties
 
+De `select-rich` component kan 1 of meerdere waardes bevatten. Die waardes worden weergegeven als opties in de select
+component.<br/> Om die opties te beheren, zijn er verschillende mogelijkheden:
+
+### met methods
+
+De `select-rich` component heeft een aantal methodes die je kan gebruiken om de opties te beheren:
+
+- `selectByValue(value: string | string[])`: vinkt 1 of meerdere optie(s) aan
+- `removeSelectionByValue(value: string | string[])`: vinkt 1 of meerdere optie(s) uit
+- `removeAllSelections()`: vinkt alle opties uit
+
+### `options` property
+
 De `options` property bevat een array van objecten die de opties van de select component bevatten.
 
-Als de referentie van deze array verandert, wordt de Lit lifecycle getriggerd en wordt de select opnieuw opgebouwd op basis van de nieuwe opties.<br/>
-Hierdoor is het noodzakelijk om de opties door te geven aan de select component met behulp van een variabele, en de opties niet direct in de template te zetten.<br/>
-Indien je de opties direct in de template zet, zal bij elke render de select opnieuw opgebouwd worden en de gekozen opties verwijderd worden.
+Als de referentie van deze array verandert, wordt de Lit lifecycle getriggerd en wordt de select opnieuw
+opgebouwd op basis van de nieuwe opties.<br/>
+Hierdoor is het noodzakelijk om de opties door te geven aan de select component met behulp van een variabele,
+en de opties niet direct in de template te zetten.<br/>
+Indien je de opties direct in de template zet, zal bij elke render de select opnieuw opgebouwd worden en de
+gekozen opties verwijderd worden.
 
-Dit betekent ook dat als je programmatorisch een optie wil veranderen, toevoegen of verwijderen, je de referentie van de array moet aanpassen.<br/>
+Dit betekent ook dat als je programmatorisch een optie wil veranderen, toevoegen of verwijderen,
+je de referentie van de array moet aanpassen.<br/>
 Dit kan je doen door de opties de spreaden in een nieuwe array (`[...options]`).
 
+### `initial-options` property
+
+De `initial-options` property is een array van objecten die de opties van de select component bevatten.<br/>
+Deze zijn de standaard opties die worden getoond bij het laden van de pagina.<br/>
+
+Als de form reset, worden deze opties getoond in de select component.<br/>
+
+Indien je de `opties` direct in de template zet bij het laden van de `vl-select-rich`, worden deze intern ingesteld als
+de `initial-options` property.<br/>
 
 ## Accessibility
 
@@ -232,7 +278,8 @@ Indien de 'required' boolean op true staat, moet je een value programmatorisch s
 
 ## Validatie
 
-Meer info over validatie binnen onze form componenten vind je hier: [Form - Validatie](/docs/ontwerp-form-validation--documentatie)
+Meer info over validatie binnen onze form componenten vind je hier:
+[Form - Validatie](/docs/ontwerp-form-validation--documentatie)
 
 
 ## Referenties
@@ -243,6 +290,8 @@ Meer info over validatie binnen onze form componenten vind je hier: [Form - Vali
 
 ### Digitaal Vlaanderen
 
-[Documentatie Digitaal Vlaanderen - Select](https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-select)
+[Documentatie Digitaal Vlaanderen -
+    Select](https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-select)
 
-[Documentatie Digitaal Vlaanderen - Multiselect](https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect)
+[Documentatie Digitaal Vlaanderen -
+    Multiselect](https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect)

--- a/libs/components/src/form/select-rich/styles/vl-select.dv-css.ts
+++ b/libs/components/src/form/select-rich/styles/vl-select.dv-css.ts
@@ -367,6 +367,8 @@ const style = css`
         cursor: default;
         display: flex;
         align-items: center;
+        min-height: calc(3.5rem - 1.2rem);
+        height: calc(3.5rem - 1.2rem);
     }
 
     .js-vl-select .vl-select__item--disabled {

--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
+import { parseFormData } from '../utils';
 import { VlSelectRichComponent } from './vl-select-rich.component';
 import { SelectRichOption } from './index';
 
@@ -141,7 +142,13 @@ describe('component - vl-select-rich - single', () => {
 
     it('should set result limit', () => {
         cy.mount(
-            html`<vl-select-rich label="geboorteplaats" result-limit="1" search .options=${options}></vl-select-rich>`
+            html`<vl-select-rich
+                label="geboorteplaats"
+                placeholder="kies geboorteplaats"
+                result-limit="1"
+                search
+                .options=${options}
+            ></vl-select-rich>`
         );
         cy.injectAxe();
 
@@ -172,7 +179,7 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-select__item.has-no-results')
             .contains('Geen geboorteplaatsen gevonden');
 
-        // het is niet accessible als de dropdown open is
+        // TODO: het is niet accessible als de dropdown open is
         // cy.checkA11y('vl-select-rich');
     });
 
@@ -194,7 +201,7 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-select__item.has-no-choices')
             .contains('Geen resterende geboorteplaatsen gevonden');
 
-        // het is niet accessible als de dropdown open is
+        // TODO: het is niet accessible als de dropdown open is
         // cy.checkA11y('vl-select-rich');
     });
 
@@ -216,7 +223,14 @@ describe('component - vl-select-rich - single', () => {
     });
 
     it('should search', () => {
-        cy.mount(html`<vl-select-rich label="geboorteplaats" search .options=${options}></vl-select-rich>`);
+        cy.mount(
+            html`<vl-select-rich
+                label="geboorteplaats"
+                placeholder="kies je geboorteplaats"
+                search
+                .options=${options}
+            ></vl-select-rich>`
+        );
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
@@ -260,8 +274,8 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-select__item')
             .contains('Turnhout')
             .click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Hasselt').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Turnhout');
+        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Hasselt').should('be.disabled');
+        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Turnhout').should('not.be.disabled');
         cy.checkA11y('vl-select-rich');
     });
 
@@ -299,21 +313,21 @@ describe('component - vl-select-rich - single', () => {
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Lier');
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Rio Piedras');
 
-        // het is niet accessible als de dropdown open is
+        // TODO: het is niet accessible als de dropdown open is
         // cy.checkA11y('vl-select-rich');
     });
 
     it('should dispatch vl-change event on select and delete option', () => {
         cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
-        cy.injectAxe();
 
         cy.createStubForEvent('vl-select-rich', 'vl-change');
+        cy.injectAxe();
         cy.checkA11y('vl-select-rich');
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
         cy.get('@vl-change')
-            .should('have.been.calledOnce')
-            .its('firstCall.args.0.detail')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
             .should('deep.equal', { value: 'hasselt' });
         cy.get('vl-select-rich')
             .shadow()
@@ -322,19 +336,18 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-pill__close')
             .click();
         cy.get('@vl-change')
-            .should('have.been.calledTwice')
-            .its('secondCall.args.0.detail')
+            .should('have.been.calledThrice')
+            .its('thirdCall.args.0.detail')
             .should('deep.equal', { value: null });
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should dispatch vl-select on select and delete option', () => {
+    it('should dispatch vl-input on select and delete option', () => {
         cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
         cy.injectAxe();
-        cy.createStubForEvent('vl-select-rich', 'vl-input');
-
         cy.checkA11y('vl-select-rich');
-        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click({ force: true });
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
         cy.get('@vl-input')
             .should('have.been.calledOnce')
@@ -353,35 +366,32 @@ describe('component - vl-select-rich - single', () => {
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should dispatch vl-change, but not vl-select when programmatically selecting and deleting option', () => {
+    it('should dispatch vl-change, but not vl-input when programmatically selecting and deleting option', () => {
         cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
-        cy.injectAxe();
         cy.createStubForEvent('vl-select-rich', 'vl-change');
         cy.createStubForEvent('vl-select-rich', 'vl-input');
-
+        cy.injectAxe();
         cy.checkA11y('vl-select-rich');
         cy.get('vl-select-rich').then((el) => {
             const select = el[0] as VlSelectRichComponent;
-            const filteredOptions = select.options.filter((option) => option.value !== 'hasselt');
-            select.options = [...filteredOptions, { label: 'Hasselt', value: 'hasselt', selected: true }];
+            select.selectByValue('hasselt');
         });
 
         cy.get('@vl-change')
-            .should('have.been.calledOnce')
-            .its('firstCall.args.0.detail')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
             .should('deep.equal', { value: 'hasselt' });
 
         cy.get('@vl-input').should('to.not.have.been.called.at.all');
 
         cy.get('vl-select-rich').then((el) => {
             const select = el[0] as VlSelectRichComponent;
-            const filteredOptions = select.options.filter((option) => option.value !== 'hasselt');
-            select.options = [...filteredOptions, { label: 'Hasselt', value: 'hasselt' }];
+            select.removeSelectionByValue('hasselt');
         });
 
         cy.get('@vl-change')
-            .should('have.been.calledTwice')
-            .its('secondCall.args.0.detail')
+            .should('have.been.calledThrice')
+            .its('thirdCall.args.0.detail')
             .should('deep.equal', { value: null });
         cy.checkA11y('vl-select-rich');
 
@@ -389,7 +399,14 @@ describe('component - vl-select-rich - single', () => {
     });
 
     it('should dispatch vl-select-search event on input search value', () => {
-        cy.mount(html`<vl-select-rich label="geboorteplaats" search .options=${options}></vl-select-rich>`);
+        cy.mount(
+            html`<vl-select-rich
+                label="geboorteplaats"
+                placeholder="zoek geboorteplaats"
+                search
+                .options=${options}
+            ></vl-select-rich>`
+        );
         cy.injectAxe();
         cy.createStubForEvent('vl-select-rich', 'vl-select-search');
 
@@ -410,9 +427,10 @@ describe('component - vl-select-rich - single', () => {
 
     it('should dispatch vl-valid event on valid selection', () => {
         cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options} required></vl-select-rich>`);
-        cy.injectAxe();
-
         cy.createStubForEvent('vl-select-rich', 'vl-valid');
+        cy.createStubForEvent('vl-select-rich', 'vl-change');
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.injectAxe();
         cy.checkA11y('vl-select-rich');
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
@@ -427,6 +445,8 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-pill__close')
             .click();
         cy.get('@vl-valid').should('have.been.calledOnce');
+        cy.get('@vl-input').should('have.been.calledTwice');
+        cy.get('@vl-change').should('have.been.calledThrice');
         cy.checkA11y('vl-select-rich');
     });
 
@@ -437,12 +457,42 @@ describe('component - vl-select-rich - single', () => {
         cy.checkA11y('vl-select-rich');
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Hasselt');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Turnhout').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Knokke-Heist').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Waregem').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Lier').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Rio Piedras').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Waregem')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Lier')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('not.have.attr', 'selected');
         cy.checkA11y('vl-select-rich');
     });
 
@@ -460,11 +510,11 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-select__item')
             .find('.vl-pill__close')
             .click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.exist');
+        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.have.attr', 'selected');
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should select option programmatically', () => {
+    it('should select initial option programmatically', () => {
         const options: SelectRichOption[] = [
             { label: 'Hasselt', value: 'hasselt', selected: true },
             { label: 'Turnhout', value: 'turnhout' },
@@ -478,12 +528,380 @@ describe('component - vl-select-rich - single', () => {
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Hasselt');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Turnhout').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Knokke-Heist').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Waregem').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Lier').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Rio Piedras').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Waregem')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Lier')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.options = [
+                { label: 'Hasselt', value: 'hasselt' },
+                { label: 'Turnhout', value: 'turnhout', selected: true },
+                { label: 'Knokke-Heist', value: 'knokke-heist' },
+                { label: 'Waregem', value: 'waregem' },
+                { label: 'Lier', value: 'lier' },
+                { label: 'Rio Piedras', value: 'rio piedras' },
+            ];
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.removeSelectionByValue('hasselt');
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.selectByValue('hasselt');
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('have.attr', 'selected');
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should set new options programmatically using methods', () => {
+        const options: SelectRichOption[] = [
+            { label: 'Hasselt', value: 'hasselt' },
+            { label: 'Turnhout', value: 'turnhout' },
+            { label: 'Knokke-Heist', value: 'knokke-heist', selected: true },
+        ];
+
+        const newOptions: SelectRichOption[] = [
+            { label: 'Waregem', value: 'waregem' },
+            { label: 'Lier', value: 'lier' },
+            { label: 'Rio Piedras', value: 'rio piedras' },
+        ];
+
+        cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.setOptions(newOptions);
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Waregem')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Lier')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('not.have.attr', 'selected');
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should select & unselect option programmatically using methods', () => {
+        const options: SelectRichOption[] = [
+            { label: 'Hasselt', value: 'hasselt' },
+            { label: 'Turnhout', value: 'turnhout' },
+            { label: 'Knokke-Heist', value: 'knokke-heist', selected: true },
+            { label: 'Waregem', value: 'waregem' },
+            { label: 'Lier', value: 'lier' },
+            { label: 'Rio Piedras', value: 'rio piedras' },
+        ];
+
+        cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Waregem')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Lier')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.removeSelectionByValue('knokke-heist');
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.selectByValue('rio piedras');
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('have.attr', 'selected');
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should select & unselect option programmatically, setting options property', () => {
+        const options: SelectRichOption[] = [
+            { label: 'Hasselt', value: 'hasselt' },
+            { label: 'Turnhout', value: 'turnhout' },
+            { label: 'Knokke-Heist', value: 'knokke-heist', selected: true },
+            { label: 'Waregem', value: 'waregem' },
+            { label: 'Lier', value: 'lier' },
+            { label: 'Rio Piedras', value: 'rio piedras' },
+        ];
+
+        cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Hasselt')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Turnhout')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Waregem')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Lier')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.options = [
+                { label: 'Hasselt', value: 'hasselt' },
+                { label: 'Turnhout', value: 'turnhout' },
+                { label: 'Knokke-Heist', value: 'knokke-heist' },
+                { label: 'Waregem', value: 'waregem' },
+                { label: 'Lier', value: 'lier' },
+                { label: 'Rio Piedras', value: 'rio piedras' },
+            ];
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Knokke-Heist')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.options = [
+                { label: 'Hasselt', value: 'hasselt' },
+                { label: 'Turnhout', value: 'turnhout' },
+                { label: 'Knokke-Heist', value: 'knokke-heist' },
+                { label: 'Waregem', value: 'waregem' },
+                { label: 'Lier', value: 'lier' },
+                { label: 'Rio Piedras', value: 'rio piedras', selected: true },
+            ];
+        });
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Rio Piedras')
+            .should('have.attr', 'selected');
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should remove selected option programmatically', () => {
+        const options: SelectRichOption[] = [
+            { label: 'Padel', value: 'padel', selected: true },
+            { label: 'Dans', value: 'dans' },
+            { label: 'Drummen', value: 'drummen' },
+            { label: 'Zwemmen', value: 'zwemmen' },
+            { label: 'Boardgames', value: 'boardgames' },
+            { label: 'Fietsen', value: 'fietsen' },
+        ];
+
+        cy.mount(html`<vl-select-rich label="hobby's" .options=${options}></vl-select-rich>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Drummen')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Zwemmen')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Boardgames')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Fietsen')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.removeAllSelections();
+        });
+
+        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.have.attr', 'selected');
+
         cy.checkA11y('vl-select-rich');
     });
 
@@ -492,9 +910,12 @@ describe('component - vl-select-rich - single', () => {
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
+
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich', (component) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(component.getSelected()).to.be.null;
         });
+
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich', (component) => {
@@ -515,10 +936,13 @@ describe('component - vl-select-rich - single', () => {
             .find('.vl-input-field')
             .find('.vl-select__item')
             .find('.vl-pill__close')
-            .click();
+            .click({ force: true });
+
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich', (component) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(component.getSelected()).to.be.null;
         });
+
         cy.checkA11y('vl-select-rich');
     });
 });
@@ -534,7 +958,16 @@ describe('component - vl-select-rich - multiple', () => {
     ];
 
     it('should mount', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(
+            html`
+                <vl-select-rich
+                    label="hobby's"
+                    placeholder="Vul hobby's in"
+                    multiple
+                    .options=${options}
+                ></vl-select-rich>
+            `
+        );
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
@@ -542,7 +975,12 @@ describe('component - vl-select-rich - multiple', () => {
     });
 
     it('should search', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
@@ -559,7 +997,12 @@ describe('component - vl-select-rich - multiple', () => {
     });
 
     it('should dispatch vl-change event on select and delete option', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.createStubForEvent('vl-select-rich', 'vl-change');
@@ -588,8 +1031,13 @@ describe('component - vl-select-rich - multiple', () => {
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should dispatch vl-select event on select and delete option', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+    it('should dispatch vl-input event on select and delete option', () => {
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.createStubForEvent('vl-select-rich', 'vl-input');
@@ -618,35 +1066,38 @@ describe('component - vl-select-rich - multiple', () => {
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should dispatch vl-change, but not vl-select when programmatically selecting and deleting option', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
-        cy.injectAxe();
+    it('should dispatch vl-change, but not vl-input when programmatically selecting and deleting option', () => {
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.createStubForEvent('vl-select-rich', 'vl-change');
         cy.createStubForEvent('vl-select-rich', 'vl-input');
-
+        cy.injectAxe();
         cy.checkA11y('vl-select-rich');
+
         cy.get('vl-select-rich').then((el) => {
             const select = el[0] as VlSelectRichComponent;
-            const filteredOptions = select.options.filter((option) => option.value !== 'padel');
-            select.options = [...filteredOptions, { label: 'Padel', value: 'padel', selected: true }];
+            select.selectByValue('padel');
         });
 
         cy.get('@vl-change')
-            .should('have.been.calledOnce')
-            .its('firstCall.args.0.detail')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
             .should('deep.equal', { value: ['padel'] });
 
         cy.get('@vl-input').should('to.not.have.been.called.at.all');
 
         cy.get('vl-select-rich').then((el) => {
             const select = el[0] as VlSelectRichComponent;
-            const filteredOptions = select.options.filter((option) => option.value !== 'dans');
-            select.options = [...filteredOptions, { label: 'Dans', value: 'dans', selected: true }];
+            select.selectByValue('dans');
         });
 
         cy.get('@vl-change')
-            .should('have.been.calledTwice')
-            .its('secondCall.args.0.detail')
+            .should('have.been.calledThrice')
+            .its('thirdCall.args.0.detail')
             .should('deep.equal', { value: ['padel', 'dans'] });
 
         cy.get('@vl-input').should('to.not.have.been.called.at.all');
@@ -655,8 +1106,7 @@ describe('component - vl-select-rich - multiple', () => {
 
         cy.get('vl-select-rich').then((el) => {
             const select = el[0] as VlSelectRichComponent;
-            const filteredOptions = select.options.filter((option) => option.value !== 'padel');
-            select.options = [...filteredOptions, { label: 'Padel', value: 'padel' }];
+            select.removeSelectionByValue('padel');
         });
 
         cy.get('@vl-change')
@@ -667,7 +1117,12 @@ describe('component - vl-select-rich - multiple', () => {
     });
 
     it('should select multiple options', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
@@ -675,17 +1130,52 @@ describe('component - vl-select-rich - multiple', () => {
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Padel').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Dans').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Drummen').click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Padel');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Dans');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Drummen');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Zwemmen').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Boardgames').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Fietsen').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Drummen')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Zwemmen')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Boardgames')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Fietsen')
+            .should('not.have.attr', 'selected');
         cy.checkA11y('vl-select-rich');
     });
 
     it('should delete multiple options', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
@@ -693,16 +1183,36 @@ describe('component - vl-select-rich - multiple', () => {
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Padel').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Dans').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Drummen').click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Padel');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Dans');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Drummen');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Drummen')
+            .should('have.attr', 'selected');
         cy.get('vl-select-rich')
             .shadow()
             .find('.vl-input-field')
             .find('.vl-select__item[data-value="padel"]')
             .find('.vl-pill__close')
             .click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Padel').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('not.have.attr', 'selected');
         cy.get('vl-select-rich').shadow().find('select').find('option').contains('Dans');
         cy.get('vl-select-rich').shadow().find('select').find('option').contains('Drummen');
         cy.get('vl-select-rich')
@@ -711,8 +1221,18 @@ describe('component - vl-select-rich - multiple', () => {
             .find('.vl-select__item[data-value="dans"]')
             .find('.vl-pill__close')
             .click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Padel').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Dans').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('not.have.attr', 'selected');
         cy.get('vl-select-rich').shadow().find('select').find('option').contains('Drummen');
         cy.get('vl-select-rich')
             .shadow()
@@ -720,11 +1240,11 @@ describe('component - vl-select-rich - multiple', () => {
             .find('.vl-select__item[data-value="drummen"]')
             .find('.vl-pill__close')
             .click();
-        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.exist');
+        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.have.attr', 'selected');
         cy.checkA11y('vl-select-rich');
     });
 
-    it('should select multiple options programmatically', () => {
+    it('should select multiple options with options property', () => {
         const options: SelectRichOption[] = [
             { label: 'Padel', value: 'padel', selected: true },
             { label: 'Dans', value: 'dans', selected: true },
@@ -734,25 +1254,146 @@ describe('component - vl-select-rich - multiple', () => {
             { label: 'Fietsen', value: 'fietsen' },
         ];
 
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Padel');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Dans');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Drummen');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Zwemmen').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Boardgames').should('not.exist');
-        cy.get('vl-select-rich').shadow().find('select').find('option').contains('Fietsen').should('not.exist');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Drummen')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Zwemmen')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Boardgames')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Fietsen')
+            .should('not.have.attr', 'selected');
+        cy.checkA11y('vl-select-rich');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.options = [
+                { label: 'Hasselt', value: 'hasselt', selected: true },
+                { label: 'Turnhout', value: 'turnhout', selected: true },
+                { label: 'Knokke-Heist', value: 'knokke-heist', selected: true },
+                { label: 'Waregem', value: 'waregem', selected: true },
+                { label: 'Lier', value: 'lier', selected: true },
+                { label: 'Rio Piedras', value: 'rio piedras', selected: true },
+            ];
+        });
+
+        cy.get('vl-select-rich').shadow().find('select').find('option').should('have.attr', 'selected');
+    });
+
+    it('should remove all options programmatically', () => {
+        const options: SelectRichOption[] = [
+            { label: 'Padel', value: 'padel', selected: true },
+            { label: 'Dans', value: 'dans', selected: true },
+            { label: 'Drummen', value: 'drummen', selected: true },
+            { label: 'Zwemmen', value: 'zwemmen' },
+            { label: 'Boardgames', value: 'boardgames' },
+            { label: 'Fietsen', value: 'fietsen' },
+        ];
+
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Padel')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Dans')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Drummen')
+            .should('have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Zwemmen')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Boardgames')
+            .should('not.have.attr', 'selected');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('select')
+            .find('option')
+            .contains('Fietsen')
+            .should('not.have.attr', 'selected');
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.removeAllSelections();
+        });
+
+        cy.get('vl-select-rich').shadow().find('select').find('option').should('not.have.attr', 'selected');
+
         cy.checkA11y('vl-select-rich');
     });
 
     it('should return selected values when calling getSelected()', () => {
-        cy.mount(html`<vl-select-rich label="hobby's" multiple .options=${options}></vl-select-rich>`);
+        cy.mount(html`<vl-select-rich
+            label="hobby's"
+            placeholder="Vul hobby's in"
+            multiple
+            .options=${options}
+        ></vl-select-rich>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-select-rich');
         cy.runTestFor<VlSelectRichComponent>('vl-select-rich', (component) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(component.getSelected()).to.be.empty;
         });
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
@@ -797,6 +1438,7 @@ describe('component - vl-select-rich - single - in form', () => {
                     e.preventDefault();
                 }}
             >
+                <vl-form-label for="geboorteplaats">plaats</vl-form-label>
                 <vl-select-rich
                     id="geboorteplaats"
                     name="geboorteplaats"
@@ -857,5 +1499,135 @@ describe('component - vl-select-rich - single - in form', () => {
         cy.get('vl-select-rich').shadow().find('input.vl-input-field').type('Ha');
         cy.get('@mouseover').should('have.been.called');
         cy.get('@keydown').should('not.have.been.called');
+    });
+});
+
+describe('component - vl-select-rich - multiple - in form', () => {
+    const options: SelectRichOption[] = [
+        { label: 'Hasselt', value: 'hasselt', selected: true },
+        { label: 'Turnhout', value: 'turnhout' },
+        { label: 'Knokke-Heist', value: 'knokke-heist', selected: true },
+        { label: 'Waregem', value: 'waregem' },
+        { label: 'Lier', value: 'lier', selected: true },
+        { label: 'Rio Piedras', value: 'rio piedras' },
+    ];
+
+    beforeEach(() => {
+        cy.mount(html`
+            <form
+                id="form"
+                class="vl-form"
+                @submit=${(e: Event) => {
+                    e.preventDefault();
+                }}
+            >
+                <vl-form-label for="plaats">plaats</vl-form-label>
+                <vl-select-rich multiple id="plaats" name="plaats" .options=${options} search required></vl-select-rich>
+                <button class="vl-button" type="submit">Verstuur</button>
+                <button class="vl-button" type="reset">Reset</button>
+            </form>
+        `);
+    });
+
+    it('should submit value', () => {
+        const submittedFormData = {
+            plaats: ['hasselt', 'turnhout', 'knokke-heist', 'lier'],
+        };
+
+        cy.createStubForEvent('form', 'submit');
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Turnhout')
+            .click({ force: true });
+
+        cy.get('form').find('button[type="submit"]').click({ force: true });
+        cy.get('@submit').should('have.been.calledOnce');
+
+        cy.get('form').then(($el) => {
+            const formData = parseFormData($el.get(0) as HTMLFormElement);
+            expect(formData).to.deep.equal(submittedFormData);
+        });
+    });
+
+    it('should reset to initially checked options after selecting new option', () => {
+        const submittedFormData = {
+            plaats: ['hasselt', 'turnhout', 'knokke-heist', 'lier'],
+        };
+        const submittedAfterResetFormData = {
+            plaats: ['hasselt', 'knokke-heist', 'lier'],
+        };
+
+        cy.createStubForEvent('form', 'submit');
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Turnhout')
+            .click({ force: true });
+
+        cy.get('form').then(($el) => {
+            const formData = parseFormData($el.get(0) as HTMLFormElement);
+            expect(formData).to.deep.equal(submittedFormData);
+            cy.log(submittedFormData['plaats'].join(' '));
+        });
+
+        cy.get('form').find('button[type="reset"]').click({ force: true });
+
+        cy.get('form').then(($el) => {
+            const formData = parseFormData($el.get(0) as HTMLFormElement);
+            expect(formData).to.deep.equal(submittedAfterResetFormData);
+            cy.log(submittedAfterResetFormData['plaats'].join(' '));
+        });
+    });
+
+    it('should reset to initial options that are set after initial rendering', () => {
+        const submittedFormData = {
+            plaats: ['hasselt', 'turnhout', 'knokke-heist', 'lier'],
+        };
+        const submittedAfterResetFormData = {
+            plaats: ['waregem', 'rio piedras'],
+        };
+
+        cy.createStubForEvent('form', 'submit');
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('Turnhout')
+            .click({ force: true });
+
+        cy.get('form').then(($el) => {
+            const formData = parseFormData($el.get(0) as HTMLFormElement);
+            cy.log(submittedFormData['plaats'].join(' '));
+            expect(formData).to.deep.equal(submittedFormData);
+        });
+
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.initialOptions = [
+                { label: 'Hasselt', value: 'hasselt' },
+                { label: 'Turnhout', value: 'turnhout' },
+                { label: 'Knokke-Heist', value: 'knokke-heist' },
+                { label: 'Waregem', value: 'waregem', selected: true },
+                { label: 'Lier', value: 'lier' },
+                { label: 'Rio Piedras', value: 'rio piedras', selected: true },
+            ];
+        });
+
+        cy.get('form').find('button[type="reset"]').click({ force: true });
+
+        cy.get('form').then(($el) => {
+            const formData = parseFormData($el.get(0) as HTMLFormElement);
+            cy.log(submittedAfterResetFormData['plaats'].join(' '));
+            expect(formData).to.deep.equal(submittedAfterResetFormData);
+        });
     });
 });

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -3,7 +3,7 @@ import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
 import { iconStyle } from '@domg/govflanders-style/component';
 import { FormValue } from '@open-wc/form-control/src/types';
 import * as choices from 'choices.js';
-import { Item, Options } from 'choices.js';
+import { Options } from 'choices.js';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FormControl } from '../form-control';
@@ -23,6 +23,7 @@ export type Choices = choices.default;
 export class VlSelectRichComponent extends FormControl {
     // Properties
     options = selectRichDefaults.options;
+    initialOptions = selectRichDefaults.initialOptions;
     protected placeholder = selectRichDefaults.placeholder;
     protected search = selectRichDefaults.search;
     protected searchPlaceholder = selectRichDefaults.searchPlaceholder;
@@ -37,8 +38,8 @@ export class VlSelectRichComponent extends FormControl {
     private noChoicesText = selectRichDefaults.noChoicesText;
     // State
     private value: FormValue = null;
-    private dispatchInput = false;
-    private initialOptions: SelectRichOption[] = [];
+    private dropdownInitialised = false;
+    private isDropdownOpen = false;
 
     constructor() {
         super();
@@ -60,6 +61,7 @@ export class VlSelectRichComponent extends FormControl {
 
     static get properties(): PropertyDeclarations {
         return {
+            initialOptions: { type: Array, attribute: 'initial-options' },
             options: { type: Array },
             placeholder: { type: String },
             notDeletable: { type: Boolean, attribute: 'not-deletable' },
@@ -96,12 +98,6 @@ export class VlSelectRichComponent extends FormControl {
         this.initialOptions = [...JSON.parse(JSON.stringify(this.options))];
 
         setTimeout(() => {
-            // Fix voor Choices.js dropdown te openen in een Shadow DOM
-            this.getChoicesElement()?.addEventListener('click', this.onClickChoices);
-
-            // Fix voor Choices.js dropdown te openen als er geklikt wordt op het label
-            this.internals.labels[0]?.addEventListener('click', this.onClickChoices);
-
             // Fix voor required validator
             if (!this.value) {
                 this.setValue(null);
@@ -112,6 +108,29 @@ export class VlSelectRichComponent extends FormControl {
         }, 0);
     }
 
+    private callbackOnInit = (): void => {
+        // Fix voor Choices.js dropdown te openen in een Shadow DOM
+        this.getChoicesElement()?.addEventListener('click', this.onClickChoices);
+
+        // Fix voor Choices.js dropdown te openen als er geklikt wordt op het label
+        this.internals.labels[0]?.addEventListener('click', this.onClickChoices);
+
+        this.getChoicesElement()?.addEventListener('showDropdown', () => {
+            const dropdownElement = this.getChoicesElement()?.querySelector('.vl-select__list--dropdown');
+            if (dropdownElement && !this.dropdownInitialised) {
+                dropdownElement.setAttribute('role', 'group');
+                dropdownElement.setAttribute('id', 'vl-select__list');
+                this.dropdownInitialised = true;
+            }
+            this.isDropdownOpen = true;
+        });
+        this.getChoicesElement()?.addEventListener('hideDropdown', () => {
+            this.isDropdownOpen = false;
+        });
+
+        this.setChoicesInputAttributes();
+    };
+
     updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
 
@@ -121,20 +140,17 @@ export class VlSelectRichComponent extends FormControl {
 
         if (changedProperties.has('options')) {
             this.choices.clearStore();
-            this.choices.setChoices(this.getOptions(), 'value', 'label', true);
-            this.onChange();
+            this.choices.setChoices(this.options, 'value', 'label', true);
+            this.updateSelectedOptions(this.options);
         }
 
         if (changedProperties.has('value')) {
             const detail = { value: this.getSelected() };
-
             this.setValue(this.value);
             this.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true, detail }));
-            if (this.dispatchInput) {
-                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
-                this.dispatchInput = false;
+            if (this.validity.valid) {
+                this.dispatchEventIfValid(detail);
             }
-            this.dispatchEventIfValid(detail);
         }
 
         if (changedProperties.has('disabled')) {
@@ -156,10 +172,10 @@ export class VlSelectRichComponent extends FormControl {
 
     disconnectedCallback() {
         super.disconnectedCallback();
-
         this.getChoicesElement()?.removeEventListener('click', this.onClickChoices);
         this.internals.labels[0]?.removeEventListener('click', this.onClickChoices);
         this.choices?.input?.element?.removeEventListener('input', this.onSearchInput);
+        this.choices?.destroy();
     }
 
     render(): TemplateResult {
@@ -182,21 +198,92 @@ export class VlSelectRichComponent extends FormControl {
                 ?disabled=${this.disabled}
                 ?error=${this.error}
                 ?multiple=${this.multiple}
-                @change=${this.onChange}
-                @choice=${this.onSelect}
-                @removeItem=${this.onSelect}
+                @change=${this.onInput}
+                @addItem=${this.onChange}
+                @removeItem=${this.onChange}
             ></select>
         `;
     }
 
+    /**
+     * Reset de form control naar de initiële staat.
+     */
     resetFormControl() {
         super.resetFormControl();
 
-        this.options = [...this.initialOptions];
+        this.choices?.clearStore();
+        this.choices?.setChoices(this.options, 'value', 'label', true);
+        this.updateSelectedOptions(this.initialOptions);
+        this.onChange();
+    }
+
+    /**
+     * Vervangt de huidige opties van de select.
+     * @param options
+     */
+    setOptions(options: SelectRichOption[]): void {
+        if (!options || !options.length) {
+            return;
+        }
+        this.options = [...JSON.parse(JSON.stringify(options))];
+    }
+
+    /**
+     * Update de opties van de select met de opgegeven opties.
+     * @param options
+     */
+    updateSelectedOptions(options: SelectRichOption[]): void {
+        const selectedValues = options.filter((option) => option.selected).map((option) => option.value);
+        const unselectedValues = options.filter((option) => !option.selected).map((option) => option.value);
+        this.removeSelectionByValue(unselectedValues);
+        this.selectByValue(selectedValues);
     }
 
     getSelected(): string | string[] | null {
         return this.multiple ? this.getSelectedValues() : this.getSelectedValues()[0] || null;
+    }
+
+    /**
+     * Selecteert 1 of meerdere keuzes op basis van de opgegeven waarde(s).
+     * @param value
+     */
+    selectByValue(value: string | string[]): void {
+        if (!this.choices) {
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            this.choices.setChoiceByValue(value);
+        } else {
+            this.choices.setChoiceByValue([value]);
+        }
+    }
+
+    /**
+     * Deselecteert 1 of meerdere keuzes op basis van de opgegeven waarde(s).
+     * @param value
+     */
+    removeSelectionByValue(value: string | string[]): void {
+        if (!this.choices) {
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach((val) => this.choices!.removeActiveItemsByValue(val));
+        } else {
+            this.choices.removeActiveItemsByValue(value);
+        }
+    }
+
+    /**
+     * Verwijdert alle selecties.
+     */
+    removeAllSelections(): void {
+        if (!this.choices) {
+            return;
+        }
+
+        this.choices.removeActiveItems();
     }
 
     protected onKeydown(event: KeyboardEvent) {
@@ -206,12 +293,26 @@ export class VlSelectRichComponent extends FormControl {
         super.onKeydown(event);
     }
 
+    private setChoicesInputAttributes(): void {
+        if (this.choices?.input?.element) {
+            const inputElement = this.choices.input.element;
+            inputElement.setAttribute('type', 'text');
+            inputElement.classList.add('vl-input-field', 'vl-input-field-cloned');
+            inputElement.setAttribute('autocomplete', 'off');
+            inputElement.setAttribute('autocapitalize', 'off');
+            inputElement.setAttribute('spellcheck', 'false');
+            inputElement.setAttribute('role', 'textbox');
+            inputElement.setAttribute('aria-autocomplete', 'list');
+            inputElement.setAttribute('aria-label', 'zoek item');
+        }
+    }
+
     private getSelectedValues(): string[] {
         const selectedOptions = (this.validationTarget! as HTMLSelectElement).selectedOptions;
         return (
             Array.from(selectedOptions)
-                // Filter placeholder optie eruit
-                .filter((option) => option.value)
+                // Filter placeholders en niet-geselecteerde opties eruit
+                .filter((option) => option.value && option.hasAttribute('selected'))
                 .map((option) => option.value)
         );
     }
@@ -221,6 +322,7 @@ export class VlSelectRichComponent extends FormControl {
         const selectedValues = this.getSelectedValues();
         return selectedValues?.length
             ? selectedValues.reduce((formData: FormData, string, currentIndex) => {
+                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
                   currentIndex ? formData.append(name, string) : formData.set(name, string);
                   return formData;
               }, new FormData())
@@ -233,6 +335,7 @@ export class VlSelectRichComponent extends FormControl {
 
     private getChoicesConfig(): Partial<Options> {
         return {
+            callbackOnInit: this.callbackOnInit,
             shouldSort: false,
             removeItemButton: !this.notDeletable,
             removeItems: !this.notDeletable,
@@ -253,7 +356,7 @@ export class VlSelectRichComponent extends FormControl {
                 list: 'vl-select__list',
                 listItems: 'vl-select__list--multiple',
                 listSingle: 'vl-select__list--single',
-                listDropdown: 'vl-select__list--dropdown',
+                listDropdown: ['vl-select__list', 'vl-select__list--dropdown'],
                 item: 'vl-select__item',
                 itemSelectable: 'vl-select__item--selectable',
                 itemDisabled: 'vl-select__item--disabled',
@@ -267,29 +370,33 @@ export class VlSelectRichComponent extends FormControl {
                 return {
                     containerOuter: () => {
                         return template(
-                            `<div
+                            `
+                            <div
                                 class="js-vl-select vl-vi vl-vi-nav-down"
                                 data-type="${this.multiple ? 'select-multiple' : 'select-one'}"
                                 ${this.search ? 'aria-autocomplete="list"' : ''}
-                                role="combobox"
                                 part="vl-select-rich__combobox"
+                                role="combobox"
                                 aria-haspopup="true"
-                                aria-expanded="false"
+                                aria-expanded=${this.isDropdownOpen ? 'true' : 'false'}
                                 tabindex="0"
                                 aria-controls="vl-select__list"
                                 aria-label="${
                                     this.multiple ? 'selecteer één of meerdere opties' : 'selecteer één optie'
-                                }">
-                            </div>`
-                        );
+                                }"
+                            ></div>
+                            `
+                        ) as HTMLDivElement;
                     },
-                    item: (_config: Partial<Options>, data: Item) => {
+                    item: (_config: Partial<Options>, data: SelectRichOption) => {
+                        const isPlaceholder = data.placeholder === true;
                         if (this.notDeletable) {
                             return template(`
                             <div class="vl-select__item
                                 ${data.highlighted ? 'is-highlighted' : 'vl-select__item--selectable'}
                                 ${this.multiple ? 'vl-pill' : ''}
                                 ${data.placeholder ? 'vl-select__placeholder' : ''}"
+                                role="option"
                                 data-item
                                 data-id="${data.id}"
                                 data-value="${data.value}"
@@ -297,7 +404,7 @@ export class VlSelectRichComponent extends FormControl {
                             >
                                 ${data.label}
                             </div>
-                        `);
+                        `) as HTMLDivElement;
                         }
 
                         return template(
@@ -310,12 +417,15 @@ export class VlSelectRichComponent extends FormControl {
                                     data-item
                                     data-id="${data.id}"
                                     data-value="${data.value}"
+                                            ${isPlaceholder ? 'role="option"' : ''}
                                     ${data.disabled ? 'aria-disabled="true"' : 'data-deletable'}
                                 >
                                     <span>${data.label}</span>
-                                    <button type="button" class="vl-pill__close ${
-                                        !this.multiple ? 'vl-vi vl-vi-close' : ''
-                                    }" data-button aria-label="verwijder">
+                                    <button type="button"
+                                    ${isPlaceholder ? '' : 'role="option"'}
+                                     class="vl-pill__close ${
+                                         !this.multiple ? 'vl-vi vl-vi-close' : ''
+                                     }" data-button aria-label="verwijder ${data.label}">
                                         ${
                                             this.multiple
                                                 ? `<span class="vl-pill__close__icon vl-vi vl-vi-close" aria-hidden="true"></span>`
@@ -323,67 +433,41 @@ export class VlSelectRichComponent extends FormControl {
                                         }
                                     </button>
                                 </div>`
-                        );
+                        ) as HTMLDivElement;
                     },
-
-                    itemList: () => {
-                        if (!this.multiple) {
-                            return template(`<div class="vl-input-field"></div>`);
-                        }
-
-                        return template(`<div class="vl-input-field vl-select__list--multiple"></div>`);
-                    },
-                    input: () => {
-                        return template(
-                            `<input
-                                    type="text"
-                                    class="vl-input-field vl-input-field-cloned"
-                                    autocomplete="off"
-                                    autocapitalize="off"
-                                    spellcheck="false"
-                                    role="textbox"
-                                    aria-autocomplete="list"
-                                    aria-label="zoek item">`
-                        );
-                    },
-                    dropdown: () => {
-                        return template(
-                            `<div class="vl-select__list vl-select__list--dropdown" role="group" id="vl-select__list"></div>`
-                        );
-                    },
-                    choiceList: () => {
-                        return template(
+                    itemList: () =>
+                        template(
+                            `<div class="vl-input-field ${
+                                !this.multiple ? '' : 'vl-select__list--multiple'
+                            }" role="listbox"></div>`
+                        ) as HTMLDivElement,
+                    choiceList: () =>
+                        template(
                             `<div class="vl-select__list" role="listbox" aria-label="item lijst" tabindex="0"></div>`
-                        );
-                    },
+                        ) as HTMLDivElement,
                 };
             },
         };
     }
 
-    private getOptions(): SelectRichOption[] {
-        const options = [...this.options];
-
-        if (this.placeholder && !this.multiple) {
-            const placeholderOption: SelectRichOption = {
-                value: '',
-                label: this.placeholder,
-                placeholder: true,
-                disabled: true,
-                selected: true,
-            };
-            options.unshift(placeholderOption);
-        }
-
-        return options;
-    }
-
+    /**
+     * Event handler voor de change event van de select. Deze wordt aangeroepen wanneer de waarde van de
+     * select verandert, ongeacht de bron (bijv. door de gebruiker of door code).
+     * @private
+     */
     private onChange() {
         this.value = this.collectFormData();
     }
 
-    private onSelect() {
-        this.dispatchInput = true;
+    /**
+     * Event handler voor de input event van de select. Deze wordt aangeroepen wanneer de gebruiker
+     * de waarde van de select wijzigt.
+     * @private
+     */
+    private onInput() {
+        this.dispatchEvent(
+            new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: this.getSelected() } })
+        );
     }
 
     private onClickChoices = (event: Event) => {

--- a/libs/components/src/form/select-rich/vl-select-rich.defaults.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.defaults.ts
@@ -3,6 +3,7 @@ import { SelectRichOption, SelectRichPosition } from './vl-select-rich.model';
 
 export const selectRichDefaults = {
     ...formControlDefaults,
+    initialOptions: [] as SelectRichOption[],
     options: [] as SelectRichOption[],
     placeholder: '' as string,
     notDeletable: false as boolean,

--- a/libs/components/src/form/select-rich/vl-select-rich.model.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.model.ts
@@ -1,6 +1,11 @@
-import { Choice } from 'choices.js';
+import { InputChoice } from 'choices.js/src/scripts/interfaces/input-choice';
+import { InputGroup } from 'choices.js/src/scripts/interfaces/input-group';
 
-export type SelectRichOption = Choice;
+type MergeToOptional<T, U> = Pick<T, Extract<keyof T, keyof U>> & // gedeelde velden blijven required
+    Partial<Omit<T, keyof U>> & // velden enkel in T (optioneel)
+    Partial<Omit<U, keyof T>>; // velden enkel in U (optioneel)
+
+export type SelectRichOption = MergeToOptional<InputChoice, InputGroup>;
 
 export const SelectRichPosition = {
     AUTO: 'auto',

--- a/libs/integrations/src/form/demo/vl-form-demo.component.cy.ts
+++ b/libs/integrations/src/form/demo/vl-form-demo.component.cy.ts
@@ -139,13 +139,19 @@ describe('integrations - form demo', () => {
             expect(component.value).to.be.empty;
         });
         getGeboortedatumDatepicker().find('input#geboortedatum').should('have.value', '');
-        getGeboortePlaatsSelectRich().find('select').find('option[value="hasselt"]').should('not.exist');
-        getHobbiesSelectRich().find('select').find('option[value="padel"]').should('not.exist');
-        getHobbiesSelectRich().find('select').find('option[value="dans"]').should('not.exist');
+        getGeboortePlaatsSelectRich()
+            .find('select')
+            .find('option[value="hasselt"]')
+            .should('not.have.attr', 'selected');
+
+        getHobbiesSelectRich().find('select').find('option[value="padel"]').should('not.have.attr', 'selected');
+        getHobbiesSelectRich().find('select').find('option[value="dans"]').should('not.have.attr', 'selected');
+
         getHobbiesSelectRich({ shadow: false }).runTest((component) => {
             // @ts-ignore access private property
             expect(component.value).to.be.null;
         });
+
         getKinderenSelect().find('select').find('option[value="0"]').should('not.have.attr', 'selected');
         getInteressesTextarea().find('textarea').should('have.value', '');
         getLeeftijdInput().find('input').should('have.value', '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@open-wc/form-control": "1.0.0",
                 "@open-wc/form-helpers": "1.0.0",
                 "@ungap/custom-elements": "1.3.0",
-                "choices.js": "10.2.0",
+                "choices.js": "11.1.0",
                 "cleave.js": "1.6.0",
                 "composed-offset-position": "0.0.4",
                 "construct-style-sheets-polyfill": "3.1.0",
@@ -1990,6 +1990,7 @@
             "version": "7.23.8",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.23.8.tgz",
             "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -10876,13 +10877,11 @@
             }
         },
         "node_modules/choices.js": {
-            "version": "10.2.0",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/choices.js/-/choices.js-10.2.0.tgz",
-            "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+            "version": "11.1.0",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/choices.js/-/choices.js-11.1.0.tgz",
+            "integrity": "sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==",
             "dependencies": {
-                "deepmerge": "^4.2.2",
-                "fuse.js": "^6.6.2",
-                "redux": "^4.2.0"
+                "fuse.js": "^7.0.0"
             }
         },
         "node_modules/chokidar": {
@@ -12347,6 +12346,7 @@
             "version": "4.3.1",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14677,9 +14677,9 @@
             "dev": true
         },
         "node_modules/fuse.js": {
-            "version": "6.6.2",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-6.6.2.tgz",
-            "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+            "version": "7.1.0",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/fuse.js/-/fuse.js-7.1.0.tgz",
+            "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
             "engines": {
                 "node": ">=10"
             }
@@ -24179,14 +24179,6 @@
                 "node": ">= 10.13.0"
             }
         },
-        "node_modules/redux": {
-            "version": "4.2.1",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dependencies": {
-                "@babel/runtime": "^7.9.2"
-            }
-        },
         "node_modules/reflect-metadata": {
             "version": "0.2.1",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
@@ -24213,7 +24205,8 @@
         "node_modules/regenerator-runtime": {
             "version": "0.14.1",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+            "dev": true
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "@open-wc/form-control": "1.0.0",
         "@open-wc/form-helpers": "1.0.0",
         "@ungap/custom-elements": "1.3.0",
-        "choices.js": "10.2.0",
+        "choices.js": "11.1.0",
         "cleave.js": "1.6.0",
         "composed-offset-position": "0.0.4",
         "construct-style-sheets-polyfill": "3.1.0",


### PR DESCRIPTION
De vl-select-rich gebruikt choices.js library om de select aan te sturen. Bij deze is versie bijgewerkt van 10.2 naar 11.1. Daarnaast zijn ook enkele verbeteringen doorgevoerd in de select-rich component.

[Bamboo](https://www.milieuinfo.be/bamboo/chain/viewChain.action?planKey=FLUX-CFWC23)
[Jira](https://www.milieuinfo.be/jira/browse/FLUX-77)