### PR TITLE
fix: FLUX-199 - vl-autocomplete - bij selectie-event wordt volledig item ontsloten

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/autocomplete/vl-autocomplete.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/autocomplete/vl-autocomplete.stories.cy.ts
@@ -1,31 +1,20 @@
-const autocompleteUrl =
-    'http://localhost:8080/iframe.html?args=&id=components-block-autocomplete--autocomplete-default&viewMode=story';
-const autocompleteWithoutSuggestionsUrl =
-    'http://localhost:8080/iframe.html?id=components-block-autocomplete--autocomplete-without-suggestions&viewMode=story';
+const stories = [
+    'default',
+    'group-by-subtitle',
+    'without-suggestions',
+    'custom-caption-formatter',
+    'input-and-api-call',
+    'input-and-mocked-api-call',
+    'without-suggestions',
+    'in-side-sheet',
+];
+describe(`story - vl-autocomplete`, () => {
+    stories.forEach((storyName) => {
+        it(`should display story - ${storyName}`, () => {
+            const urlForStory = `http://localhost:8080/iframe.html?id=components-block-autocomplete--autocomplete-${storyName}&viewMode=story`;
+            cy.visit(urlForStory);
 
-describe('story vl-autocomplete', () => {
-    it('as a user, I can see the autocomplete placeholder', () => {
-        cy.visit(`${autocompleteUrl}`);
-        cy.get('vl-autocomplete').shadow().find('input').invoke('attr', 'placeholder').should('eq', 'Hint: typ Gent');
-    });
-
-    it('as a user, I can see 5 suggestions after typing the g character', () => {
-        cy.visit(`${autocompleteUrl}`);
-        cy.get('vl-autocomplete').shadow().find('input').type('g');
-        cy.get('vl-autocomplete').shadow().find('#suggestions').find('li').should('have.length', 5);
-    });
-
-    it('should show loading animation when typing without suggestions by default', () => {
-        cy.visit(`${autocompleteWithoutSuggestionsUrl}`);
-
-        cy.get('vl-autocomplete').shadow().find('input').type('g');
-        cy.get('vl-autocomplete').shadow().find('div.vl-autocomplete__loader').should('not.have.attr', 'hidden');
-    });
-
-    it('should show loading animation when typing without suggestions when disabled', () => {
-        cy.visit(`${autocompleteWithoutSuggestionsUrl}&args=disableLoading:true`);
-
-        cy.get('vl-autocomplete').shadow().find('input').type('g');
-        cy.get('vl-autocomplete').shadow().find('div.vl-autocomplete__loader').should('have.attr', 'hidden');
+            cy.get('vl-autocomplete').shadow().find('input');
+        });
     });
 });

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.cy.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.cy.ts
@@ -1,0 +1,79 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { html } from 'lit';
+import { VlAutocomplete } from './vl-autocomplete.component';
+
+registerWebComponents([VlAutocomplete]);
+
+describe('component vl-autocomplete', () => {
+    it('should set placeholder', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+            ></vl-autocomplete>
+        `);
+        cy.get('vl-autocomplete').shadow().find('input').invoke('attr', 'placeholder').should('eq', 'Hint: typ Gent');
+    });
+
+    it('should display 5 suggestions after typing the g character', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+            ></vl-autocomplete>
+        `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('g');
+        cy.get('vl-autocomplete').shadow().find('#suggestions').find('li').should('have.length', 5);
+    });
+
+    it('should return entire item in event detail', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+                @selected-autocomplete=${() => console.log('selected')}
+            ></vl-autocomplete>
+        `);
+
+        cy.createStubForEvent('vl-autocomplete', 'selected-autocomplete');
+        cy.get('vl-autocomplete').shadow().find('input').type('Gentbos');
+        cy.get('vl-autocomplete').shadow().find('#suggestions').first().click();
+
+        cy.get('@selected-autocomplete')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { title: 'Gentbos, Merelbeke', subtitle: 'Adres', value: '2', custom: 'custom' });
+    });
+
+    it('should show loading animation when typing without suggestions by default', () => {
+        cy.mount(html` <vl-autocomplete min-chars="1" placeholder="Hint: typ Gent"></vl-autocomplete> `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('g');
+        cy.get('vl-autocomplete').shadow().find('div.vl-autocomplete__loader').should('not.have.attr', 'hidden');
+    });
+
+    it('should not show loading animation when typing without suggestions when disabled', () => {
+        cy.mount(
+            html` <vl-autocomplete min-chars="1" placeholder="Hint: typ Gent" disable-loading></vl-autocomplete> `
+        );
+
+        cy.get('vl-autocomplete').shadow().find('input').type('g');
+        cy.get('vl-autocomplete').shadow().find('div.vl-autocomplete__loader').should('have.attr', 'hidden');
+    });
+});
+
+export const complexItems = [
+    { title: 'Gent', subtitle: 'Gemeente', value: '1' },
+    { title: 'Gentbos, Merelbeke', subtitle: 'Adres', value: '2', custom: 'custom' },
+    { title: 'Gentbruggestraat, Gent', subtitle: 'Adres', value: '3' },
+    { title: 'Gentele, Brugge', subtitle: 'Adres', value: '5' },
+    { title: 'Automotive Contractors Gent ', subtitle: 'Project', value: '6' },
+    { title: 'Buurtshuis Watersportbaan Gent', subtitle: 'Project', value: '7' },
+];

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
@@ -398,7 +398,7 @@ export class VlAutocomplete extends BaseLitElement {
         const id = `flux-autocomplete-item-${item.value || item.title.toLowerCase().replace(/\s/g, '-')}-${groupIndex}`;
         return html` <li
             id="${id}"
-            @click=${() => this.autocomplete(item.title, item.value ? item.value : null, id)}
+            @click=${() => this.autocomplete(item, id)}
             class="vl-autocomplete__cta flux-autocomplete-item"
             groupindex="${groupIndex}"
             role="option"
@@ -408,7 +408,8 @@ export class VlAutocomplete extends BaseLitElement {
         </li>`;
     }
 
-    autocomplete(title: string, value: string, id?: string) {
+    autocomplete(item: { title: string; value: string }, id?: string) {
+        const { title, value } = item;
         if (value == null) return;
 
         if (this.contentElement) {
@@ -422,7 +423,7 @@ export class VlAutocomplete extends BaseLitElement {
 
         this.dispatchEvent(
             new CustomEvent('selected-autocomplete', {
-                detail: { title, value },
+                detail: item,
                 composed: true,
                 bubbles: true,
             })


### PR DESCRIPTION
[Jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-199)
[Bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC101)