### PR TITLE
fix: FLUX-465 - vl-infoblock - onnodige tekst verwijderd

### DIFF
--- a/libs/components/src/block/infoblock/vl-infoblock.component.ts
+++ b/libs/components/src/block/infoblock/vl-infoblock.component.ts
@@ -16,7 +16,7 @@ export class VlInfoblockComponent extends BaseHTMLElement {
                 <header class="vl-infoblock__header" role="presentation">
                     <vl-icon id="infoblock_icon" class="vl-infoblock__header__icon"></vl-icon>
                     <slot name="title">
-                        <h2 id="title_content" class="vl-infoblock__title">tester</h2>
+                        <h2 id="title_content" class="vl-infoblock__title"></h2>
                     </slot>
                 </header>
                 <div class="vl-infoblock__content" id="infoblock_content">


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-465)