### PR TITLE
feat: FLUX-126 - vl-side-navigation - hash-sync attribute vervangt has-hash-routing

### DIFF
--- a/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-arg.ts
+++ b/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-arg.ts
@@ -1,0 +1,24 @@
+import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@resources/utils-storybook';
+import { ArgTypes } from '@storybook/web-components';
+
+export const sideNavigationArgs = {
+    ...defaultArgs,
+    hashSync: false,
+};
+
+export const sideNavigationArgTypes: ArgTypes<typeof sideNavigationArgs> = {
+    ...defaultArgTypes,
+    hashSync: {
+        name: 'hash-sync',
+        description: `Attribute wordt gebruikt om aan te duiden dat de url hash gesynchroniseerd moet worden met de 
+        side navigation. Dit gebeurt in twee richtingen: enerzijds, indien er een hash aanwezig in de url die 
+        overeenkomt met een item op de pagina dan zal de browser automatisch scrollen naar dat item, en anderzijds, 
+        wanneer je klikt op een item in de side navigation, zal de url hash worden bijgewerkt naar het id van dat 
+        item.`,
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: sideNavigationArgs.hashSync },
+        },
+    },
+};

--- a/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-doc.mdx
+++ b/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-doc.mdx
@@ -47,7 +47,7 @@ import { VlSideNavigation } from '@domg-wc/components/block';
 
 <details>
     <summary>Side-navigation code voorbeeld</summary>
-    <Source code={sideNavigationHTML} language="html" dark={true}/>
+    <Source code={sideNavigationHTML({hashSync: true})} language="html" dark={true}/>
 </details>
 
 
@@ -68,9 +68,21 @@ manier (we gebruiken content 1 als voorbeeld):
 2. Plaats op het `VlSideNavigationToggle` component het attribuut `child="content-1"`
 3. Plaats op de child links het attribuut `parent="content-1"`
 
-Plaats naast het `VlSideNavigationToggle` component een lijst element (`<ul>`) met daaronder `VlSideNavigationItem` componenten als items.
+Plaats naast het `VlSideNavigationToggle` component een lijst element (`<ul>`) met daaronder `VlSideNavigationItem` 
+componenten als items.
 
-Gebruik geen `VlSideNavigationToggle` component indien er geen subnavigatie is. Een gewone link (`<a href="#">`) onder het `VlSideNavigationItem` component volstaat dan.
+Gebruik geen `VlSideNavigationToggle` component indien er geen subnavigatie is. Een gewone link (`<a href="#">`) 
+onder het `VlSideNavigationItem` component volstaat dan.
+
+## Hash sync
+
+Indien er geen gebruik gemaakt wordt van hash-routing en de url hash op geen enkele andere manier gemanipuleerd wordt, 
+kan `hash-sync` geactiveerd worden.
+
+Dit werkt in twee richtingen:
+- Indien er een hash aanwezig is in de url die overeenkomt met een element op de pagina dan zal de browser automatisch 
+scrollen naar dat item.
+- Wanneer je klikt op een item in de side navigation, zal de url hash worden bijgewerkt naar het id van dat item.
 
 
 ## Gekende beperkingen
@@ -84,10 +96,11 @@ werken is een tijdelijke quick-fix, in de nieuwe versie van de side-navigation g
 
 ### Initialisatie in een hidden parent
 
-Als de side-navigation gerenderd wordt in een parent component die `hidden` is, bijvoorbeeld bij verschillende stappen in een flow, dan gaat de initialisatie
-fout en zal de side-navigation niet sticky worden bij het scrollen. Dit komt omdat de side-navigation bij het initialiseren een aantal dimensies capteerd en, 
-in het geval dat er een parent `hidden` is, één van de waardes op 0 komt te staan. Dit kan vermeden worden door het gebruik van `hidden` te vervangen door de 
-`when()` directive van Lit.
+Als de side-navigation gerenderd wordt in een parent component die `hidden` is, bijvoorbeeld bij verschillende stappen 
+in een flow, dan gaat de initialisatie fout en zal de side-navigation niet sticky worden bij het scrollen. Dit komt 
+omdat de side-navigation bij het initialiseren een aantal dimensies capteerd en, in het geval dat er een parent 
+`hidden` is, één van de waardes op 0 komt te staan. Dit kan vermeden worden door het gebruik van `hidden` te vervangen 
+door de `when()` directive van Lit.
 
 
 #### ❌ Voorbeeld met "hidden"

