### PR TITLE
fix: FLUX-128 - vl-info-tile - volgorde imports rechtgezet

### DIFF
--- a/libs/components/src/info-tile/vl-info-tile.component.ts
+++ b/libs/components/src/info-tile/vl-info-tile.component.ts
@@ -1,9 +1,9 @@
-import { BaseHTMLElement, registerWebComponents, VL, webComponent, isSlotEmpty } from '@domg-wc/common-utilities';
+import { BaseHTMLElement, isSlotEmpty, registerWebComponents, VL, webComponent } from '@domg-wc/common-utilities';
 import { vlElementsStyle } from '@domg-wc/elements';
 import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
 import { accordionStyle, iconStyle, infoTileStyle, linkStyle, toggleStyle } from '@domg/govflanders-style/component';
-import '@govflanders/vl-ui-accordion/dist/js/accordion.js';
 import '@govflanders/vl-ui-util/dist/js/util.js';
+import '@govflanders/vl-ui-accordion/dist/js/accordion.js';
 import 'reflect-metadata';
 import { VlAccordionComponent } from '../accordion/vl-accordion.component';
 import infoTileUigStyle from './vl-info-tile.uig-css';


### PR DESCRIPTION
De volgorde van imports in de vl-info-tile is incorrect. In die accordion.js wordt dan het vl-object gebruikt die nog niet is aangemaakt. Dit werkte vroeger per ongeluk afhankelijk van andere componenten die wel het vl-object aanmaakten voor de vl-info-tile werd geregistreerd.

[Jira](https://www.milieuinfo.be/jira/browse/FLUX-128)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC40)