### PR TITLE
feat: FLUX-304 - vl-map - invalid style toegevoegd voor self-intersecting geometry, 'allow-self-intersecting-geometry' attribuut en 'hasSelfIntersectingGeometries' method toegevoegd op vl-map

### DIFF
--- a/libs/map/src/components/action/draw-action/draw-line-action/stories/vl-map-draw-line-action.stories-doc.mdx
+++ b/libs/map/src/components/action/draw-action/draw-line-action/stories/vl-map-draw-line-action.stories-doc.mdx
@@ -10,7 +10,6 @@ Gebruik de `map-draw-line-action` component om een lijn te tekenen op een
 Deze component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,
 die op zijn beurt overerft van de `VlMapAction` klasse.
 
-
 ## Voorbeeld
 
 ```js

--- a/libs/map/src/components/action/draw-action/draw-polygon-action/stories/vl-map-draw-polygon-action.stories-doc.mdx
+++ b/libs/map/src/components/action/draw-action/draw-polygon-action/stories/vl-map-draw-polygon-action.stories-doc.mdx
@@ -10,6 +10,11 @@ Gebruik het `map-draw-polygon-action` component om een polygon te tekenen op een
 Dit component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,
 die op zijn beurt overerft van de `VlMapAction` klasse.
 
+## Ongeldige polygonen
+
+Wanneer je op de kaart een ongeldige polygon tekent, bijvoorbeeld één die zichzelf kruist, dan krijgt deze standaard 
+een rode "invalid" stijl. 
+[Zie de vl-map documentatie voor meer informatie](/docs/map-map--documentatie#ongeldige-geometrieën).
 
 ## Voorbeeld
 

--- a/libs/map/src/components/layer-style/stories/vl-map-layer-style.stories-arg.ts
+++ b/libs/map/src/components/layer-style/stories/vl-map-layer-style.stories-arg.ts
@@ -6,6 +6,7 @@ export const mapLayerStyleArg = {
     borderColor: 'rgba(2, 85, 204, 1)',
     borderSize: 1,
     color: 'rgba(2, 85, 204, 0.8)',
+    invalid: false,
     name: '',
     textBackgroundColor: 'rgba(0, 0, 0, 0)',
     textBorderColor: 'rgba(255, 255, 255, 0)',
@@ -44,6 +45,16 @@ export const mapLayerStyleArgTypes: ArgTypes<typeof mapLayerStyleArg> = {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: mapLayerStyleArg.color },
+        },
+    },
+    invalid: {
+        name: 'invalid',
+        description:
+            'Geeft aan of de "invalid" stijl toegepast moet worden. Je kan dit gebruiken om de kaartlaag manueel als "invalid" te renderen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(mapLayerStyleArg.invalid) },
         },
     },
     name: {

--- a/libs/map/src/components/layer-style/stories/vl-map-layer-style.stories.ts
+++ b/libs/map/src/components/layer-style/stories/vl-map-layer-style.stories.ts
@@ -28,6 +28,7 @@ const Template = story(
         borderSize,
         color,
         name,
+        invalid,
         textBackgroundColor,
         textBorderColor,
         textBorderSize,
@@ -67,6 +68,7 @@ const Template = story(
                     border-size=${borderSize}
                     color=${color}
                     name=${name}
+                    invalid=${invalid}
                     text-background-color=${textBackgroundColor}
                     text-border-color=${textBorderColor}
                     text-border-size=${textBorderSize}
@@ -90,6 +92,12 @@ MapLayerStyleText.args = {
     textColor: 'rgba(255, 255, 255, 1)',
     textFeatureAttributeName: 'label',
     textSize: '12px',
+};
+
+export const MapLayerStyleInvalid = Template.bind({});
+MapLayerStyleInvalid.storyName = 'vl-map-layer-style - invalid';
+MapLayerStyleInvalid.args = {
+    invalid: true,
 };
 
 export const MapLayerStyleLegend = story(

--- a/libs/map/src/components/layer-style/vl-map-layer-circle-style/vl-map-layer-circle-style.ts
+++ b/libs/map/src/components/layer-style/vl-map-layer-circle-style/vl-map-layer-circle-style.ts
@@ -34,7 +34,7 @@ export class VlMapLayerCircleStyle extends VlMapLayerStyle {
     }
 
     get _styleFunction() {
-        return (feature, resolution) => {
+        return (feature) => {
             const features = feature && feature.get ? feature.get('features') || [] : [];
             let { textColor, color, borderColor, borderSize } = this;
             const numberOfFeatures = features.length || 1;

--- a/libs/map/src/components/layer-style/vl-map-layer-style.cy.ts
+++ b/libs/map/src/components/layer-style/vl-map-layer-style.cy.ts
@@ -1,5 +1,8 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
+import Feature from 'ol/Feature';
+import { LineString, Polygon } from 'ol/geom';
+import OlStyle from 'ol/style/Style';
 import { VlMap } from '../../vl-map';
 import { VlMapLayerStyle } from '../layer-style/vl-map-layer-style';
 import { VlMapFeaturesLayer } from '../layer/vector-layer/vl-map-features-layer/vl-map-features-layer';
@@ -230,3 +233,50 @@ describe('cypress-component - map - vl-map-layer-style', () => {
         });
     });
 });
+
+describe('cypress-component - map - vl-map-layer-style - _styleFunction', () => {
+    it('geeft de invalid style terug voor een ongeldige feature', () => {
+        const badPolygon = new Polygon([
+            [
+                [2, 2],
+                [4, 4],
+                [4, 2],
+                [2, 4],
+                [2, 2],
+            ],
+        ]);
+        const feature = new Feature(badPolygon);
+
+        cy.mount(mapLayerStyleFixture);
+        cy.runTestFor<VlMap>('vl-map', (vlMap) => {
+            cy.wrap(vlMap.ready).then(() => {
+                const layerStyle = vlMap.querySelector<VlMapLayerStyle>('vl-map-layer-style');
+                const style = layerStyle._styleFunction(feature);
+                expect(style).to.be.instanceOf(OlStyle);
+                const strokeColor = style.getStroke().getColor();
+                expect(strokeColor).to.eq('#d2373c');
+            });
+        });
+    });
+
+    it('geeft de gewone style terug voor een valid feature', () => {
+        const goodLine = new LineString([
+            [0, 0],
+            [1, 1],
+            [2, 2],
+        ]);
+        const feature = new Feature({ geometry: goodLine });
+
+        cy.mount(mapLayerStyleFixture);
+        cy.runTestFor<VlMap>('vl-map', (vlMap) => {
+            cy.wrap(vlMap.ready).then(() => {
+                const layerStyle = vlMap.querySelector<VlMapLayerStyle>('vl-map-layer-style');
+                const style = layerStyle._styleFunction(feature);
+                expect(style).to.be.instanceOf(OlStyle);
+                const strokeColor = style.getStroke().getColor();
+                expect(strokeColor).to.eq(layerStyle.borderColor);
+            });
+        });
+    });
+});
+

--- a/libs/map/src/components/layer-style/vl-map-layer-style.ts
+++ b/libs/map/src/components/layer-style/vl-map-layer-style.ts
@@ -1,13 +1,20 @@
 import { BaseHTMLElement, webComponent } from '@domg-wc/common';
+import { Feature } from 'ol';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleStroke from 'ol/style/Stroke';
 import OlStyle from 'ol/style/Style';
 import OlStyleText from 'ol/style/Text';
+import { OpenLayersUtil } from '../../utils/ol-util';
+import { VlMap } from '../../vl-map';
 
 @webComponent('vl-map-layer-style')
 export class VlMapLayerStyle extends BaseHTMLElement {
+    private mapElement: VlMap | null = null;
+
     connectedCallback() {
         super.connectedCallback();
+
+        this.mapElement = this.closest('vl-map');
 
         this._setStyleOnParent();
     }
@@ -60,19 +67,35 @@ export class VlMapLayerStyle extends BaseHTMLElement {
         return this.getAttribute('text-offset-y') || 0;
     }
 
+    get invalid() {
+        return this.hasAttribute('invalid');
+    }
+
     // @ts-expect-error: style exists in HTMLElement
     get style() {
         return (feature, resolution) => {
             if (!this.appliesTo(feature)) {
                 return null;
             }
-            return this._styleFunction(feature, resolution);
+            return this._styleFunction(feature);
         };
     }
 
     get _styleFunction() {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        return (feature, resolution) => {
+        return (feature) => {
+            const geometry = feature instanceof Feature && feature?.getGeometry();
+
+            if (
+                this.invalid ||
+                (!this.mapElement.invalidGeometryAllowed && geometry && OpenLayersUtil.geometryIsInvalid(geometry))
+            ) {
+                return new OlStyle({
+                    fill: new OlStyleFill({ color: 'rgba(210, 55, 60, 0.3)' }),
+                    stroke: new OlStyleStroke({ color: '#d2373c', width: 2, lineDash: [4, 4] }),
+                    text: this._getTextStyle(feature),
+                });
+            }
+
             const styleConfig = {
                 fill: new OlStyleFill({
                     color: this.color,
@@ -81,9 +104,9 @@ export class VlMapLayerStyle extends BaseHTMLElement {
                     color: this.borderColor,
                     width: this.borderSize as number,
                 }),
-                text: undefined,
+                text: this._getTextStyle(feature),
             };
-            styleConfig.text = this._getTextStyle(feature);
+
             return new OlStyle(styleConfig);
         };
     }

--- a/libs/map/src/stories/vl-map.stories-arg.ts
+++ b/libs/map/src/stories/vl-map.stories-arg.ts
@@ -1,20 +1,21 @@
 import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
-import { EVENT } from '../vl-map.model';
 import { action } from 'storybook/actions';
+import { EVENT } from '../vl-map.model';
 
 export const mapArgs = {
     ...defaultArgs,
     allowFullscreen: false,
+    allowInvalidGeometry: false,
     disableEscape: false,
-    disableRotation: false,
-    disableMousewheelZoom: false,
     disableKeyboard: false,
+    disableMousewheelZoom: false,
+    disableRotation: false,
     fullHeight: false,
+    lambert2008: false,
     noBorder: false,
     activeActionChange: action(EVENT.ACTIVE_ACTION_CHANGED),
     layerVisibleChange: action(EVENT.LAYER_VISIBLE_CHANGED),
-    lambert2008: false,
 };
 
 export const mapArgTypes: ArgTypes<typeof mapArgs> = {
@@ -27,6 +28,16 @@ export const mapArgTypes: ArgTypes<typeof mapArgs> = {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: String(mapArgs.allowFullscreen) },
+        },
+    },
+    allowInvalidGeometry: {
+        name: 'allow-invalid-geometry',
+        description:
+            'Standaard worden ongeldige geometrieën gemarkeerd met een rode "invalid" stijl. Je kan dit attribuut gebruiken om dit gedrag uit te zetten.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(mapArgs.allowInvalidGeometry) },
         },
     },
     disableEscape: {
@@ -82,7 +93,7 @@ export const mapArgTypes: ArgTypes<typeof mapArgs> = {
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: mapArgs.lambert2008 },
+            defaultValue: { summary: String(mapArgs.lambert2008) },
         },
     },
     noBorder: {

--- a/libs/map/src/stories/vl-map.stories-doc.mdx
+++ b/libs/map/src/stories/vl-map.stories-doc.mdx
@@ -59,6 +59,19 @@ Vereist je project Lambert 72 coordinaten bij het intekenen, dan wordt het upgra
 beter uitgesteld tot wanneer het project ook Lambert 2008 data ondersteunt. De regel hierbij is dat het 
 coördinatenstelsel van intekenen hetzelfde moet zijn als dat van de kaart.
 
+## Ongeldige geometrieën
+
+Wanneer je op de kaart een ongeldige geometrie tekent, bijvoorbeeld een zelf-kruisende polygoon, dan krijgt deze 
+standaard een rode "invalid" stijl. Indien je dit niet wenst kan je het 
+attribuut `allow-invalid-geometries` gebruiken.
+
+Om te controleren of een kaart 1 of meerdere ongeldige geometrieën bevat kan je de methode 
+`hasInvalidGeometries` gebruiken:
+
+```typescript
+const map = document.querySelector<VlMap>('#my-map');
+const hasInvalidGeometries = map.hasInvalidGeometries();
+```
 
 ## Configuratie
 

--- a/libs/map/src/stories/vl-map.stories.ts
+++ b/libs/map/src/stories/vl-map.stories.ts
@@ -4,6 +4,7 @@ import { story } from '@resources/utils-storybook';
 // -> buiten de monorepo werkt dat niet omdat sideEffects disabled worden voor de root-barrel file in de artifacts
 import { registerWebComponents } from '@domg-wc/common';
 import { VlTitleComponent } from '@domg-wc/components/atom';
+import { VlToasterComponent } from '@domg-wc/components/block';
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import '../components/action/draw-action/draw-line-action/vl-map-draw-line-action';
@@ -27,6 +28,7 @@ import { LEGEND_PLACEMENT } from '../components/legend/vl-map-legend.defaults';
 import '../components/overview-map/vl-map-overview-map';
 import '../components/side-sheet/vl-map-side-sheet';
 import '../vl-map';
+import { VlMap } from '../vl-map';
 import { mapArgs, mapArgTypes } from './vl-map.stories-arg';
 import mapDoc from './vl-map.stories-doc.mdx';
 import {
@@ -166,6 +168,7 @@ export const MapPlayground = story(
     mapArgs,
     ({
         allowFullscreen,
+        allowInvalidGeometry,
         disableEscape,
         disableRotation,
         disableMousewheelZoom,
@@ -176,7 +179,9 @@ export const MapPlayground = story(
         layerVisibleChange,
     }) => html`
         <vl-map