--- a/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-html.ts
+++ b/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-html.ts
@@ -2,8 +2,9 @@
 // De source van de story toont niet de correcte code omdat er een aantal classes en attributen toegevoegd worden in de
 // interne keuken van de elementen.
 import '../index';
+import { sideNavigationArgs } from './vl-side-navigation.stories-arg';
 
-export const sideNavigationHTML = `
+export const sideNavigationHTML = ({ hashSync }: Partial<typeof sideNavigationArgs>) => `
 <section class="vl-section">
     <div class="vl-content-block">
         <div class="vl-grid vl-stacked-medium">
@@ -164,7 +165,9 @@ export const sideNavigationHTML = `
                 </vl-side-navigation-reference>
             </div>
             <div class="vl-column vl-column--3 vl-column--m-3 vl-column--s-12 vl-column--xs-12 vl-column--start-10 vl-column--s-start-1">
-                <vl-side-navigation aria-label="inhoudsopgave">
+                <vl-side-navigation aria-label="inhoudsopgave" ${
+                    hashSync ? 'hash-sync' : ''
+                } side-navigation-id="side-navigation">
                     <vl-side-navigation-h5>Op deze pagina</vl-side-navigation-h5>
                     <vl-side-navigation-content>
                         <vl-side-navigation-group>

--- a/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories.ts
+++ b/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories.ts
@@ -1,4 +1,5 @@
 import { registerWebComponents } from '@domg-wc/common';
+import { story } from '@resources/utils-storybook';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { VlSideNavigationContentComponent } from '../vl-side-navigation-content.component';
@@ -8,6 +9,7 @@ import { VlSideNavigationReferenceComponent } from '../vl-side-navigation-refere
 import { VlSideNavigationH5 } from '../vl-side-navigation-title.component';
 import { VlSideNavigationToggleComponent } from '../vl-side-navigation-toggle.component';
 import { VlSideNavigationComponent } from '../vl-side-navigation.component';
+import { sideNavigationArgs, sideNavigationArgTypes } from './vl-side-navigation.stories-arg';
 import sideNavigationDoc from './vl-side-navigation.stories-doc.mdx';
 import { sideNavigationHTML } from './vl-side-navigation.stories-html';
 
@@ -15,6 +17,8 @@ export default {
     id: 'components-block-side-navigation',
     title: 'Components - Block/side-navigation',
     tags: ['autodocs'],
+    args: sideNavigationArgs,
+    argTypes: sideNavigationArgTypes,
     parameters: {
         controls: { hideNoControlsWarning: true },
         docs: { page: sideNavigationDoc },
@@ -32,10 +36,16 @@ registerWebComponents([
     VlSideNavigationH5,
 ]);
 
-export const SideNavigationDefault = () => html`${unsafeHTML(sideNavigationHTML)}`;
+export const SideNavigationDefault = story(
+    sideNavigationArgs,
+    ({ hashSync }) => html`${unsafeHTML(sideNavigationHTML({ hashSync }))}`
+);
 SideNavigationDefault.storyName = 'vl-side-navigation - default';
 
-export const SideNavigationMobile = () => html`${unsafeHTML(sideNavigationHTML)}`;
+export const SideNavigationMobile = story(
+    sideNavigationArgs,
+    ({ hashSync }) => html`${unsafeHTML(sideNavigationHTML({ hashSync }))}`
+);
 SideNavigationMobile.storyName = 'vl-side-navigation - mobile';
 SideNavigationMobile.parameters = {
     viewport: {

--- a/libs/components/src/block/side-navigation/vl-side-navigation-item.component.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation-item.component.ts
@@ -15,22 +15,22 @@ export class VlSideNavigationItemComponent extends BaseLitElement {
             parent: { type: Boolean },
         };
     }
-    
+
     protected createRenderRoot(): HTMLElement | DocumentFragment {
         return this;
     }
 
     protected hasStickyHeader(): boolean {
-        return !!this.getRootNode().querySelector('vl-header')
+        return !!this.getRootNode().querySelector('vl-header');
     }
 
     protected get scrollOffset(): number {
         return this.hasStickyHeader() ? 43 : 0;
     }
 
-    protected get hasHashRouting(): boolean {
+    protected get hashSync(): boolean {
         const parent = this.closest('vl-side-navigation');
-        return parent ? parent.hasAttribute('has-hash-routing') : false;
+        return parent ? parent.hasAttribute('hash-sync') : false;
     }
 
     firstUpdated() {
@@ -50,20 +50,20 @@ export class VlSideNavigationItemComponent extends BaseLitElement {
                 console.warn('vl-side-navigation-item vereist een geldige href op het anchor element.');
                 return;
             }
-            
+
             const element = findDeepestElementThroughShadowRoot(this.getRootNode(), href);
             if (!element) {
                 console.warn(`Element met id "${href}" niet gevonden in de DOM.`);
                 return;
             }
-            
+
             const rect = element.getBoundingClientRect();
             const scrollTop = window.scrollY + rect.top - this.scrollOffset;
             window.scrollTo({ top: scrollTop, behavior: 'smooth' });
 
-            if (!this.hasHashRouting) {
+            if (this.hashSync) {
                 history.pushState(null, '', href);
-            }    
+            }
         });
     }
 }

--- a/libs/components/src/block/side-navigation/vl-side-navigation-toggle.component.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation-toggle.component.ts
@@ -26,16 +26,16 @@ export class VlSideNavigationToggleComponent extends BaseLitElement {
     }
 
     protected hasStickyHeader(): boolean {
-        return !!this.getRootNode().querySelector('vl-header')
+        return !!this.getRootNode().querySelector('vl-header');
     }
 
     protected get scrollOffset(): number {
         return this.hasStickyHeader() ? 43 : 0;
     }
 
-    protected get hasHashRouting(): boolean {
+    protected get hashSync(): boolean {
         const parent = this.closest('vl-side-navigation');
-        return parent ? parent.hasAttribute('has-hash-routing') : false;
+        return parent ? parent.hasAttribute('hash-sync') : false;
     }
 
     firstUpdated() {
@@ -47,11 +47,11 @@ export class VlSideNavigationToggleComponent extends BaseLitElement {
             console.warn('vl-side-navigation-toggle vereist een geldige href.');
             return;
         }
-        
+
         const childNodes = this.childNodes;
         const aNode = document.createElement('a');
         aNode.setAttribute('href', this.href);
-        
+
         const iconNode = document.createElement('vl-icon');
         iconNode.setAttribute('icon', 'arrow-right-fat');
         aNode.append(...childNodes, iconNode);
@@ -65,14 +65,14 @@ export class VlSideNavigationToggleComponent extends BaseLitElement {
                 console.warn(`Element met id "${this.href}" niet gevonden in de DOM.`);
                 return;
             }
-            
+
             const rect = element.getBoundingClientRect();
             const scrollTop = window.scrollY + rect.top - this.scrollOffset;
             window.scrollTo({ top: scrollTop, behavior: 'smooth' });
-            
-            if (!this.hasHashRouting) {
+
+            if (this.hashSync) {
                 history.pushState(null, '', this.href);
-            }  
+            }
         });
     }
 }

--- a/libs/components/src/block/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.component.cy.ts
@@ -476,7 +476,26 @@ describe('component - vl-side-navigation', () => {
         cy.get('vl-side-navigation').should('be.visible');
     });
 
-    it('should update the browser history on click', () => {
+    it('should not update the browser history on click', () => {
+        window.location.hash = ''; // Reset hash before test
+
+        cy.get('vl-side-navigation').find("vl-side-navigation-toggle[href='#content-1']").click();
+        cy.location('hash').should('eq', '');
+
+        cy.get('vl-side-navigation').find("vl-side-navigation-toggle[href='#content-2']").click();
+        cy.location('hash').should('eq', '');
+
+        cy.get('vl-side-navigation').find("a[href='#content-3']").click();
+        cy.location('hash').should('eq', '');
+    });
+
+    it('should update the browser history on click in case hash-sync is set', () => {
+        window.location.hash = ''; // Reset hash before test
+
+        cy.get('vl-side-navigation').then(([sideNavigation]) => {
+            sideNavigation.setAttribute('hash-sync', '');
+        });
+
         cy.get('vl-side-navigation').find("vl-side-navigation-toggle[href='#content-1']").click();
         cy.location('hash').should('eq', '#content-1');
 
@@ -485,22 +504,5 @@ describe('component - vl-side-navigation', () => {
 
         cy.get('vl-side-navigation').find("a[href='#content-3']").click();
         cy.location('hash').should('eq', '#content-3');
-    });
-
-    it('should not update the browser history on click in case has-hash-routing is set', () => {
-        window.location.hash = ''; // Reset hash before test
-        cy.location('hash').should('eq', '#');
-
-        cy.get('vl-side-navigation').then(([sideNavigation]) => {
-            sideNavigation.setAttribute('has-hash-routing', '');
-        });
-        cy.get('vl-side-navigation').find("vl-side-navigation-toggle[href='#content-1']").click();
-        cy.location('hash').should('eq', '#');
-
-        cy.get('vl-side-navigation').find("vl-side-navigation-toggle[href='#content-2']").click();
-        cy.location('hash').should('eq', '#');
-
-        cy.get('vl-side-navigation').find("a[href='#content-3']").click();
-        cy.location('hash').should('eq', '#');
     });
 });

--- a/libs/components/src/block/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.component.ts
@@ -23,11 +23,7 @@ registerWebComponents([legacyCore, legacyBreakpoint]);
 export class VlSideNavigationComponent extends BaseLitElement {
     static initializedSideNavigationId = '';
 
-    /**
-     * Indien de applicatie gebruik maakt van hash routing, kan je hiermee aangeven dat de side navigation
-     * geen browser history entry moet aanmaken bij het navigeren naar een item.
-     */
-    private hasHashRouting = sideNavigationDefaults.hasHashRouting;
+    private hashSync = sideNavigationDefaults.hashSync;
 
     constructor() {
         super();
@@ -38,8 +34,8 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
     static get properties(): PropertyDeclarations {
         return {
-            hasHashRouting: { type: Boolean, attribute: 'has-hash-routing' },
-        }
+            hashSync: { type: Boolean, attribute: 'hash-sync' },
+        };
     }
 
     protected createRenderRoot(): HTMLElement | DocumentFragment {
@@ -47,7 +43,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
     }
 
     protected hasStickyHeader(): boolean {
-        return !!this.getRootNode().querySelector('vl-header')
+        return !!this.getRootNode().querySelector('vl-header');
     }
 
     protected get scrollOffset(): number {
@@ -68,14 +64,14 @@ export class VlSideNavigationComponent extends BaseLitElement {
                 vlSectionStyles.styleSheet as CSSStyleSheet,
                 vlContentBlockStyles.styleSheet as CSSStyleSheet,
                 vlIconStyles.styleSheet as CSSStyleSheet,
-                ...vlLegacyStyles.map((style) => style.styleSheet) as CSSStyleSheet[],
+                ...(vlLegacyStyles.map((style) => style.styleSheet) as CSSStyleSheet[]),
             ];
         } else {
             document.adoptedStyleSheets = [
                 ...document.adoptedStyleSheets,
                 vlSideNavigationStyles.styleSheet as CSSStyleSheet,
                 vlIconStyles.styleSheet as CSSStyleSheet,
-                ...vlLegacyStyles.map((style) => style.styleSheet) as CSSStyleSheet[],
+                ...(vlLegacyStyles.map((style) => style.styleSheet) as CSSStyleSheet[]),
             ];
         }
 
@@ -83,7 +79,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
     }
 
     private initialScroll() {
-        if (this.hasHashRouting) {
+        if (!this.hashSync) {
             return;
         }
         const id = location.hash.slice(1);

--- a/libs/components/src/block/side-navigation/vl-side-navigation.defaults.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.defaults.ts
@@ -1,3 +1,3 @@
 export const sideNavigationDefaults = {
-    hasHashRouting: false,
+    hashSync: false,
 } as const;


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-126)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC64)