### PR TITLE
fix: FLUX-122 - vl-toaster - werking verbeterd

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/toaster/vl-toaster.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/toaster/vl-toaster.stories.cy.ts
@@ -1,11 +1,13 @@
 const toasterDefaultUrl =
     'http://localhost:8080/iframe.html?args=&id=components-block-toaster--toaster-default&viewMode=story';
+const toasterDefaultSlottUrl =
+    'http://localhost:8080/iframe.html?args=&id=components-block-toaster--toaster-default-slot&viewMode=story';
 const toasterShowAlertUrl =
     'http://localhost:8080/iframe.html?args=&id=components-block-toaster--toaster-show-alert&viewMode=story';
 const toasterFadeOutStoryUrl =
     'http://localhost:8080/iframe.html?args=&id=components-block-toaster--toaster-fade-out&viewMode=story';
 
-describe('story vl-toaster', () => {
+describe('story - vl-toaster', () => {
     it('should render', () => {
         cy.visit(toasterDefaultUrl);
 
@@ -13,7 +15,15 @@ describe('story vl-toaster', () => {
     });
 });
 
-describe('story vl-toaster show alert', () => {
+describe('story - vl-toaster - default slot', () => {
+    it('should render', () => {
+        cy.visit(toasterDefaultSlottUrl);
+
+        cy.get('vl-toaster').shadow().find('output');
+    });
+});
+
+describe('story - vl-toaster - show alert', () => {
     it('should render', () => {
         cy.visit(toasterShowAlertUrl);
 
@@ -21,7 +31,7 @@ describe('story vl-toaster show alert', () => {
     });
 });
 
-describe('story vl-toaster fade out', () => {
+describe('story - vl-toaster - fade out', () => {
     it('should render', () => {
         cy.visit(toasterFadeOutStoryUrl);
 

--- a/libs/components/src/block/toaster/stories/vl-toaster.stories-arg.ts
+++ b/libs/components/src/block/toaster/stories/vl-toaster.stories-arg.ts
@@ -15,29 +15,30 @@ export const toasterArgTypes: ArgTypes = {
     ...defaultArgTypes,
     fadeOut: {
         name: 'fade-out',
-        description: 'Elke alert verdwijnt automatisch 5 seconden na openen. \n Dit attribuut is niet reactief.',
+        description: 'Elke alert verdwijnt automatisch 5 seconden na openen.<br>Dit attribuut is niet reactief.',
         table: {
             type: {
                 summary: TYPES.BOOLEAN,
             },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: false },
+            defaultValue: { summary: toasterDefaults.fadeOut },
         },
     },
     placement: {
         name: 'placement',
-        description: 'Positioneert de toaster. \nStandaard worden die geplaatst in de rechterbovenhoek.',
+        description: 'Positioneert de toaster.<br>Standaard worden die geplaatst in de rechterbovenhoek.',
         options: Object.values(TOASTER_PLACEMENT),
         table: {
             type: {
-                summary: TYPES.STRING,
+                summary: Object.values(TOASTER_PLACEMENT),
             },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: false },
+            defaultValue: { summary: toasterDefaults.placement },
         },
     },
     defaultSlot: {
         name: '[default]',
+        description: 'De inhoud van de toaster. Dit is typisch een vl-alert.',
         table: {
             type: { summary: TYPES.HTML },
             category: CATEGORIES.SLOTS,

--- a/libs/components/src/block/toaster/stories/vl-toaster.stories-doc.mdx
+++ b/libs/components/src/block/toaster/stories/vl-toaster.stories-doc.mdx
@@ -5,7 +5,7 @@ import * as VlToasterStories from './vl-toaster.stories';
 
 <FluxMetaData id="components-block-toaster" />
 
-Gebruik de `toaster` component om een toaster af te beelden.<br/>
+Gebruik de `toaster` component om meldingen af te beelden.<br/>
 
 ## Voorbeeld
 
@@ -17,45 +17,65 @@ import { VlToasterComponent } from '@domg-wc/components/block';
 <vl-toaster></vl-toaster>
 ```
 
-<Canvas of={VlToasterStories.ToasterDefault} inline />
+<Canvas of={VlToasterStories.ToasterDefault} />
 
 ## Configuratie
 
 <ArgTypes of={VlToasterStories.ToasterDefault} />
 
-## Meldingen tonen
+## Gebruik
+
+### Declaratief
+
+Je kan de meldingen declaratief toevoegen in het default slot van de `vl-toaster`, typisch gebruiken we
+ hiervoor de [vl-alert](/docs/components-block-alert--documentatie) component.
+ Het element verschijnt dan automatisch op de gekozen positie.
+
+<Canvas of={VlToasterStories.ToasterDefaultSlot} />
 
 ### Dynamisch
 
-Om een melding te tonen, gebruik je de `showAlert()` methode.
+De `showAlert()`-methode, is de eenvoudigste manier om een melding te tonen.
+Achterliggend maken we een [vl-alert](/docs/components-block-alert--documentatie) component aan met de
+ opgegeven parameters.
 
-Deze methode roep je op de volgende manier op:
-
-```ts
+```js
 const toaster = document.querySelector('vl-toaster');
 toaster.showAlert({
   type: 'error',
   title: 'Fout',
   message: 'Dit is een foutmelding'
+  fadeOut: true // optioneel, standaard is false
 });
 ```
 
-Je kan het meegegeven object uitbreiden met de properties van de [vl-alert](/docs/components-block-alert--documentatie) component.
+Je kan het meegegeven object uitbreiden met de properties van de [vl-alert](/docs/components-block-alert--documentatie)
+component.
 
 <Canvas of={VlToasterStories.ToasterShowAlert} />
 
-### Declaratief
+Als je meer controle wilt over de melding, kan je ook de `show()` methode gebruiken om een zelf samengesteld
+ HTML-element te tonen als melding.
 
-Daarnaast kan je de meldingen ook declaratief toevoegen in het default slot van de `vl-toaster`, typisch gebruiken we
- hiervoor de [vl-alert](/docs/components-block-alert--documentatie) component.
-
-Om een melding te tonen, gebruik je de `show()` methode:
-
-```ts
+```js
 const toaster = document.querySelector('vl-toaster');
 // toont de melding gedeclareerd in het default slot van de toaster
-toaster.show();
+toaster.show(document.querySelector('#warning-123')); // deze methode toont het meegegeven HTML element als toast
 ```
+
+### Fade out
+
+We bieden de mogelijkheid aan om meldingen automatisch te laten verdwijnen na een bepaalde tijd met
+ de `fade-out` property.
+
+<FluxAlert type="warning">
+{`
+   Echter raden we aan om dit te vermijden waar mogelijk gezien dit de toegankelijkheid van de
+   toaster negatief kan beïnvloeden. Gebruikers kunnen de melding mogelijk niet op tijd lezen of begrijpen,
+   vooral als ze gebruik maken van schermlezers of andere hulpmiddelen.
+`}
+</FluxAlert>
+
 
 <Canvas of={VlToasterStories.ToasterFadeOut} />
 

--- a/libs/components/src/block/toaster/stories/vl-toaster.stories.ts
+++ b/libs/components/src/block/toaster/stories/vl-toaster.stories.ts
@@ -35,23 +35,49 @@ export default {
 export const ToasterDefault = story<ToasterArgs>(toasterArgs, ({ placement, fadeOut, defaultSlot }) => {
     return html`
         <script>
-            document.querySelector('vl-button')?.addEventListener('vl-click', () => {
+            document.querySelector('#default-toaster-button')?.addEventListener('click', () => {
                 const toaster = document.querySelector('vl-toaster');
-                toaster.show();
+                const template = document.querySelector('template');
+
+                if (template && toaster) {
+                    const clone = template.content.cloneNode(true);
+                    const alert = clone.querySelector('#alert-success');
+                    toaster.appendChild(alert);
+                }
             });
         </script>
+        <template>
+            <vl-alert id="alert-success" type="success" icon="check" title="Gelukt" closable>
+                <p>Wij hebben uw melding goed ontvangen en nemen deze spoedig in behandeling.</p>
+            </vl-alert>
+        </template>
         <vl-toaster id="default-toaster" placement=${placement} ?fade-out=${fadeOut}>
             ${unsafeHTML(defaultSlot)}
         </vl-toaster>
-        <vl-button> Toon succesmelding</vl-button>
+        <vl-button id="default-toaster-button"> Toon succesmelding</vl-button>
     `;
 });
 ToasterDefault.storyName = 'vl-toaster - default';
-ToasterDefault.args = {
-    defaultSlot:
-        '<vl-alert type="success" icon="check" title="Gelukt" closable>\n ' +
-        '<p>Wij hebben uw melding goed ontvangen en nemen deze spoedig in behandeling.</p>\n' +
-        '</vl-alert>',
+
+export const ToasterDefaultSlot = story<ToasterArgs>(toasterArgs, ({ placement, fadeOut, defaultSlot }) => {
+    return html`
+        <vl-toaster id="default-toaster" placement=${placement} ?fade-out=${fadeOut}>
+            ${unsafeHTML(defaultSlot)}
+        </vl-toaster>
+    `;
+});
+ToasterDefaultSlot.storyName = 'vl-toaster - default slot';
+ToasterDefaultSlot.args = {
+    placement: 'bottom-right',
+    defaultSlot: `<vl-alert
+                    id="alert-default"
+                    type="error"
+                    icon="warning"
+                    title="Foutmelding"
+                    small
+                >
+                    <p>Voorwaarden niet voldaan.</p>
+                </vl-alert>`,
 };
 
 export const ToasterShowAlert = story<ToasterArgs>(toasterArgs, ({ placement, fadeOut }) => {
@@ -91,6 +117,14 @@ export const ToasterFadeOut = story<ToasterArgs>(toasterArgs, ({ placement, fade
                 toaster.show('#alert-loader');
             });
         </script>
+        <template>
+            <vl-alert id="alert-error" type="error" icon="warning" title="Error">
+                <p>Er is een fout opgetreden.</p>
+            </vl-alert>
+            <vl-alert id="alert-loader" title="Melding">
+                <vl-loader></vl-loader>
+            </vl-alert>
+        </template>
         <vl-toaster id="toaster-fade-out" placement=${placement} ?fade-out=${fadeOut}>
             ${unsafeHTML(defaultSlot)}
         </vl-toaster>
@@ -101,9 +135,4 @@ export const ToasterFadeOut = story<ToasterArgs>(toasterArgs, ({ placement, fade
 ToasterFadeOut.storyName = 'vl-toaster - fade out';
 ToasterFadeOut.args = {
     fadeOut: true,
-    defaultSlot:
-        '<vl-alert id="alert-error" type="error" icon="warning" title="Error">\n' +
-        '<p>Er is een fout opgetreden.</p>\n </vl-alert>\n' +
-        '<vl-alert id="alert-loader" title="Melding">\n' +
-        '<vl-loader></vl-loader>\n </vl-alert>',
 };

--- a/libs/components/src/block/toaster/vl-toaster.component.cy.ts
+++ b/libs/components/src/block/toaster/vl-toaster.component.cy.ts
@@ -1,25 +1,26 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
+import { VlAlert } from '../alert';
 import { VlToasterComponent } from './vl-toaster.component';
 
-registerWebComponents([VlToasterComponent]);
+registerWebComponents([VlToasterComponent, VlAlert]);
 
 describe('component - vl-toaster', () => {
     it('should mount', () => {
-        cy.mount(html`<vl-toaster></vl-toaster>`);
+        cy.mount(html` <vl-toaster></vl-toaster>`);
 
         cy.get('vl-toaster').shadow().find('output.vl-toaster');
     });
 
     it('should be accessible', () => {
-        cy.mount(html`<vl-toaster></vl-toaster>`);
+        cy.mount(html` <vl-toaster></vl-toaster>`);
         cy.injectAxe();
 
         cy.checkA11y('vl-toaster');
     });
 
     it('should set top right by default', () => {
-        cy.mount(html`<vl-toaster></vl-toaster>`);
+        cy.mount(html` <vl-toaster></vl-toaster>`);
 
         cy.get('vl-toaster').should('not.have.attr', 'placement');
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'top', value: '0px' });
@@ -27,7 +28,7 @@ describe('component - vl-toaster', () => {
     });
 
     it('should set top right', () => {
-        cy.mount(html`<vl-toaster placement="top-right"></vl-toaster>`);
+        cy.mount(html` <vl-toaster placement="top-right"></vl-toaster>`);
 
         cy.get('vl-toaster').should('have.attr', 'placement', 'top-right');
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'top', value: '0px' });
@@ -35,7 +36,7 @@ describe('component - vl-toaster', () => {
     });
 
     it('should set top left', () => {
-        cy.mount(html`<vl-toaster placement="top-left"></vl-toaster>`);
+        cy.mount(html` <vl-toaster placement="top-left"></vl-toaster>`);
 
         cy.get('vl-toaster').should('have.attr', 'placement', 'top-left');
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'top', value: '0px' });
@@ -43,7 +44,7 @@ describe('component - vl-toaster', () => {
     });
 
     it('should set bottom left', () => {
-        cy.mount(html`<vl-toaster placement="bottom-left"></vl-toaster>`);
+        cy.mount(html` <vl-toaster placement="bottom-left"></vl-toaster>`);
 
         cy.get('vl-toaster').should('have.attr', 'placement', 'bottom-left');
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'bottom', value: '0px' });
@@ -51,7 +52,7 @@ describe('component - vl-toaster', () => {
     });
 
     it('should set bottom right', () => {
-        cy.mount(html`<vl-toaster placement="bottom-right"></vl-toaster>`);
+        cy.mount(html` <vl-toaster placement="bottom-right"></vl-toaster>`);
 
         cy.get('vl-toaster').should('have.attr', 'placement', 'bottom-right');
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'bottom', value: '0px' });
@@ -59,7 +60,7 @@ describe('component - vl-toaster', () => {
     });
 
     it('should set z-index', () => {
-        cy.mount(html`<vl-toaster></vl-toaster>`);
+        cy.mount(html` <vl-toaster></vl-toaster>`);
 
         cy.get('vl-toaster').shouldHaveComputedStyle({ style: 'z-index', value: '10012' });
     });
@@ -67,42 +68,72 @@ describe('component - vl-toaster', () => {
     it('should show a toast', () => {
         cy.mount(html`
             <vl-toaster>
-                <vl-alert title="toast"></vl-alert>
+                <vl-alert title="toast">
+                    <p>message</p>
+                </vl-alert>
             </vl-toaster>
         `);
-        cy.get('vl-toaster').then((toaster) => {
-            cy.get('vl-toaster').shadow().find('vl-alert').should('not.be.visible');
-            toaster[0].show();
-            cy.get('vl-toaster').shadow().find('vl-alert').should('be.visible');
-        });
+        cy.get('vl-toaster').find('vl-alert').should('be.visible');
     });
 
     it('should set fade out', () => {
-        cy.mount(html`
-            <vl-toaster fade-out>
-                <vl-alert title="toast"></vl-alert>
-            </vl-toaster>
-        `);
-        cy.get('vl-toaster').should('have.attr', 'fade-out');
-        cy.get('vl-toaster').then((toaster) => {
-            cy.get('vl-toaster').shadow().find('vl-alert').should('not.be.visible');
-            toaster[0].show();
-            cy.get('vl-toaster').shadow().find('vl-alert').should('be.visible');
+        cy.mount(html` <vl-toaster fade-out></vl-toaster> `);
+        cy.get('vl-toaster').then(($toaster) => {
+            cy.get('vl-toaster').shadow().find('vl-alert').should('not.exist');
+            $toaster[0].showAlert({
+                title: 'Gelukt',
+                message: 'Wij hebben uw melding goed ontvangen en nemen deze spoedig in behandeling.',
+                type: 'success',
+            });
+            cy.get('vl-toaster').shadow().find('vl-alert').should('be.visible').and('exist');
             cy.wait(5000);
             cy.get('vl-toaster').shadow().find('vl-alert').should('not.exist');
         });
     });
 
     it('should show a dynamically created alert', () => {
-        cy.mount(html` <vl-toaster> </vl-toaster> `);
-        cy.get('vl-toaster').then((toaster) => {
-            cy.get('vl-toaster').shadow().find('vl-alert').should('not.be.visible');
-            toaster[0].showAlert({
+        cy.mount(html` <vl-toaster></vl-toaster> `);
+        cy.get('vl-toaster').then(($toaster) => {
+            cy.get('vl-toaster').shadow().find('vl-alert').should('not.exist');
+            $toaster[0].showAlert({
                 title: 'Gelukt',
                 message: 'Wij hebben uw melding goed ontvangen en nemen deze spoedig in behandeling.',
                 type: 'success',
             });
             cy.get('vl-toaster').shadow().find('vl-alert').should('be.visible');
         });
+    });
+
+    it('should show a toast in the output slot', () => {
+        cy.mount(html`
+            <vl-toaster>
+                <vl-alert title="toast"></vl-alert>
+            </vl-toaster>
+        `);
+
+        cy.get('vl-toaster').find('vl-alert').should('be.visible');
+    });
+
+    it('should show a toast when dynamically adding it to the output slot', () => {
+        cy.mount(html`
+            <main>
+                <vl-alert title="toast"></vl-alert>
+                <vl-toaster></vl-toaster>
+            </main>
+        `);
+
+        cy.get('vl-toaster').shadow().find('vl-alert').should('not.exist');
+
+        cy.get('vl-alert')
+            .then(($alert) => {
+                cy.get('vl-toaster').then(($toaster) => {
+                    $toaster[0].show($alert[0]);
+                });
+            })
+            .get('vl-toaster')
+            .shadow()
+            .find('output')
+            .find('vl-alert')
+            .should('be.visible');
     });
 });

--- a/libs/components/src/block/toaster/vl-toaster.component.ts
+++ b/libs/components/src/block/toaster/vl-toaster.component.ts
@@ -10,10 +10,12 @@ registerWebComponents([VlAlert]);
 
 @webComponent('vl-toaster')
 export class VlToasterComponent extends BaseLitElement {
+    // properties
     private fadeOut = toasterDefaults.fadeOut;
     private placement: Placement = toasterDefaults.placement;
-
+    // state
     private abortController = new AbortController();
+    private initialized = false;
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [toasterStyles];
@@ -27,23 +29,36 @@ export class VlToasterComponent extends BaseLitElement {
     }
 
     render(): HTMLTemplateResult {
-        return html` <output class="vl-toaster"></output> `;
+        return html`
+            <output class="vl-toaster">
+                <slot></slot>
+            </output>
+        `;
     }
 
     disconnectedCallback() {
         this.abortController.abort('animationend');
     }
 
+    /**
+     * Wanneer aangeroepen zonder argument, wordt het eerste element in de toaster getoond.
+     * Je kan ook een specifiek element tonen door een selector mee te geven of een HTMLElement.
+     * @param target
+     */
     show(target?: string | HTMLElement): void {
         let toast;
         const firstChild = this.children[0]?.cloneNode(true) as HTMLElement;
         if (!target && firstChild) {
             toast = firstChild;
+            // we verwijderen het id attribuut op de gekloonde node om dubbele id's te voorkomen
+            toast?.removeAttribute('id');
+            toast?.removeAttribute('slot');
         } else if (target && typeof target === 'string') {
-            const foundElement = this.querySelector(target);
+            const foundElement = document.querySelector(target);
             toast = foundElement?.cloneNode(true) as HTMLElement;
             // we verwijderen het id attribuut op de gekloonde node om dubbele id's te voorkomen
-            toast.removeAttribute('id');
+            toast?.removeAttribute('id');
+            toast?.removeAttribute('slot');
         } else if (target instanceof HTMLElement) {
             toast = target as HTMLElement;
         }
@@ -54,6 +69,10 @@ export class VlToasterComponent extends BaseLitElement {
         this.showToast(toast);
     }
 
+    /**
+     * Toont een vl-alert in de toaster met de opgegeven attributen/properties.
+     * @param alert
+     */
     showAlert(alert: VlAlertModel) {
         const vlAlert = document.createElement('vl-alert');
         Object.entries(alert).forEach(([key, value]) => {
@@ -61,17 +80,25 @@ export class VlToasterComponent extends BaseLitElement {
                 vlAlert.setAttribute(`${key}`, value);
             }
         });
-        this.appendChild(vlAlert);
         this.showToast(vlAlert);
     }
 
-    private showToast(toast: HTMLElement) {
-        if (this.placement === 'bottom-right' || this.placement === 'bottom-left') {
-            this.shadowRoot?.appendChild(toast);
-        } else {
-            this.shadowRoot?.prepend(toast);
+    private get outputElement(): HTMLElement | null | undefined {
+        return this.shadowRoot?.querySelector('output');
+    }
+
+    private showToast = async (toast: HTMLElement) => {
+        // wacht tot <output> element is gerenderd
+        if (!this.initialized) {
+            this.initialized = true;
+            await this.updateComplete;
         }
 
+        if (this.placement === 'bottom-right' || this.placement === 'bottom-left') {
+            this.outputElement?.appendChild(toast);
+        } else {
+            this.outputElement?.prepend(toast);
+        }
         if (this.fadeOut) {
             toast.addEventListener(
                 'animationend',
@@ -83,7 +110,7 @@ export class VlToasterComponent extends BaseLitElement {
                 { signal: this.abortController.signal }
             );
         }
-    }
+    };
 }
 
 declare global {

--- a/libs/components/src/block/toaster/vl-toaster.css.ts
+++ b/libs/components/src/block/toaster/vl-toaster.css.ts
@@ -3,20 +3,37 @@ import { css } from 'lit';
 export const toasterStyles = css`
     :host {
         position: fixed;
-        width: 30rem;
+        width: 100%;
+        max-width: 30rem;
         top: 0;
         right: 0;
         z-index: var(--vl-z-layer--toaster);
+
+        ::slotted(vl-alert),
+        vl-alert {
+            display: block;
+            margin: 1rem 1rem 0 0;
+        }
     }
 
     :host([placement='top-left']) {
         right: auto;
         left: 0;
+
+        ::slotted(vl-alert),
+        vl-alert {
+            margin: 1rem 0 0 1rem;
+        }
     }
 
     :host([placement='bottom-right']) {
         top: auto;
         bottom: 0;
+
+        ::slotted(vl-alert),
+        vl-alert {
+            margin: 0 1rem 1rem 0;
+        }
     }
 
     :host([placement='bottom-left']) {
@@ -24,13 +41,18 @@ export const toasterStyles = css`
         right: auto;
         bottom: 0;
         left: 0;
+
+        ::slotted(vl-alert),
+        vl-alert {
+            margin: 0 0 1rem 1rem;
+        }
     }
 
-    :host > * {
+    :host output * {
         animation: fade-in 0.3s ease;
     }
 
-    :host([fade-out]) > * {
+    :host([fade-out]) output * {
         animation: fade-in 0.3s ease, fade-out 0.3s ease 4.4s;
     }
 


### PR DESCRIPTION
De declaratieve manier van meldingen tonen is veranderd; in de vorige Lit variant van de `vl-toaster` werden meldingen pas getoond als de bijhorende functie werd aangeroepen. Nu worden die onmiddellijk getoond, deze werking is nu dezelfde hoe de vroegere `is="vl-toaster"` werkte. Daarnaast is ook ontbrekende witruimte toegevoegd en responsiveness op mobiel verbeterd.

[Jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-122)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC50)