### PR TITLE
fix: FLUX-492 - in de gegenereerde web-types ontbrak de omschrijving op component niveau

### DIFF
--- a/libs/components/src/atom/atom.web-types.json
+++ b/libs/components/src/atom/atom.web-types.json
@@ -9,6 +9,7 @@
             "elements": [
                 {
                     "name": "vl-button",
+                    "description": "Gebruik de `button` component om een button af te beelden op een pagina.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-button--documentatie",
                     "attributes": [
                         {
@@ -144,6 +145,7 @@
                 },
                 {
                     "name": "vl-icon",
+                    "description": "Gebruik de `icon` component om een icoon af te beelden op een pagina.<br/>\nZie het [overzicht](#overzicht) onderaan voor alle beschikbare iconen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-icon--documentatie",
                     "attributes": [
                         {
@@ -199,6 +201,7 @@
                 },
                 {
                     "name": "vl-link",
+                    "description": "Gebruik de `link` component om een link af te beelden op een pagina.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-link--documentatie",
                     "attributes": [
                         {
@@ -270,6 +273,7 @@
                 },
                 {
                     "name": "vl-paragraph",
+                    "description": "Gebruik de `paragraph` component om een paragraaf af te beelden op een pagina.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-paragraph--documentatie",
                     "attributes": [
                         {
@@ -298,6 +302,7 @@
                 },
                 {
                     "name": "vl-text",
+                    "description": "Gebruik de `text` component om een tekst af te beelden op andere wijze.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-text-text--documentatie",
                     "attributes": [
                         {
@@ -356,6 +361,7 @@
                 },
                 {
                     "name": "vl-title",
+                    "description": "Gebruik de `title` component om een title af te beelden.<br/>\n\nDeze component geniet de voorkeur boven het oude [vl-title](/docs/elements-title-h1--documentatie) element.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-atom-title--documentatie",
                     "attributes": [
                         {

--- a/libs/components/src/block/block.web-types.json
+++ b/libs/components/src/block/block.web-types.json
@@ -9,6 +9,7 @@
             "elements": [
                 {
                     "name": "vl-accordion",
+                    "description": "Gebruik de `accordion` component om informatie te tonen of te verbergen aan de hand van een toggle.\nVoor meer informatie over het afbeelden van meerdere accordions zie de\n[accordion-list](/docs/components-block-accordion-list--documentatie) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-accordion--documentatie",
                     "attributes": [
                         {
@@ -59,6 +60,15 @@
                             "name": "toggle-text",
                             "description": "Tekst waarop de gebruiker kan klikken om de accordion te openen of te sluiten.<br>Kan niet in combinatie gebruikt worden met:<br>• close-toggle-text attribuut<br>• open-toggle-text attribuut<br>• title slot",
                             "default": ""
+                        },
+                        {
+                            "name": "heading-level",
+                            "description": "Bepaalt het heading level (h1, h2, h3, ...) van de titel van de accordion.",
+                            "value": {
+                                "kind": "plain",
+                                "type": "'1' | '2' | '3' | '4' | '5' | '6'"
+                            },
+                            "default": ""
                         }
                     ],
                     "slots": [
@@ -95,6 +105,7 @@
                 },
                 {
                     "name": "vl-alert",
+                    "description": "Gebruik de `alert` component om de gebruiker op de hoogte te houden van belangrijke informatie.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-alert--documentatie",
                     "attributes": [
                         {
@@ -175,6 +186,7 @@
                 },
                 {
                     "name": "vl-autocomplete",
+                    "description": "Gebruik de `autocomplete` component om een lijst met suggesties weer te geven, gefilterd op de ingevoerde tekst. De\nlijst kan een statische lijst zijn (`static-list`) of kan worden opgehaald uit een api (dataFetcher).",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-autocomplete--documentatie",
                     "attributes": [
                         {
@@ -281,6 +293,7 @@
                 },
                 {
                     "name": "vl-breadcrumb",
+                    "description": "Gebruik de `breadcrumb` component om de locatie van de huidige pagina af te beelden binnen een navigeerbare hiërarchie.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-breadcrumb--documentatie"
                 },
                 {
@@ -313,6 +326,7 @@
                 },
                 {
                     "name": "vl-content-header",
+                    "description": "Gebruik de `content-header` component bovenaan informerende pagina's. Hij biedt gebruikers alle informatie over de\nwebsite die ze bezoeken.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-content-header--documentatie",
                     "attributes": [
                         {
@@ -409,6 +423,7 @@
                 },
                 {
                     "name": "vl-document",
+                    "description": "Gebruik de `document` component om een link naar een bestand toe te voegen dat de gebruiker in de browser kan bekijken\nof downloaden.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-document--documentatie",
                     "attributes": [
                         {
@@ -448,6 +463,7 @@
                 },
                 {
                     "name": "vl-functional-header",
+                    "description": "Gebruik de `functional-header` component om bovenaan de pagina generieke informatie te tonen zoals bijvoorbeeld\neen titel en acties.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-functional-header--documentatie",
                     "attributes": [
                         {
@@ -498,6 +514,11 @@
                                 "type": "'none' | 'small' | 'medium' | 'large'"
                             },
                             "default": "large"
+                        },
+                        {
+                            "name": "skip-to-content-id",
+                            "description": "Aanbevolen voor [toegankelijkheidsrichtlijn 2.4 Blokken omzeilen](/?path=/docs/richtlijnen-toegankelijkheid-aanpak-2-bedienbaar-2-4-navigeerbaar--documentatie#blokken-omzeilen). Vul hier de ID in van de eerste heading van de content.",
+                            "default": ""
                         },
                         {
                             "name": "sticky",
@@ -561,6 +582,7 @@
                 },
                 {
                     "name": "vl-http-error-message",
+                    "description": "Gebruik de `http-error-message` component om een error boodschap aan de gebruiker te tonen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-http-error-message--documentatie",
                     "attributes": [
                         {
@@ -604,6 +626,7 @@
                 },
                 {
                     "name": "vl-info-tile",
+                    "description": "Gebruik de `info-tile` component in informatieve en interactieve dashboards.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-info-tile--documentatie",
                     "attributes": [
                         {
@@ -724,6 +747,7 @@
                 },
                 {
                     "name": "vl-input-slider",
+                    "description": "Gebruik de `input-slider` om een waarde te selecteren tussen een minimum en maximum waarde.\n**Let op**: deze component is niet dezelfde als de `vl-ui-range` component van Digitaal Vlaanderen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-input-slider--documentatie",
                     "attributes": [
                         {
@@ -846,6 +870,7 @@
                 },
                 {
                     "name": "vl-cascader",
+                    "description": "Gebruik de `cascader` component om hiërarchische data weer te geven als een drilldown van lijsten.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-cascader-cascader--documentatie",
                     "attributes": [
                         {
@@ -961,6 +986,7 @@
                 },
                 {
                     "name": "vl-table",
+                    "description": "Gebruik de `table` component om op een gestructureerde manier (grote hoeveelheden) relationele data te tonen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-table--documentatie",
                     "attributes": [
                         {
@@ -1007,6 +1033,7 @@
                 },
                 {
                     "name": "vl-doormat",
+                    "description": "Gebruik de `doormat` component om een snel en duidelijk overzicht weer te geven van de informatie op je website.<br/>\nElke doormat krijgt zijn eigen titel, tekst, optionele afbeelding en linkt naar een pagina binnen je website.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-doormat--documentatie",
                     "attributes": [
                         {
@@ -1070,6 +1097,7 @@
                 },
                 {
                     "name": "vl-infotext",
+                    "description": "Gebruik de `infotext` component om belangrijke nummers duidelijk weer te gevem.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-infotext--documentatie",
                     "attributes": [
                         {
@@ -1108,6 +1136,7 @@
                 },
                 {
                     "name": "vl-properties",
+                    "description": "Gebruik de `properties` component om properties te tonen op een pagina. Je kan de properties specifiëren als\ninner-html of als json-structuur meegeven aan het `props` attribuut.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-properties--documentatie",
                     "attributes": [
                         {
@@ -1139,6 +1168,7 @@
                 },
                 {
                     "name": "vl-search-result",
+                    "description": "Gebruik de `search-result` component om een zoekresultaat weer te geven.<br/>\n\nVolgende sub-componenten zijn beschikbaar om het zoekresultaat op te bouwen:\n\n- VlSearchResultProperties `[vl-search-result-properties]`\n- VlSearchResultText `[vl-search-result-text]`\n- VlSearchResultTitle `[vl-search-result-title]`",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-search-result--documentatie",
                     "attributes": [
                         {
@@ -1169,6 +1199,7 @@
                 },
                 {
                     "name": "vl-side-navigation",
+                    "description": "Gebruik de `side-navigation` component om een compact navigatie-element aan een pagina toe te voegen. Het vat de\ninhoud van lange pagina's samen, leidt de gebruiker door de pagina inhoud en kan ook naar externe pagina's verwijzen.\n\nDe `vl-side-navigation` wordt opgebouwd uit volgende sub-componenten:\n\n- VlSideNavigation `[vl-side-navigation]`\n- VlSideNavigationTitle<br/>\n    `[vl-side-navigation-h1 / vl-side-navigation-h2 / vl-side-navigation-h3 /`\n    `vl-side-navigation-h4 / vl-side-navigation-h5 / vl-side-navigation-h6]`\n- VlSideNavigationContent `[vl-side-navigation-content]`\n- VlSideNavigationGroup `[vl-side-navigation-group]`\n- VlSideNavigationItem `[vl-side-navigation-item]`\n- VlSideNavigationToggle `[vl-side-navigation-toggle]`\n- VlSideNavigationReference `[vl-side-navigation-reference]`\n\n```js\nimport { VlSideNavigation } from '@domg-wc/components/block';\n```\n\n```html\n<vl-side-navigation></vl-side-navigation>\n```\n\n<Canvas of={VlSideNavigationStories.SideNavigationDefault}/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-side-navigation--documentatie"
                 },
                 {
@@ -1217,6 +1248,7 @@
                 },
                 {
                     "name": "vl-search-filter",
+                    "description": "Gebruik de `search-filter` component om een zoek filter te tonen op een pagina.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-search-filter--documentatie",
                     "attributes": [
                         {
@@ -1248,6 +1280,7 @@
                 },
                 {
                     "name": "vl-steps",
+                    "description": "Gebruik de `steps` component om een verticale lijst van stappen af te beelden om de gebruiker door een procedure te\nbegeleiden.<br/>\n\nDeze component is de nieuwe versie van de [vl-steps](/docs/components-block-steps--documentatie) component, we raden aan deze versie te gebruiken.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-steps-steps--documentatie",
                     "attributes": [
                         {
@@ -1426,6 +1459,7 @@
                 },
                 {
                     "name": "vl-popover",
+                    "description": "Een popover is een nieuw, meestal kleiner venster / popup dat boven de andere inhoud op het scherm verschijnt.\nHet doel van de popover is het bouwen van context- of submenu's. Je kan deze menu's opbouwen a.d.h.v. de\n`vl-popover-action-list` en `vl-popover-action` componenten. De popover kan ook andere interactieve HTML-elementen\nbevatten.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-popover--documentatie",
                     "attributes": [
                         {
@@ -1512,6 +1546,7 @@
                 },
                 {
                     "name": "vl-progress-bar",
+                    "description": "Gebruik een `vl-progress-bar` om procentuele voortgang te tonen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-progress-bar--documentatie",
                     "attributes": [
                         {
@@ -1548,6 +1583,7 @@
                 },
                 {
                     "name": "vl-progress-indicator",
+                    "description": "Gebruik een `progress-indicator` om de vooruitgang te tonen van een proces dat uit verschillende stappen bestaat.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-progress-indicator--documentatie",
                     "attributes": [
                         {
@@ -1605,6 +1641,7 @@
                 },
                 {
                     "name": "vl-proza-message",
+                    "description": "Gebruik de `proza-message` component om een Proza bericht af te beelden dat achterliggend beheerd kan worden door de\nbusiness.<br/>\nVoor het ophalen van alle Proza berichten voor een domein zie de\n[proza-message-preloader](/docs/components-block-proza-message-preloader--proza-message-preloader-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-proza-message--documentatie",
                     "attributes": [
                         {
@@ -1641,6 +1678,7 @@
                 },
                 {
                     "name": "vl-proza-message-preloader",
+                    "description": "Gebruik de `proza-message-preloader` component om alle Proza berichten van een domein in 1 keer op te halen en in\ncache te stoppen.<br/>\nDe [proza-message](/docs/components-block-proza-message--proza-message-default) component gaat eerst kijken of het bericht in\nde cache zit vooraleer een request naar buiten te sturen.<br/>\nDeze component voeg je 1 keer toe in je applicatie per domein, bij voorkeur op het hoogste niveau.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-proza-message-preloader--documentatie",
                     "attributes": [
                         {
@@ -1688,6 +1726,7 @@
                 },
                 {
                     "name": "vl-rich-data-table",
+                    "description": "Een tabel op basis van een dynamische lijst van data die uitgebreid kan worden met functionaliteiten om het consumeren\nvan data door de gebruiker te verbeteren.\n\nDe code voorbeelden bij elke story is dezelfde code die gebruikt wordt om de stories te laten werken.\n- combineert de functionaliteiten van het [rich-data](?path=/docs/components-block-rich-data--rich-data-default)-component en [data-table](?path=/docs/elements-data-table--data-table-default)-component.\n- om de velden te configureren kan je gebruik maken van `rich-data-field`",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-rich-data-table--documentatie",
                     "attributes": [
                         {
@@ -1778,6 +1817,7 @@
                 },
                 {
                     "name": "vl-side-sheet",
+                    "description": "De `side-sheet`-component heeft containers die aan de linker- of rechterrand van het scherm zijn verankerd. Deze kunnen\ngeopend of gesloten worden aan de hand van een knop.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-side-sheet--documentatie",
                     "attributes": [
                         {
@@ -1861,6 +1901,7 @@
                 },
                 {
                     "name": "vl-tabs",
+                    "description": "Gebruik de `tabs` component om gerelateerde informatie op te splitsen in kleinere stukken content.\nOp mobiel wordt de tab navigatie omgevormd tot een uitklapbaar menu.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-tabs--documentatie",
                     "attributes": [
                         {
@@ -1963,6 +2004,7 @@
                 },
                 {
                     "name": "vl-toaster",
+                    "description": "Gebruik de `toaster` component om meldingen af te beelden.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-toaster--documentatie",
                     "attributes": [
                         {
@@ -1990,6 +2032,7 @@
                 },
                 {
                     "name": "vl-tooltip",
+                    "description": "Een tooltip is een klein contextueel venster dat verschijnt wanneer de gebruiker over een element hovert of het\nelement focust. Gebruik een tooltip om korte bijkomende informatie te tonen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-tooltip--documentatie",
                     "attributes": [
                         {
@@ -2065,6 +2108,7 @@
                 },
                 {
                     "name": "vl-upload-progress",
+                    "description": "Gebruik `vl-upload-progress` om procentuele voortgang van een bestandsupload te tonen.\n\nDit component laadt toe om de upload te annuleren of te herstarten en heeft de mogelijkheid om een foutboodschap\nweer te geven.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-upload-progress--documentatie",
                     "attributes": [
                         {
@@ -2138,6 +2182,7 @@
                 },
                 {
                     "name": "vl-video-player",
+                    "description": "Gebruik de `video-player` component om een video-player af te beelden.<br/>\n\nDeze component is de nieuwe versie van het [vl-video-player](/docs/elements-video-player--documentatie) element, we raden aan om op termijn deze versie\nte gebruiken.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-video-player--documentatie",
                     "attributes": [
                         {
@@ -2169,6 +2214,7 @@
                 },
                 {
                     "name": "vl-wizard",
+                    "description": "Gebruik een `wizard` om een gebruiker door een meerstapsproces te begeleiden. Een wizard maakt het mogelijk om een\ningewikkeld proces op te delen in overzichtelijke, kleine stappen. Een wizard biedt ook de mogelijkheid opties in een\nbepaalde stap aan te passen op basis van keuzes die de gebruiker in een voorgaande stap heeft gemaakt.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-wizard-wizard--documentatie",
                     "attributes": [
                         {
@@ -2213,6 +2259,7 @@
                 },
                 {
                     "name": "vl-wizard-pane",
+                    "description": "Gebruik de `wizard-pane` component om een stap in de wizard af te beelden.\nTe gebruiken in combinatie met de [wizard](/docs/components-block-wizard-wizard--documentatie) component",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-wizard-wizard-pane--documentatie",
                     "attributes": [
                         {

--- a/libs/components/src/compliance/compliance.web-types.json
+++ b/libs/components/src/compliance/compliance.web-types.json
@@ -9,6 +9,7 @@
             "elements": [
                 {
                     "name": "vl-accessibility",
+                    "description": "Toegankelijkheidsverklaring pagina.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-accessibility--documentatie",
                     "attributes": [
                         {
@@ -82,6 +83,7 @@
                 },
                 {
                     "name": "vl-cookie-consent",
+                    "description": "De cookie consent kan gebruikt worden om de gebruiker te informeren over al de cookies die gebruikt worden.\nDaarnaast kunnen er mits toestemming van de gebruiker analytics worden toegepast.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-cookie-consent--documentatie",
                     "attributes": [
                         {
@@ -135,6 +137,7 @@
                 },
                 {
                     "name": "vl-cookie-statement",
+                    "description": "Cookieverklaring pagina.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-cookie-statement--documentatie",
                     "attributes": [
                         {
@@ -201,6 +204,7 @@
                 },
                 {
                     "name": "vl-footer",
+                    "description": "<span style=\"color: rgb(240,0,0)\">[legacy-component]</span><br/>Injecteert de footer widget van Digitaal Vlaanderen.\nDefault wordt de footer geïnjecteerd in het native `<body>` element.\n\nVoor het consistent gebruik van de footer doorheen alle applicaties van Departement Omgeving, raden we aan om volgende\ntemplate aan te houden:\n\n\n>   **[app-name] is een officiële website van de Vlaamse overheid**\n>    uitgegeven door Departement Omgeving\n\n\n\"Departement Omgeving\" is hierbij een externe link naar https://omgeving.vlaanderen.be/.\n\nDeze gegevens worden beheerd door Digitaal Vlaanderen en kunnen ingesteld worden bij het verkrijgen van de unieke\nidentifier. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via dit\n[stappenplan](https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer) van Digitaal Vlaanderen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-footer--documentatie",
                     "attributes": [
                         {
@@ -226,6 +230,7 @@
                 },
                 {
                     "name": "vl-header",
+                    "description": "<span style=\"color: rgb(240,0,0)\">[legacy-component]</span><br/>Injecteert de global header widget van Digitaal Vlaanderen.\nDefault wordt de header geïnjecteerd in het native `<body>` element.\n\nVoor het consistent gebruik van de header doorheen alle applicaties van Departement Omgeving, raden we aan om volgende\ntemplate aan te houden:\n\n\n>   **[Logo Vlaanderen]** | **[App-name]** | witruimte | **Aanmelden** | **Hulp nodig?**\n\n- **\"Logo Vlaanderen\"** is hierbij een link naar https://vlaanderen.be.\n- **\"App-name\"** blijft op alle pagina's de naam van de applicatie en krijgt als link de startpagina van de applicatie.\n- Onder **\"Aanmelden\"** kan je app-links definiëren (zie [Applicatieve links](#applicatieve-links)).\n- Onder **\"Hulp nodig?\"** komt de tekst: **\"Neem contact op met Departement Omgeving\"**, gevolgd door verschillende\ncontact opties (telefoonnummer, adres, e-mailadres).\n\nDeze gegevens worden beheerd door Digitaal Vlaanderen en kunnen ingesteld worden bij het verkrijgen van de unieke\nidentifier. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via dit\n[stappenplan](https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer) van Digitaal Vlaanderen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-header--documentatie",
                     "attributes": [
                         {
@@ -305,6 +310,7 @@
                 },
                 {
                     "name": "vl-privacy",
+                    "description": "Privacy pagina.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-compliance-privacy--documentatie",
                     "attributes": [
                         {

--- a/libs/components/src/form/form.web-types.json
+++ b/libs/components/src/form/form.web-types.json
@@ -9,6 +9,7 @@
             "elements": [
                 {
                     "name": "vl-checkbox",
+                    "description": "Gebruik de `checkbox` component om de gebruiker de mogelijkheid te geven om 1 of meerdere dingen te selecteren in een\nlijst.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-checkbox--documentatie",
                     "attributes": [
                         {
@@ -110,6 +111,7 @@
                 },
                 {
                     "name": "vl-datepicker",
+                    "description": "Gebruik de `datepicker` component om de gebruiker op een gebruiksvriendelijke manier een datum of tijd te laten selecteren.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-datepicker--documentatie",
                     "attributes": [
                         {
@@ -276,6 +278,7 @@
                 },
                 {
                     "name": "vl-form-message",
+                    "description": "Gebruik de `form-message` component om een boodschap af te beelden voor een input veld.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-form-message--documentatie",
                     "attributes": [
                         {
@@ -314,6 +317,7 @@
                 },
                 {
                     "name": "vl-form-label",
+                    "description": "Gebruik de `form-label` component om een form label af te beelden.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-form-label--documentatie",
                     "attributes": [
                         {
@@ -352,6 +356,7 @@
                 },
                 {
                     "name": "vl-input-field",
+                    "description": "Gebruik de `input-field` component om een input veld toe te voegen aan een pagina.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-input-field--documentatie",
                     "attributes": [
                         {
@@ -499,6 +504,7 @@
                 },
                 {
                     "name": "vl-input-field-masked",
+                    "description": "Gebruik de `input-field-masked` component om een input veld met een mask toe te voegen aan een pagina.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-input-field-masked--documentatie",
                     "attributes": [
                         {
@@ -757,6 +763,7 @@
                 },
                 {
                     "name": "vl-radio-group",
+                    "description": "Gebruik de `radio-group` component om de gebruiker de mogelijkheid te geven om 1 keuze te selecteren in een lijst.<br/>\nWanneer mogelijk, selecteer geen `radio` van vooraf zodat de gebruiker een bewuste keuze kan maken.<br/>\nDe `radio` component is een onderdeel van de `radio-group` component.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-radio-group--documentatie",
                     "attributes": [
                         {
@@ -836,6 +843,7 @@
                 },
                 {
                     "name": "vl-select",
+                    "description": "Gebruik de `select` component om een select veld toe te voegen aan een pagina.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-select--documentatie",
                     "attributes": [
                         {
@@ -939,6 +947,7 @@
                 },
                 {
                     "name": "vl-select-rich",
+                    "description": "Gebruik de `select-rich` component om een uitgebreid select of multiselect veld toe te voegen aan een pagina.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-select-rich--documentatie",
                     "attributes": [
                         {
@@ -1076,6 +1085,7 @@
                 },
                 {
                     "name": "vl-textarea",
+                    "description": "Gebruik de `textarea` component om een textarea veld toe te voegen aan een pagina.<br/>\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.\n\nDeze component bevat geen rich-text modus: gebruik daarvoor\n[vl-textarea-rich](/docs/components-form--text-area-rich--documentatie).",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-textarea--documentatie",
                     "attributes": [
                         {
@@ -1190,6 +1200,7 @@
                 },
                 {
                     "name": "vl-textarea-rich",
+                    "description": "Gebruik de `textarea-rich` component om een rich textarea veld toe te voegen aan een pagina.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-textarea-rich--documentatie",
                     "attributes": [
                         {
@@ -1327,6 +1338,7 @@
                 },
                 {
                     "name": "vl-upload",
+                    "description": "Gebruik de `upload` component om één of meerdere bestanden te selecteren of te slepen naar het upload-veld.\n\nZie het [form demo](/docs/ontwerp-form-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-upload--documentatie",
                     "attributes": [
                         {

--- a/libs/map/map.web-types.json
+++ b/libs/map/map.web-types.json
@@ -9,6 +9,7 @@
             "elements": [
                 {
                     "name": "vl-map-click-action",
+                    "description": "Gebruik het `map-click-action` component om een klikactie op de [map](/docs/map-map--map-default) op te vangen.<br/>\nBij het klikken op de [map](/docs/map-map--map-default) wordt er een `vl-map-click-action-pindrop` op de kaart geplaatst.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-click-action--documentatie",
                     "attributes": [
                         {
@@ -33,6 +34,7 @@
                 },
                 {
                     "name": "vl-map-draw-action-style",
+                    "description": "Gebruik de `map-draw-action-style` component om een style mee te geven aan de `map-draw-action`.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-draw-action-draw-action-style--documentatie",
                     "attributes": [
                         {
@@ -79,6 +81,7 @@
                 },
                 {
                     "name": "vl-map-draw-line-action",
+                    "description": "Gebruik de `map-draw-line-action` component om een lijn te tekenen op een\n[map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default).<br/>\nDeze component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,\ndie op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-draw-action-draw-action-style--documentatie",
                     "attributes": [
                         {
@@ -119,6 +122,7 @@
                 },
                 {
                     "name": "vl-map-draw-point-action",
+                    "description": "Gebruik het `map-draw-point-action` component om een punt te tekenen op een\n[map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default).<br/>\nDit component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,\ndie op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-draw-action-draw-point-action--documentatie",
                     "attributes": [
                         {
@@ -159,6 +163,7 @@
                 },
                 {
                     "name": "vl-map-draw-polygon-action",
+                    "description": "Gebruik het `map-draw-polygon-action` component om een polygon te tekenen op een\n[map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default).<br/>\nDit component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,\ndie op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-draw-action-draw-polygon-action--documentatie",
                     "attributes": [
                         {
@@ -199,6 +204,7 @@
                 },
                 {
                     "name": "vl-map-measure-action",
+                    "description": "Gebruik het `map-measure-action` component om de afstand tussen 2 punten te meten op een\n[map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default).<br/>\nDit component erft over van de `VlMapDrawAction` klasse, die op zijn beurt overerft van de `VlMapLayerAction` klasse,\ndie op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-draw-action-measure-action--documentatie",
                     "attributes": [
                         {
@@ -243,6 +249,7 @@
                 },
                 {
                     "name": "vl-map-delete-action",
+                    "description": "Gebruik het `map-delete-action` component om een feature op een\n[map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) te verwijderen.<br/>\nDit component erft over van de `VlMapLayerAction` klasse, die op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-layer-action-delete-action--documentatie",
                     "attributes": [
                         {
@@ -273,6 +280,7 @@
                 },
                 {
                     "name": "vl-map-modify-action",
+                    "description": "Gebruik het `map-modify-action` component om een feature op een [map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) aan te passen.<br/>\nDit component erft over van de `VlMapLayerAction` klasse, die op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-layer-action-modify-action--documentatie",
                     "attributes": [
                         {
@@ -313,6 +321,7 @@
                 },
                 {
                     "name": "vl-map-select-action",
+                    "description": "Gebruik het `map-select-action` component om een feature op een [map-features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) te selecteren.<br/>\nDit component erft over van de `VlMapLayerAction` klasse, die op zijn beurt overerft van de `VlMapAction` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-layer-action-select-action--documentatie",
                     "attributes": [
                         {
@@ -348,6 +357,7 @@
                 },
                 {
                     "name": "vl-map-multiselect-actions",
+                    "description": "Gebruik de `map-multiselect-actions` component om meerdere overlappende features samen te selecteren.<br/>\nDeze component erft over van de\n[map-select-actions](/docs/map-action-layer-action-select-action--map-select-actions-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-layer-action-select-action-multiselect-actions--documentatie",
                     "attributes": [
                         {
@@ -389,6 +399,7 @@
                 },
                 {
                     "name": "vl-map-select-actions",
+                    "description": "Gebruik het `map-select-actions` component om features op meerdere\n[map-features-layers](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) te selecteren.<br/>\nDeze component erft over van de\n[map-select-action](/docs/map-action-layer-action-select-action--map-select-action-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-action-layer-action-select-action-select-actions--documentatie",
                     "attributes": [
                         {
@@ -430,6 +441,7 @@
                 },
                 {
                     "name": "vl-map-baselayer",
+                    "description": "Gebruik het `map-baselayer` component om een basis kaartlaag af te beelden.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-baselayer--documentatie",
                     "attributes": [
                         {
@@ -479,6 +491,7 @@
                 },
                 {
                     "name": "vl-map-baselayer-grb",
+                    "description": "Gebruik het `map-baselayer-grb` component om een basis GRB kaartlaag af te beelden.<br/>\nDit component erft over van het [map-baselayer](/docs/map-baselayer--map-baselayer-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-baselayer-baselayer-grb--documentatie",
                     "attributes": [
                         {
@@ -528,6 +541,7 @@
                 },
                 {
                     "name": "vl-map-baselayer-grb-gray",
+                    "description": "Gebruik de `map-baselayer-grb-gray` component om een basis GRB kaartlaag met grijstinten af te beelden.<br/>\nDeze component erft over van de [map-baselayer](/docs/map-baselayer--map-baselayer-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-baselayer-baselayer-grb-gray--documentatie",
                     "attributes": [
                         {
@@ -577,6 +591,7 @@
                 },
                 {
                     "name": "vl-map-baselayer-grb-ortho",
+                    "description": "Gebruik de `map-baselayer-grb-ortho` component om een basis GRB ortho kaartlaag af te beelden.<br/>\nDeze component erft over van de [map-baselayer](/docs/map-baselayer--map-baselayer-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-baselayer-baselayer-grb-ortho--documentatie",
                     "attributes": [
                         {
@@ -626,6 +641,7 @@
                 },
                 {
                     "name": "vl-map-action-controls",
+                    "description": "Gebruik de `map-action-controls` component als wrapper rond\n[map-action-control](/docs/map-controls-action-control--map-action-control-default) componenten.<br/>\nDe `map-action-controls` zorgt ervoor dat de map-acties in de rechterbovenhoek van de `map` afgebeeld worden.<br/>\nVerder zorgt deze ervoor dat er altijd maar 1 actieve `map-action-control` is.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-controls-action-controls--documentatie",
                     "attributes": [
                         {
@@ -637,6 +653,7 @@
                 },
                 {
                     "name": "vl-map-action-control",
+                    "description": "Gebruik de `map-action-control` component om een map-actie aan of uit te zetten met behulp van een\n[button met toggle](/docs/components-atom-button--documentatie#toggle).<br/>\nEen `map-action-control` linken aan een map-actie gebeurt op de volgende manier:\n    - plaats op de `map-action-control` het attribuut `action-id` met als waarde bv. 'draw-polygon-action'\n    - plaats op de map-actie het attribuut `id` en geef hier dezelfde waarde mee als in de vorige stap",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-controls-action-control--documentatie",
                     "attributes": [
                         {
@@ -668,6 +685,7 @@
                 },
                 {
                     "name": "vl-map-measure-control",
+                    "description": "Gebruik de `map-measure-control` component om de meet-actie aan of uit te zetten door behulp van een\n[button met toggle](/docs/components-atom-button--documentatie#toggle).",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-controls-measure-control--documentatie",
                     "attributes": [
                         {
@@ -679,6 +697,7 @@
                 },
                 {
                     "name": "vl-map-current-location",
+                    "description": "Gebruik het `map-current-location` component om een huidige locatie knop af te beelden op de map.<br/>\nNa het drukken op de knop wordt de huidige locatie van de gebruiker centraal afgebeeld.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-current-location--documentatie",
                     "attributes": [
                         {
@@ -700,6 +719,7 @@
                 },
                 {
                     "name": "vl-map-features-layer",
+                    "description": "Gebruik de `map-features-layer` component om een kaartlaag af te beelden waarbij je een set van te tonen features kan\nstellen.<br/>\nDeze component erft over van de `VlMapVectorLayer` klasse, die op zijn beurt overerft van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-vector-layer-features-layer--documentatie",
                     "attributes": [
                         {
@@ -776,6 +796,7 @@
                 },
                 {
                     "name": "vl-map-wfs-layer",
+                    "description": "Gebruik de `map-wfs-layer` component om een WFS kaartlaag af te beelden.<br/>\nDeze component erft over van de `VlMapVectorLayer` klasse, die op zijn beurt overerft van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-vector-layer-wfs-layer--documentatie",
                     "attributes": [
                         {
@@ -827,6 +848,7 @@
                 },
                 {
                     "name": "vl-map-image-wms-layer",
+                    "description": "Gebruik de `map-image-wms-layer` component om een WMS kaartlaag af te beelden waarbij de bevraging telkens met één\nafbeelding gebeurt.<br/>\nDeze component erft over van de `VlMapWmsLayer` klasse, die op zijn beurt overerft van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-wms-layer-image-wms-layer--documentatie",
                     "attributes": [
                         {
@@ -883,6 +905,7 @@
                 },
                 {
                     "name": "vl-map-tiled-wms-layer",
+                    "description": "Gebruik de `map-tiled-wms-layer` component om een WMS kaartlaag af te beelden.<br/>\nDeze component erft over van de `VlMapWmsLayer` klasse, die op zijn beurt overerft van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-wms-layer-tiled-wms-layer--documentatie",
                     "attributes": [
                         {
@@ -939,6 +962,7 @@
                 },
                 {
                     "name": "vl-map-xyz-wms-layer",
+                    "description": "Gebruik de `map-xyz-wms-layer` component om een WMS kaartlaag af te beelden.<br/>\nDeze component erft over van de `VlMapWmsLayer` klasse, die op zijn beurt overerft van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-wms-layer-xyz-wms-layer--documentatie",
                     "attributes": [
                         {
@@ -995,6 +1019,7 @@
                 },
                 {
                     "name": "vl-map-wms-style",
+                    "description": "Gebruik de `map-wms-style` component om een WMS kaartlaag server side te stijlen.<br/>",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-wms-layer-wms-style--documentatie",
                     "attributes": [
                         {
@@ -1011,6 +1036,7 @@
                 },
                 {
                     "name": "vl-map-wmts-layer",
+                    "description": "Gebruik de `map-wmts-layer` component om een WMTS kaartlaag af te beelden.<br/>\nDeze component erft over van de `VlMapLayer` klasse.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-wmts-layer--documentatie",
                     "attributes": [
                         {
@@ -1067,6 +1093,7 @@
                 },
                 {
                     "name": "vl-map-layer-style",
+                    "description": "Gebruik de `map-layer-style` component om een\n[features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) of een\n[wfs-layer](/docs/map-layer-vector-layer-wfs-layer--map-wfs-layer-default) te stylen.<br/>\n**Let op**: Bij gebruik van de [map-legend](/docs/map-legend--map-legend-features-layer-multiple-styles) worden de\nattributen niet reactief toegepast op de legende.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-style--documentatie",
                     "attributes": [
                         {
@@ -1141,6 +1168,7 @@
                 },
                 {
                     "name": "vl-map-layer-circle-style",
+                    "description": "Gebruik de `map-layer-circle-style` component om een\n[features-layer](/docs/map-layer-vector-layer-features-layer--map-features-layer-default) te stylen.<br/>\nDeze component erft over van de [map-layer-style](/docs/map-layer-style--map-layer-style-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-style-layer-circle-style--documentatie",
                     "attributes": [
                         {
@@ -1235,6 +1263,7 @@
                 },
                 {
                     "name": "vl-map-layer-switcher",
+                    "description": "Gebruik de `map-layer-switcher` component om kaartlagen zichtbaar of onzichtbaar te maken.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-layer-switcher--documentatie",
                     "attributes": [
                         {
@@ -1261,6 +1290,7 @@
                 },
                 {
                     "name": "vl-map-legend",
+                    "description": "Gebruik de `map-legend` component om een legende af te beelden op de kaart.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-legend--documentatie",
                     "attributes": [
                         {
@@ -1316,6 +1346,7 @@
                 },
                 {
                     "name": "vl-map-legend-item",
+                    "description": "Gebruik de `map-legend-item` component om een custom legende af te beelden op de kaart.\n\nIndien geen icon- en labelslots meegegeven zijn zal het `map-legend-item` de default style items van de bijhorende laag tonen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-legend-item--documentatie",
                     "attributes": [
                         {
@@ -1349,6 +1380,7 @@
                 },
                 {
                     "name": "vl-map-loading-indicator",
+                    "description": "Gebruik de `map-loading-indicator` component om op te vangen wanneer de [vl-map](/docs/map-map--map-default) aan het\nladen is.<br/>\nToont een 'loading' bar bovenaan de map.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-loading-indicator--documentatie",
                     "attributes": [
                         {
@@ -1360,6 +1392,7 @@
                 },
                 {
                     "name": "vl-map-overview-map",
+                    "description": "Gebruik de `map-overview-map` component zodat gebruikers kunnen wisselen tussen de verschillende basis kaartlagen.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-overview-map--documentatie",
                     "attributes": [
                         {
@@ -1371,6 +1404,7 @@
                 },
                 {
                     "name": "vl-map-search",
+                    "description": "Gebruik de `map-search` component om een zoekbalk toe te voegen aan de map waarmee gebruikers kunnen zoeken op adres.<br/>\nDeze component maakt gebruik van de [select-location](/docs/map-select-location--select-location-default) component en\nvan de [search](/docs/components-block-search--search-default) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-search--documentatie",
                     "attributes": [
                         {
@@ -1407,6 +1441,7 @@
                 },
                 {
                     "name": "vl-select-location",
+                    "description": "Gebruik de `vl-select-location` component om een zoekbalk af te beelden waarmee er een adres geselecteerd kan worden.\n\nDeze component erft over van de [vl-select-rich](/docs/components-form-select-rich--documentatie) component.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-select-location--documentatie",
                     "attributes": [
                         {
@@ -1534,6 +1569,7 @@
                 },
                 {
                     "name": "vl-map-side-sheet",
+                    "description": "Gebruik de `map-side-sheet` component om een uitklapbaar zijpaneel af te beelden over de map.<br/>\nDeze component erft over van de [side-sheet](/docs/components-block-side-sheet--side-sheet-default) component en heeft ook al diens functionaliteit.<br/>\n**Let op**: de default positie van de `map-side-sheet` is links, terwijl de default positie van de\n[side-sheet](/docs/components-block-side-sheet--side-sheet-default) rechts is.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-side-sheet-side-sheet--documentatie",
                     "attributes": [
                         {
@@ -1626,6 +1662,7 @@
                 },
                 {
                     "name": "vl-map",
+                    "description": "Gebruik de `map` component om een kaart af te beelden met verschillende lagen en acties.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/map-map--documentatie",
                     "attributes": [
                         {

--- a/resources/generate-web-types/web-types.generator.ts
+++ b/resources/generate-web-types/web-types.generator.ts
@@ -60,13 +60,13 @@ const extractDocFileDescription = (component: string, docFile: string): string =
     let prefix = '';
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
-        if (!firstHashLinePassed && line.startsWith('#')) {
+        if (!firstHashLinePassed && line.startsWith('##')) {
             // de eerste lijn met een # bevat een titel, deze maakt geen deel uit van de omschrijving
             firstHashLinePassed = true;
             continue;
         }
-        if (!fluxMetaDataPassed && line.includes('FluxComponentEvolution')) {
-            // de <FluxComponentEvolution /> maakt geen deel uit van de omschrijving
+        if (!fluxMetaDataPassed && line.includes('FluxComponentMetaData')) {
+            // de <FluxComponentMetaData /> maakt geen deel uit van de omschrijving
             fluxMetaDataPassed = true;
             // de id bepalen
             const componentId = line.split('"')[1];
@@ -75,7 +75,7 @@ const extractDocFileDescription = (component: string, docFile: string): string =
         }
         if (firstHashLinePassed && fluxMetaDataPassed) {
             // bij de tweede lijn met een # stopt de omschrijving
-            if (line.startsWith('#')) {
+            if (line.startsWith('##')) {
                 // de witruimte voor- en achteraan verwijderen
                 description = prefix + description.trim();
                 // de omschrijving is volledig


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-492