### PR TITLE
fix: FLUX-311 - vl-functional-header - documentatie opgekuist

### DIFF
--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
@@ -27,7 +27,6 @@ export const functionalHeaderArgs = {
     backSlot: '',
     backLinkSlot: '',
     sticky: false,
-    stickyOffsetTop: '',
     subHeaderSlot: '',
     subTitleSlot: '',
     titleSlot: '',

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
@@ -71,7 +71,13 @@ demo van deze opzet vind je hier: [Voorbeeld Met Sticky En Side Navigation](/doc
 
 ### Met tabs
 
-Gebruik de [vl-tabs](/docs/components-block-tabs--tabs-default) component in het `sub-header` slot om tabs af te beelden binnen de `functional-header`.
+Gebruik het [vl-tabs](/docs/components-block-tabs-tabs--documentatie) component in het `sub-header` slot om tabs af te beelden binnen de `functional-header`.
+
+<FluxAlert type="info">
+{`
+    Opgelet: het \`vl-tabs\` component moet in dit geval het attribuut \`within-functional-header\` meekrijgen.
+`}
+</FluxAlert>
 
 <Canvas of={VlFunctionalHeaderStories.FunctionalHeaderTabs} />
 

--- a/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-arg.ts
+++ b/libs/components/src/block/side-navigation/stories/vl-side-navigation.stories-arg.ts
@@ -4,7 +4,6 @@ import { ArgTypes } from '@storybook/web-components';
 export const sideNavigationArgs = {
     ...defaultArgs,
     hashSync: false,
-    stickyOffsetTop: '43',
 };
 
 export const sideNavigationArgTypes: ArgTypes<typeof sideNavigationArgs> = {
@@ -18,7 +17,7 @@ wanneer je klikt op een item in de side navigation, zal de url hash worden bijge
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: sideNavigationArgs.hashSync },
+            defaultValue: { summary: String(sideNavigationArgs.hashSync) },
         },
     },
 };

--- a/libs/components/src/block/tabs/stories/vl-tabs.stories-arg.ts
+++ b/libs/components/src/block/tabs/stories/vl-tabs.stories-arg.ts
@@ -7,8 +7,8 @@ import {
     TYPES,
 } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
-import { DISPLAY_STYLE } from '../vl-tabs.model';
 import { action } from 'storybook/actions';
+import { DISPLAY_STYLE } from '../vl-tabs.model';
 
 export const tabsArgs = {
     ...defaultArgs,
@@ -19,6 +19,7 @@ export const tabsArgs = {
     displayStyle: 'default',
     onChangeActiveTab: action('change'),
     onClickActiveTab: action('vl-click'),
+    withinFunctionalHeader: false,
 };
 
 export const tabsArgTypes: ArgTypes<typeof tabsArgs> = {
@@ -72,6 +73,17 @@ export const tabsArgTypes: ArgTypes<typeof tabsArgs> = {
             type: { summary: getSelectControlOptions(Object.values(DISPLAY_STYLE)) },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: tabsArgs.displayStyle },
+        },
+    },
+    withinFunctionalHeader: {
+        name: 'within-functional-header',
+        description:
+            'Duidt aan dat de tabs in de functional header gerenderd worden. Aan de hand van dit attribuut wordt de layout van de tabs licht aangepast.',
+        control: false,
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(tabsArgs.withinFunctionalHeader) },
         },
     },
     onChangeActiveTab: {

--- a/libs/components/src/block/tabs/stories/vl-tabs.stories-doc.mdx
+++ b/libs/components/src/block/tabs/stories/vl-tabs.stories-doc.mdx
@@ -46,6 +46,12 @@ Zie de code onder de story voor het volledige voorbeeld.
     <Source code={tabsStoryUtils} language="ts" dark={true} />
 </details>
 
+### In functional header
+
+Wanneer de tabs in een functional header gerenderd worden, moet het attribuut `within-functional-header` toegevoegd worden.
+
+Hier vind je een [voorbeeld van een functional header met tabs](/story/components-block-functional-header--functional-header-tabs).
+
 ## Referenties
 
 ### Digitaal Vlaanderen


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-311)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC129)