### PR TITLE
fix: FLUX-125 - vl-stacked - margin-top door row-gap vervangen

### DIFF
--- a/apps/storybook-e2e/src/e2e/styles/layout/stacked/vl-stacked.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/styles/layout/stacked/vl-stacked.stories.cy.ts
@@ -10,10 +10,10 @@ describe('story - stacked-next - large', () => {
         cy.visit(stackedNextLargeUrl);
 
         cy.viewport(1920, 1080);
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '60px' });
+        cy.get('.vl-grid-next').shouldHaveComputedStyle({ style: 'row-gap', value: '60px' });
 
         cy.viewport(375, 667);
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '30px' });
+        cy.get('.vl-grid-next').shouldHaveComputedStyle({ style: 'row-gap', value: '30px' });
     });
 });
 
@@ -21,7 +21,7 @@ describe('story - stacked-next - medium', () => {
     it('should render', () => {
         cy.visit(stackedNextMediumUrl);
 
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '30px' });
+        cy.get('.vl-grid-next').shouldHaveComputedStyle({ style: 'row-gap', value: '30px' });
     });
 });
 
@@ -29,6 +29,6 @@ describe('story - stacked-next - small', () => {
     it('should render', () => {
         cy.visit(stackedNextSmallUrl);
 
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({ style: 'margin-top', value: '15px' });
+        cy.get('.vl-grid-next').shouldHaveComputedStyle({ style: 'row-gap', value: '15px' });
     });
 });

--- a/libs/common/utilities/src/css/layout/stacked/stories/vl-stacked.stories-doc.mdx
+++ b/libs/common/utilities/src/css/layout/stacked/stories/vl-stacked.stories-doc.mdx
@@ -17,7 +17,7 @@ import * as VlStackedStories from './vl-stacked.stories';
 
 ## Doel
 
-De 'stacked' style-classes beïnvloeden de ruimte tussen kind items.
+De 'stacked' style-classes beïnvloeden de ruimte tussen kind items binnen Flexbox of Grid containers
 
 ## Gebruik
 

--- a/libs/common/utilities/src/css/layout/stacked/vl-stacked.css.cy.ts
+++ b/libs/common/utilities/src/css/layout/stacked/vl-stacked.css.cy.ts
@@ -20,30 +20,37 @@ describe('stacked styles', () => {
         cy.then(() => GlobalStyles.getInstance().register());
         cy.mount(stackedLarge);
         cy.viewport(1100, 800);
-        cy.get('.vl-column-next').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
-        });
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '60px 0px 0px',
-        });
-        cy.get('.vl-column-next').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '60px 0px 0px',
+        cy.get('.vl-grid-next').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '60px',
         });
         cy.viewport(700, 800);
-        cy.get('.vl-column-next').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
+        cy.get('.vl-grid-next').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '30px',
         });
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '30px 0px 0px',
-        });
-        cy.get('.vl-column-next').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '30px 0px 0px',
+    });
+
+    const stackedMedium = html`
+        <style>
+            .vl-grid-next .vl-column-next {
+                background-color: mediumspringgreen;
+                border: lightseagreen 2px solid;
+            }
+        </style>
+        <div class="vl-grid-next vl-stacked-next-medium">
+            <div class="vl-column-next vl-column-next--8 vl-column-next--start-3"></div>
+            <div class="vl-column-next vl-column-next--8 vl-column-next--start-3"></div>
+            <div class="vl-column-next vl-column-next--8 vl-column-next--start-3"></div>
+        </div>
+    `;
+
+    it('should have medium stacked style', () => {
+        cy.then(() => GlobalStyles.getInstance().register());
+        cy.mount(stackedMedium);
+        cy.get('.vl-grid-next').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '30px',
         });
     });
 
