### PR TITLE
fix: FLUX-374 - vl-cascader - vlLayoutStyles toegevoegd in shadow DOM

### DIFF
--- a/libs/common/utilities/src/css/index.ts
+++ b/libs/common/utilities/src/css/index.ts
@@ -1,5 +1,5 @@
 export { vlColorVars } from './base/var/vl-color.css';
-export { GlobalStyles } from './styles';
+export { GlobalStyles, layoutStyles as vlLayoutStyles } from './styles';
 export { vlAccessibilityStyles } from './base/accessibility/vl-accessibility.css';
 export { iconFontLocation } from './base/font/vl-font.css';
 export { vlFocusOutlineMixin } from './base/mixin/vl-outlines.css';

--- a/libs/components/src/next/cascader/vl-cascader-item.component.ts
+++ b/libs/components/src/next/cascader/vl-cascader-item.component.ts
@@ -1,13 +1,12 @@
-import { vlGroupStyles } from '@domg-wc/common-utilities/css';
-import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { BaseLitElement, findNodesForSlot } from '@domg-wc/common-utilities';
-import { customElement } from 'lit/decorators.js';
+import { vlLayoutStyles } from '@domg-wc/common-utilities/css';
 import { resetStyle } from '@domg/govflanders-style/common';
-import { vlElementsStyle } from '@domg-wc/elements';
+import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import cascaderItemUigStyle from './vl-cascader-item.uig-css';
+import { VlCascaderComponent } from './vl-cascader.component';
 import { CASCADER_MESSAGES, CASCADER_SLOTS, CascaderItem } from './vl-cascader.model';
 import { defaultItemActionTemplate, getDefaultItemTemplate, getTemplateFunctionForType } from './vl-cascader.utils';
-import { VlCascaderComponent } from './vl-cascader.component';
 
 @customElement('vl-cascader-item')
 export class VlCascaderItemComponent extends BaseLitElement {
@@ -27,7 +26,7 @@ export class VlCascaderItemComponent extends BaseLitElement {
     }
 
     static get styles(): (CSSResult | CSSResult[])[] {
-        return [resetStyle, vlGroupStyles, cascaderItemUigStyle];
+        return [resetStyle, vlLayoutStyles, cascaderItemUigStyle];
     }
 
     connectedCallback() {

--- a/libs/components/src/next/cascader/vl-cascader.component.ts
+++ b/libs/components/src/next/cascader/vl-cascader.component.ts
@@ -1,4 +1,5 @@
 import { BaseLitElement, findNodesForSlot, registerWebComponents } from '@domg-wc/common-utilities';
+import { vlLayoutStyles } from '@domg-wc/common-utilities/css';
 import { resetStyle } from '@domg/govflanders-style/common';
 import { breadcrumbStyle } from '@domg/govflanders-style/component';
 import { CSSResult, html, nothing, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
@@ -8,7 +9,6 @@ import { VlIconComponent } from '../icon';
 import { VlLinkComponent } from '../link';
 import { vlTitleStyles } from '../title/vl-title.css';
 import { VlCascaderItemComponent } from './vl-cascader-item.component';
-import vlCascaderItemUigCss from './vl-cascader-item.uig-css';
 import { cascaderDefaults } from './vl-cascader.defaults';
 import { CASCADER_SLOTS, CascaderItem, ItemListFn, NarrowDownFn, TemplateFn } from './vl-cascader.model';
 import cascaderUigStyle from './vl-cascader.uig-css';
@@ -54,7 +54,7 @@ export class VlCascaderComponent extends BaseLitElement {
     }
 
     static get styles(): (CSSResult | CSSResult[])[] {
-        return [resetStyle, breadcrumbStyle, cascaderUigStyle, vlCascaderItemUigCss, vlTitleStyles];
+        return [resetStyle, breadcrumbStyle, cascaderUigStyle, vlTitleStyles, vlLayoutStyles];
     }
 
     connectedCallback() {


### PR DESCRIPTION
De `vl-cascader` component rendert de templates van de afnemer binnen de shadow DOM, daarom is het belangrijk dat de layout styles ook toegevoegd zijn aan de shadow DOM van de component

Daarnaast ook cascader item styles verwijderd uit de `vl-cascader` component, die enkel in de `vl-cascader-item` component horen te staan.

[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-374)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC160)