### PR TITLE
fix: FLUX-489 - vl-alert - message-attribuut werking uitgebreid met newline character ondersteuning

### DIFF
--- a/libs/components/src/block/alert/vl-alert.flux-css.ts
+++ b/libs/components/src/block/alert/vl-alert.flux-css.ts
@@ -10,4 +10,8 @@ export const vlAlertFluxStyles: CSSResult = css`
             max-width: 90%;
         }
     }
+    
+    #message.vl-alert-message > p {
+        white-space: pre-line;
+    }
 `;


### PR DESCRIPTION

[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-489)