+            id="map-playground"
             lambert2008
+            ?allow-invalid-geometry=${allowInvalidGeometry}
             ?allow-fullscreen=${allowFullscreen}
             ?disable-escape-key=${disableEscape}
             ?disable-rotation=${disableRotation}
@@ -291,6 +296,27 @@ export const MapPlayground = story(
                         >
                         </vl-button>
                         <p>Draw Polygon</p>
+                    </div>
+
+                    <div>
+                        <vl-button
+                            @click=${() => {
+                                const hasInvalidGeometries = document
+                                    .querySelector<VlMap>('#map-playground')
+                                    ?.hasInvalidGeometries();
+                                const toaster = document.querySelector<VlToasterComponent>('#toaster-invalid');
+                                toaster.showAlert({
+                                    icon: hasInvalidGeometries ? 'alert-circle' : 'check-circle',
+                                    type: hasInvalidGeometries ? 'error' : 'success',
+                                    message: `Deze kaart heeft ${
+                                        hasInvalidGeometries ? '' : 'GEEN'
+                                    } ongeldige geometrieën.`,
+                                    closable: true,
+                                });
+                            }}
+                            >Check invalid shapes</vl-button
+                        >
+                        <vl-toaster id="toaster-invalid" fade-out></vl-toaster>
                     </div>
                 </div>
             </vl-map-side-sheet>
@@ -332,6 +358,7 @@ export const MapPlaygroundLB72 = story(
     mapArgs,
     ({
         allowFullscreen,
+        allowInvalidGeometry,
         disableEscape,
         disableRotation,
         disableMousewheelZoom,
@@ -342,7 +369,9 @@ export const MapPlaygroundLB72 = story(
         layerVisibleChange,
     }) => html`
         <vl-map
+            id="map-playground-lb72"
             ?allow-fullscreen=${allowFullscreen}
+            ?allow-invalid-geometry=${allowInvalidGeometry}
             ?disable-escape-key=${disableEscape}
             ?disable-rotation=${disableRotation}
             ?disable-mouse-wheel-zoom=${disableMousewheelZoom}
@@ -456,6 +485,27 @@ export const MapPlaygroundLB72 = story(
                         >
                         </vl-button>
                         <p>Draw Polygon</p>
+                    </div>
+
+                    <div>
+                        <vl-button
+                            @click=${() => {
+                                const hasInvalidGeometries = document
+                                    .querySelector<VlMap>('#map-playground-lb72')
+                                    ?.hasInvalidGeometries();
+                                const toaster = document.querySelector<VlToasterComponent>('#toaster-invalid-lb72');
+                                toaster.showAlert({
+                                    icon: hasInvalidGeometries ? 'alert-circle' : 'check-circle',
+                                    type: hasInvalidGeometries ? 'error' : 'success',
+                                    message: `Deze kaart heeft ${
+                                        hasInvalidGeometries ? '' : 'GEEN'
+                                    } ongeldige geometrieën.`,
+                                    closable: true,
+                                });
+                            }}
+                            >Check invalid shapes</vl-button
+                        >
+                        <vl-toaster id="toaster-invalid-lb72" fade-out></vl-toaster>
                     </div>
                 </div>
             </vl-map-side-sheet>

--- a/libs/map/src/utils/ol-util.ts
+++ b/libs/map/src/utils/ol-util.ts
@@ -1,3 +1,10 @@
+import { GeoJSONReader } from 'jsts/org/locationtech/jts/io';
+import { IsValidOp } from 'jsts/org/locationtech/jts/operation/valid';
+import GeoJSON from 'ol/format/GeoJSON';
+import { Geometry } from 'ol/geom';
+
+const geoJsonFormatter = new GeoJSON();
+
 export class OpenLayersUtil {
     static createDummyLayer(id, source?) {
         return {
@@ -41,5 +48,17 @@ export class OpenLayersUtil {
                 }
             },
         };
+    }
+
+    static geometryIsInvalid(geometry: Geometry): boolean {
+        if (!geometry) return false;
+
+        const geoJSON = new GeoJSON();
+        const geoJSONReader = new GeoJSONReader();
+
+        const geojson = geoJSON.writeGeometryObject(geometry as Geometry);
+        const jstsGeometry = geoJSONReader.read(geojson);
+
+        return !IsValidOp.isValid(jstsGeometry);
     }
 }

--- a/libs/map/src/utils/ol-utils.spec.ts
+++ b/libs/map/src/utils/ol-utils.spec.ts
@@ -1,0 +1,131 @@
+import { GeometryCollection, LineString, MultiPolygon, Polygon } from 'ol/geom';
+import { OpenLayersUtil } from './ol-util';
+
+describe('jest - map - ol-utils', () => {
+    it('geeft false terug voor een geldige Polygon', () => {
+        const polygon = new Polygon([
+            [
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+                [0, 0],
+            ],
+        ]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(polygon)).toBe(false);
+    });
+
+    it('geeft true terug voor een ongeldige Polygon', () => {
+        const polygon = new Polygon([
+            [
+                [0, 0],
+                [2, 2],
+                [2, 0],
+                [0, 2],
+                [0, 0],
+            ],
+        ]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(polygon)).toBe(true);
+    });
+
+    it('geeft true terug wanneer een GeometryCollection een ongeldige geometrie bevat', () => {
+        const goodPolygon = new Polygon([
+            [
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+                [0, 0],
+            ],
+        ]);
+
+        const badPolygon = new Polygon([
+            [
+                [0, 0],
+                [2, 2],
+                [2, 0],
+                [0, 2],
+                [0, 0],
+            ],
+        ]);
+
+        const collection = new GeometryCollection([goodPolygon, badPolygon]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(collection)).toBe(true);
+    });
+
+    it('geeft false terug wanneer alle geometrieën in een GeometryCollection geldig zijn', () => {
+        const line1 = new LineString([
+            [0, 0],
+            [1, 1],
+        ]);
+
+        const line2 = new LineString([
+            [2, 2],
+            [3, 3],
+        ]);
+
+        const collection = new GeometryCollection([line1, line2]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(collection)).toBe(false);
+    });
+
+    it('geeft true terug voor een MultiPolygon die een ongeldige polygoon bevat', () => {
+        const validPolygon = new Polygon([
+            [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0],
+            ],
+        ]);
+
+        const badPolygon = new Polygon([
+            [
+                [2, 2],
+                [4, 4],
+                [4, 2],
+                [2, 4],
+                [2, 2],
+            ],
+        ]);
+
+        const multi = new MultiPolygon([validPolygon.getCoordinates(), badPolygon.getCoordinates()]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(multi)).toBe(true);
+    });
+
+    it('geeft false terug voor een MultiPolygon met enkel geldige polygonen', () => {
+        const p1 = new Polygon([
+            [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0],
+            ],
+        ]);
+
+        const p2 = new Polygon([
+            [
+                [2, 2],
+                [3, 2],
+                [3, 3],
+                [2, 3],
+                [2, 2],
+            ],
+        ]);
+
+        const multi = new MultiPolygon([p1.getCoordinates(), p2.getCoordinates()]);
+
+        expect(OpenLayersUtil.geometryIsInvalid(multi)).toBe(false);
+    });
+
+    it('geeft false terug voor niet-ondersteunde geometrietypes', () => {
+        // intentionally passing an invalid value (null)
+        expect(OpenLayersUtil.geometryIsInvalid(null as any)).toBe(false);
+    });
+});

--- a/libs/map/src/vl-map.cy.ts
+++ b/libs/map/src/vl-map.cy.ts
@@ -1,6 +1,8 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
 import OlFullScreenControl from 'ol/control/FullScreen';
+import Feature from 'ol/Feature';
+import { LineString, Polygon } from 'ol/geom';
 import OlLayerGroup from 'ol/layer/Group';
 import proj4 from 'proj4';
 import { VlSelectAction } from './actions/select/select-action';
@@ -411,6 +413,69 @@ describe('cypress-component - map - vl-map', () => {
                 // @ts-ignore
                 expect(vlMap.map.controls.getArray().find((control) => control instanceof OlFullScreenControl)).to
                     .exist;
+            });
+        });
+    });
+
+    it('returns true if one of the layers has an invalid feature', () => {
+        const badPolygon = new Polygon([
+            [
+                [2, 2],
+                [4, 4],
+                [4, 2],
+                [2, 4],
+                [2, 2],
+            ],
+        ]);
+        const feature = new Feature(badPolygon);
+
+        const mockLayer = {
+            layer: {
+                getSource: () => ({
+                    getFeatures: () => [feature],
+                }),
+            },
+        } as any;
+
+        cy.mount(mapFixture);
+        cy.runTestFor<VlMap>('vl-map', (vlMap) => {
+            cy.wrap(vlMap.ready).then(() => {
+                Object.defineProperty(vlMap, 'nonBaseLayers', {
+                    get: () => [mockLayer],
+                });
+
+                const result = vlMap.hasInvalidGeometries();
+                expect(result).equals(true);
+            });
+        });
+    });
+
+    it('returns false if none of the layers have invalid features', () => {
+        const feature = new Feature(
+            new LineString([
+                [0, 0],
+                [1, 1],
+                [2, 2],
+            ])
+        );
+
+        const mockLayer = {
+            layer: {
+                getSource: () => ({
+                    getFeatures: () => [feature],
+                }),
+            },
+        } as any;
+
+        cy.mount(mapFixture);
+        cy.runTestFor<VlMap>('vl-map', (vlMap) => {
+            cy.wrap(vlMap.ready).then(() => {
+                Object.defineProperty(vlMap, 'nonBaseLayers', {
+                    get: () => [mockLayer],
+                });
+
+                const result = vlMap.hasInvalidGeometries();
+                expect(result).equals(false);
             });
         });
     });

--- a/libs/map/src/vl-map.ts
+++ b/libs/map/src/vl-map.ts
@@ -11,6 +11,7 @@ import { VlMapWfsLayer } from './components/layer/vector-layer/vl-map-wfs-layer/
 import { VlMapLayer } from './components/layer/vl-map-layer';
 import { VlMapWmsLayer } from './components/layer/wms-layer/vl-map-wms-layer';
 import { getLambert2008Code, getLambert2008Extent, getLambert72Code, getLambert72Extent } from './utils/capabilities';
+import { OpenLayersUtil } from './utils/ol-util';
 import { vlMapFluxStyles } from './vl-map.flux-css';
 import { EVENT } from './vl-map.model';
 
@@ -25,7 +26,7 @@ export class VlMap extends BaseHTMLElement {
     protected __ready: any;
 
     static get _observedAttributes() {
-        return ['lambert2008'];
+        return ['lambert2008', 'allow-invalid-geometry'];
     }
 
     constructor() {
@@ -148,6 +149,29 @@ export class VlMap extends BaseHTMLElement {
 
     get _extent() {
         return this.isLambert2008 ? getLambert2008Extent() : getLambert72Extent();
+    }
+
+    get invalidGeometryAllowed() {
+        return this.hasAttribute('allow-invalid-geometry');
+    }
+
+    public hasInvalidGeometries(): boolean {
+        return this.nonBaseLayers.some((vlMapLayer) => {
+            const { layer } = vlMapLayer;
+            if (!layer?.getSource) return false;
+
+            return layer
+                .getSource()
+                .getFeatures()
+                .some((feature) => {
+                    const geometry = feature.getGeometry();
+                    if (geometry) {
+                        return OpenLayersUtil.geometryIsInvalid(geometry);
+                    }
+
+                    return false;
+                });
+        });
     }
 
     get zoomInTipLabel() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26083,10 +26083,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.15.7",


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-304)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC136)