### PR TITLE
feat: FLUX-480 - vl-input-field - geen lege pattern renderen

### DIFF
--- a/libs/components/src/form/input-field/vl-input-field.component.cy.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.cy.ts
@@ -134,6 +134,13 @@ describe('cypress-component - form components - vl-input-field', () => {
         cy.get('vl-input-field').shadow().find('input').should('have.attr', 'pattern', 'Van(.*)');
     });
 
+    it('should not set pattern when empty', () => {
+        cy.mount(html`<vl-input-field></vl-input-field>`);
+
+        cy.get('vl-input-field').should('not.have.attr', 'pattern');
+        cy.get('vl-input-field').shadow().find('input').should('not.have.attr', 'pattern');
+    });
+
     it('should set min-exlusive', () => {
         cy.mount(html`<vl-input-field min-exclusive></vl-input-field>`);
 

--- a/libs/components/src/form/input-field/vl-input-field.component.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.ts
@@ -1,6 +1,7 @@
 import { webComponent } from '@domg-wc/common';
 import { maxLengthValidator, minLengthValidator } from '@open-wc/form-control';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { FormControl } from '../form-control';
@@ -123,7 +124,7 @@ export class VlInputFieldComponent extends FormControl {
                 maxlength=${this.maxLength ?? nothing}
                 min=${this.min ?? nothing}
                 max=${this.max ?? nothing}
-                pattern=${this.pattern}
+                pattern=${ifDefined(this.pattern ? this.pattern : undefined)}
                 inputmode=${this.inputMode}
                 @input=${this.onInput}
             />


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-480)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC191)