### PR TITLE
fix: FLUX-125 - vl-stacked - margin-top door row-gap vervangen

### DIFF
--- a/apps/storybook-e2e/src/e2e/styles/layout/stacked/vl-stacked.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/styles/layout/stacked/vl-stacked.stories.cy.ts
@@ -10,10 +10,10 @@ describe('story - stacked - large', () => {
         cy.visit(stackedLargeUrl);
 
         cy.viewport(1920, 1080);
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '60px' });
+        cy.get('.vl-grid').shouldHaveComputedStyle({ style: 'row-gap', value: '60px' });
 
         cy.viewport(375, 667);
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '30px' });
+        cy.get('.vl-grid').shouldHaveComputedStyle({ style: 'row-gap', value: '30px' });
     });
 });
 
@@ -21,7 +21,7 @@ describe('story - stacked - medium', () => {
     it('should render', () => {
         cy.visit(stackedMediumUrl);
 
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '30px' });
+        cy.get('.vl-grid').shouldHaveComputedStyle({ style: 'row-gap', value: '30px' });
     });
 });
 
@@ -29,6 +29,6 @@ describe('story - stacked - small', () => {
     it('should render', () => {
         cy.visit(stackedSmallUrl);
 
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '15px' });
+        cy.get('.vl-grid').shouldHaveComputedStyle({ style: 'row-gap', value: '15px' });
     });
 });

--- a/libs/integrations/src/form/demo/vl-form-demo.component.ts
+++ b/libs/integrations/src/form/demo/vl-form-demo.component.ts
@@ -1,5 +1,5 @@
 import { registerWebComponents, webComponent } from '@domg-wc/common';
-import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { vlGridStyles, vlLegacyStyles, vlStackedStyles } from '@domg-wc/styles';
 import { VlButtonComponent, VlTextComponent } from '@domg-wc/components/atom';
 import {
     parseFormData,
@@ -82,6 +82,7 @@ export class VlFormDemoComponent extends LitElement {
         return [
             vlLegacyStyles,
             vlGridStyles,
+            vlStackedStyles,
             css`
                 form {
                     margin-top: 1rem;
@@ -100,7 +101,7 @@ export class VlFormDemoComponent extends LitElement {
     override render() {
         return html`
             <form id="form" class="vl-form" @submit=${this.onSubmit}>
-                <div class="vl-grid">
+                <div class="vl-grid vl-stacked-small">
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="naam" label="Naam *"></vl-form-label>
                         <vl-text annotation small>(enkel achternaam)</vl-text>

--- a/libs/styles/src/layout/stacked/stories/vl-stacked.stories-doc.mdx
+++ b/libs/styles/src/layout/stacked/stories/vl-stacked.stories-doc.mdx
@@ -17,7 +17,7 @@ import * as VlStackedStories from './vl-stacked.stories';
 
 ## Doel
 
-De 'stacked' style-classes beïnvloeden de ruimte tussen kind items.
+De 'stacked' style-classes beïnvloeden de ruimte tussen kind items binnen Flexbox of Grid containers
 
 ## Gebruik
 

--- a/libs/styles/src/layout/stacked/vl-stacked.css.cy.ts
+++ b/libs/styles/src/layout/stacked/vl-stacked.css.cy.ts
@@ -20,30 +20,37 @@ describe('stacked styles', () => {
         cy.then(() => GlobalStyles.getInstance().register());
         cy.mount(stackedLarge);
         cy.viewport(1100, 800);
-        cy.get('.vl-column').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
-        });
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '60px 0px 0px',
-        });
-        cy.get('.vl-column').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '60px 0px 0px',
+        cy.get('.vl-grid').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '60px',
         });
         cy.viewport(700, 800);
-        cy.get('.vl-column').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
+        cy.get('.vl-grid').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '30px',
         });
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '30px 0px 0px',
-        });
-        cy.get('.vl-column').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '30px 0px 0px',
+    });
+
+    const stackedMedium = html`
+        <style>
+            .vl-grid .vl-column {
+                background-color: mediumspringgreen;
+                border: lightseagreen 2px solid;
+            }
+        </style>
+        <div class="vl-grid vl-stacked-medium">
+            <div class="vl-column vl-column--8 vl-column--start-3"></div>
+            <div class="vl-column vl-column--8 vl-column--start-3"></div>
+            <div class="vl-column vl-column--8 vl-column--start-3"></div>
+        </div>
+    `;
+
+    it('should have medium stacked style', () => {
+        cy.then(() => GlobalStyles.getInstance().register());
+        cy.mount(stackedMedium);
+        cy.get('.vl-grid').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '30px',
         });
     });
 
@@ -64,17 +71,9 @@ describe('stacked styles', () => {
     it('should have small stacked style', () => {
         cy.then(() => GlobalStyles.getInstance().register());
         cy.mount(stackedSmall);
-        cy.get('.vl-column').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
-        });
-        cy.get('.vl-column').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '15px 0px 0px',
-        });
-        cy.get('.vl-column').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '15px 0px 0px',
+        cy.get('.vl-grid').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '15px',
         });
     });
 });

--- a/libs/styles/src/layout/stacked/vl-stacked.css.ts
+++ b/libs/styles/src/layout/stacked/vl-stacked.css.ts
@@ -1,26 +1,20 @@
 import { css, CSSResult } from 'lit';
 import { vlMediaScreenMedium } from '../../base/var/vl-media-screen.css';
 
-// TODO margin-top, kan dat niet gwn row-gap zijn?
 export const vlStackedStyles: CSSResult = css`
     .vl-stacked-medium {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--medium);
-        }
+        row-gap: var(--vl-spacing--medium);
     }
 
     .vl-stacked-large {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--large);
+        row-gap: var(--vl-spacing--large);
 
-            @media screen and (max-width: ${vlMediaScreenMedium}px) {
-                margin-top: var(--vl-spacing--medium);
-            }
+        @media screen and (max-width: ${vlMediaScreenMedium}px) {
+            row-gap: var(--vl-spacing--medium);
         }
     }
 
     .vl-stacked-small {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--small);
+        row-gap: var(--vl-spacing--small);
     }
 `;


### PR DESCRIPTION
De selector met > *:not(:first-child), werkt als er maar 1 kolom is. Echter, als er meerdere kolommen zijn in bijvoorbeeld een grid layout, dan zal dit de layout breken, met row-gap spreken we de native manier aan om witruimte in grid & flexbox layouts te wijzigen. Dit heeft wel als gevolg dat vl-stacked styling niet meer zal werken buiten flexbox & grid context.

[Jira](https://www.milieuinfo.be/jira/browse/FLUX-125)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC36)