### PR TITLE
fix: FLUX-374 - vl-cascader - vlLayoutStyles toegevoegd in shadow DOM

### DIFF
--- a/libs/components/src/block/cascader/vl-cascader-item.component.ts
+++ b/libs/components/src/block/cascader/vl-cascader-item.component.ts
@@ -1,4 +1,4 @@
-import { vlGroupStyles } from '@domg-wc/styles';
+import { vlGroupStyles, vlLayoutStyles } from '@domg-wc/styles';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { BaseLitElement, findNodesForSlot } from '@domg-wc/common';
 import { customElement } from 'lit/decorators.js';
@@ -26,7 +26,7 @@ export class VlCascaderItemComponent extends BaseLitElement {
     }
 
     static get styles(): (CSSResult | CSSResult[])[] {
-        return [resetStyle, vlGroupStyles, vlCascaderItemFluxStyles];
+        return [resetStyle, vlLayoutStyles, vlCascaderItemFluxStyles];
     }
 
     connectedCallback() {

--- a/libs/components/src/block/cascader/vl-cascader.component.ts
+++ b/libs/components/src/block/cascader/vl-cascader.component.ts
@@ -13,6 +13,7 @@ import { cascaderDefaults } from './vl-cascader.defaults';
 import { CASCADER_SLOTS, CascaderItem, ItemListFn, NarrowDownFn, TemplateFn } from './vl-cascader.model';
 import { vlCascaderFluxStyles } from './vl-cascader.flux-css';
 import { getDefaultItemTemplate, getTemplateFunctionForType } from './vl-cascader.utils';
+import { vlLayoutStyles } from '@domg-wc/styles';
 
 @customElement('vl-cascader')
 export class VlCascaderComponent extends BaseLitElement {
@@ -54,7 +55,7 @@ export class VlCascaderComponent extends BaseLitElement {
     }
 
     static get styles(): (CSSResult | CSSResult[])[] {
-        return [resetStyle, breadcrumbStyle, vlCascaderFluxStyles, vlCascaderItemFluxStyles, vlTitleStyles];
+        return [resetStyle, breadcrumbStyle, vlCascaderFluxStyles, vlTitleStyles, vlLayoutStyles];
     }
 
     get items(): CascaderItem[] {


### PR DESCRIPTION
De `vl-cascader` component rendert de templates van de afnemer binnen de shadow DOM, daarom is het belangrijk dat de layout styles ook toegevoegd zijn aan de shadow DOM van de component

Daarnaast ook cascader item styles verwijderd uit de `vl-cascader` component, die enkel in de `vl-cascader-item` component horen te staan.

[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-374)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC161)