### PR TITLE
fix: FLUX-371 - vl-link - cursor: pointer ingesteld voor button-as-link

### DIFF
--- a/libs/components/src/atom/link/vl-button-as-link.css.ts
+++ b/libs/components/src/atom/link/vl-button-as-link.css.ts
@@ -22,6 +22,5 @@ export const buttonAsLinkStyles = css`
         position: relative;
         word-break: break-word;
         line-height: inherit;
-        cursor: default;
     }
 `;


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-371)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC168)