### PR TITLE
fix: FLUX-310 - vl-rich-data - escape functionaliteit verbeterd

### DIFF
--- a/libs/components/src/rich-data/vl-rich-data.component.cy.ts
+++ b/libs/components/src/rich-data/vl-rich-data.component.cy.ts
@@ -136,9 +136,25 @@ describe('component - vl-rich-data with vl-search-filter-next', () => {
         cy.get('vl-rich-data').shadow().find('#content').should('have.class', 'vl-column-next--8');
     });
 
-    it('should be able to close the search filter using the escape key', () => {
+    it('should be able to close the search filter using the escape key when closable', () => {
         cy.viewport(1024, 768);
         cy.get('vl-search-filter-next').should('not.have.attr', 'hidden');
+        cy.get('#filterOpId').shadow().find('input').type('{esc}', { force: true });
+        cy.get('vl-search-filter-next').should('have.attr', 'hidden');
+    });
+
+    it('should not close the search filter using the escape key when not closable', () => {
+        cy.viewport(1024, 768);
+        cy.get('vl-search-filter-next').should('not.have.attr', 'hidden');
+        cy.get('vl-rich-data').invoke('removeAttr', 'data-vl-filter-closable');
+        cy.get('#filterOpId').shadow().find('input').type('{esc}', { force: true });
+        cy.get('vl-search-filter-next').should('not.have.attr', 'hidden');
+    });
+
+    it('should close the search filter using the escape key without closable attribute in mobile', () => {
+        cy.viewport(375, 667);
+        cy.get('vl-search-filter-next').should('not.have.attr', 'hidden');
+        cy.get('vl-rich-data').invoke('removeAttr', 'data-vl-filter-closable');
         cy.get('#filterOpId').shadow().find('input').type('{esc}', { force: true });
         cy.get('vl-search-filter-next').should('have.attr', 'hidden');
     });

--- a/libs/components/src/rich-data/vl-rich-data.component.ts
+++ b/libs/components/src/rich-data/vl-rich-data.component.ts
@@ -513,7 +513,11 @@ export class VlRichData extends BaseElementOfType(HTMLElement) {
                 });
             });
             this.__searchFilterForm.addEventListener('keyup', ({ code }: KeyboardEvent) => {
-                if (code.toLowerCase() === 'escape' && !this.hasAttribute('data-vl-filter-closed')) {
+                const isClosable = this.hasAttribute('data-vl-filter-closable');
+                const isFilterClosed = !this.hasAttribute('data-vl-filter-closed');
+                const isMobile =
+                    this.hasAttribute('mobile-modal') || this.hasAttribute('data-vl-mobile-modal') || this.__isModal();
+                if (code.toLowerCase() === 'escape' && isFilterClosed && (isClosable || isMobile)) {
                     this._onToggleFilter();
                 }
             });
@@ -536,11 +540,14 @@ export class VlRichData extends BaseElementOfType(HTMLElement) {
         return observer;
     }
 
+    __isModal() {
+        return Boolean(
+            this.__searchFilter.hasAttribute('data-vl-mobile-modal') || this.__searchFilter.hasAttribute('mobile-modal')
+        );
+    }
+
     __processScrollableBody() {
-        if (
-            this.__searchFilter.hasAttribute('data-vl-mobile-modal') ||
-            this.__searchFilter.hasAttribute('mobile-modal')
-        ) {
+        if (this.__isModal()) {
             this.__disableBodyScroll();
         } else {
             this.__enableBodyScroll();


### PR DESCRIPTION
Vroeger verborg de escape knop de search-filter in alle gevallen en wanneer er geen filter toggle knop is, kon de filter niet meer terug verschijnen. Nu verbergt de escape knop enkel de search-filter als het data-vl-filter-closable attribuut opstaat.

[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-310)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC127)