### PR TITLE
fix: FLUX-358 - vl-properties - columns layout brak uit zijn parent container

### DIFF
--- a/libs/components/src/block/properties/vl-properties.css.ts
+++ b/libs/components/src/block/properties/vl-properties.css.ts
@@ -77,7 +77,8 @@ export const propertiesStyles: CSSResult = css`
     }
 
     dl:has(.item) {
-        display: initial;
+        display: flow-root;
+        margin-block: 0;
     }
 
     dl .item {


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-358)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC143)