@@ -64,17 +71,9 @@ describe('stacked styles', () => {
     it('should have small stacked style', () => {
         cy.then(() => GlobalStyles.getInstance().register());
         cy.mount(stackedSmall);
-        cy.get('.vl-column-next').eq(0).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '0px',
-        });
-        cy.get('.vl-column-next').eq(1).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '15px 0px 0px',
-        });
-        cy.get('.vl-column-next').eq(2).shouldHaveComputedStyle({
-            style: 'margin',
-            value: '15px 0px 0px',
+        cy.get('.vl-grid-next').eq(0).shouldHaveComputedStyle({
+            style: 'row-gap',
+            value: '15px',
         });
     });
 });

--- a/libs/common/utilities/src/css/layout/stacked/vl-stacked.css.ts
+++ b/libs/common/utilities/src/css/layout/stacked/vl-stacked.css.ts
@@ -1,26 +1,20 @@
 import { css, CSSResult } from 'lit';
 import { vlMediaScreenMedium } from '../../base/var/vl-media-screen.css';
 
-// TODO margin-top, kan dat niet gwn row-gap zijn?
 export const vlStackedStyles: CSSResult = css`
     .vl-stacked-next-medium {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--medium);
-        }
+        row-gap: var(--vl-spacing--medium);
     }
 
     .vl-stacked-next-large {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--large);
+        row-gap: var(--vl-spacing--large);
 
-            @media screen and (max-width: ${vlMediaScreenMedium}px) {
-                margin-top: var(--vl-spacing--medium);
-            }
+        @media screen and (max-width: ${vlMediaScreenMedium}px) {
+            row-gap: var(--vl-spacing--medium);
         }
     }
 
     .vl-stacked-next-small {
-        > *:not(:first-child) {
-            margin-top: var(--vl-spacing--small);
+        row-gap: var(--vl-spacing--small);
     }
 `;

--- a/libs/integration/src/form/demo/vl-form-demo.component.ts
+++ b/libs/integration/src/form/demo/vl-form-demo.component.ts
@@ -97,7 +97,7 @@ export class VlFormDemoComponent extends LitElement {
     override render() {
         return html`
             <form id="form" class="vl-form" @submit=${this.onSubmit}>
-                <div class="vl-grid-next">
+                <div class="vl-grid-next vl-stacked-next-small">
                     <div class="vl-column-next vl-column-next--4 vl-column-next--s-12">
                         <vl-form-label-next for="naam" label="Naam *"></vl-form-label-next>
                         <vl-text-next annotation small>(enkel achternaam)</vl-text-next>
@@ -140,11 +140,11 @@ export class VlFormDemoComponent extends LitElement {
                             placeholder="bv. 86-12-31-123-45"
                         ></vl-input-field-masked-next>
                         <vl-error-message-next for="rrn" state="valueMissing"
-                            >Gelieve een rijksregisternummer in te vullen.</vl-error-message-next
-                        >
+                            >Gelieve een rijksregisternummer in te vullen.
+                        </vl-error-message-next>
                         <vl-error-message-next for="rrn" state="patternMismatch"
-                            >Gelieve een geldig rijksregisternummer in te vullen.</vl-error-message-next
-                        >
+                            >Gelieve een geldig rijksregisternummer in te vullen.
+                        </vl-error-message-next>
                     </div>
                     <div class="vl-column-next vl-column-next--4 vl-column-next--s-12">
                         <vl-form-label-next for="geboortedatum" label="Geboortedatum *" block></vl-form-label-next>


### PR DESCRIPTION
De selector met > *:not(:first-child), werkt als er maar 1 kolom is. Echter, als er meerdere kolommen zijn in bijvoorbeeld een grid layout, dan zal dit de layout breken, met row-gap spreken we de native manier aan om witruimte in grid & flexbox layouts te wijzigen. Dit heeft wel als gevolg dat vl-stacked styling niet meer zal werken buiten flexbox & grid context.

[Jira](https://www.milieuinfo.be/jira/browse/FLUX-125)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC37)