### PR TITLE
fix: FLUX-372 - vl-modal - genest in shadow-dom's opent de modal nu

### DIFF
--- a/libs/components/src/block/modal/vl-modal.lib.js
+++ b/libs/components/src/block/modal/vl-modal.lib.js
@@ -949,6 +949,39 @@
     const mFallbackBackdropClass = '.backdrop';
     const noOverflowClass = ''.concat(vl.ns, 'u-no-overflow');
 
+    /**
+     * Zoekt elementen in zowel document als parent shadow DOMs.
+     * Dit lost het probleem op waarbij modals niet werken als de parent een shadow DOM heeft.
+     * @param {Element} element - Het modal dialog element
+     * @param {string} selector - De CSS selector om naar te zoeken
+     * @return {NodeList|Array} Array van gevonden elementen
+     */
+    function findOpenTrigger(element, selector) {
+        const triggers = [];
+
+        // Zoek in document root
+        triggers.push(...Array.from(document.querySelectorAll(selector)));
+
+        // Zoek in parent shadow DOMs
+        let currentElement = element.parentNode;
+        while (currentElement) {
+            if (currentElement instanceof ShadowRoot) {
+                triggers.push(...Array.from(currentElement.querySelectorAll(selector)));
+            }
+
+            // Ga naar de volgende parent
+            if (currentElement instanceof ShadowRoot) {
+                currentElement = currentElement.host.parentNode;
+            } else if (currentElement instanceof Element) {
+                currentElement = currentElement.parentNode;
+            } else {
+                break;
+            }
+        }
+
+        return triggers;
+    }
+
     const Modal =
         /* #__PURE__ */
         (function () {
@@ -992,7 +1025,7 @@
 
                         element.setAttribute(mDressedAtt, true); // Handle open/close
 
-                        linkedOpenTrigger = document.querySelectorAll('['.concat(mOpen, '="').concat(element.id, '"]'));
+                        linkedOpenTrigger = findOpenTrigger(element, '['.concat(mOpen, '="').concat(element.id, '"]'));
                         linkedClosedTrigger = element.querySelectorAll('['.concat(mClose, ']')); // See if closable (by esc or backdrop)
 
                         closable = element.hasAttribute(mClosable);


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-372
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC199

fix in vl-modal.lib.js - component moet eens herschreven worden / lib moet eigenlijkt weggewerkt worden

uitgetest in playground-lit, na deze fix werkt het inderdaad met een shadow-dom, als je het wil testen:
```
import { registerWebComponents } from '@domg-wc/common';
import { VlPopoverActionComponent, VlPopoverActionListComponent, VlPopoverComponent } from '@domg-wc/components/block';
import { VlHeader } from '@domg-wc/components/compliance';
import { html, LitElement } from 'lit';
import { customElement } from 'lit/decorators.js';

@customElement('app-component')
export class AppComponent extends LitElement {
    static {
        registerWebComponents([
            VlHeader,
            VlPopoverComponent,
            VlPopoverActionListComponent,
            VlPopoverActionComponent,
        ]);
    }

    render() {
        return html`
            <vl-template>
                <vl-header
                    slot="header"
                    development
                    simple
                    identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
                ></vl-header>
                <main slot="main">
                    <section class="vl-section">
                        <div class="vl-content-block vl-content-block--full-width">
                            <vl-title type="h2">Breadcrumbs met submenus</vl-title>
                            <div>
                                <vl-button id="button-open-modal-vt" modal-open="pl-modal"
                                           data-cy="button-modal-toggle">
                                    Open
                                </vl-button>
                                <vl-modal
                                    id="pl-modal"
                                    title="Hallo"
                                >
                                    <span slot="content">
                                        <vl-datepicker block></vl-datepicker>
                                        Lorem ipsum dolor sit amet.
                                    </span>
                                </vl-modal>
                            </div>
                        </div>
                    </section>
                </main>
            </vl-template>
        `;
    }

    // protected createRenderRoot(): HTMLElement | DocumentFragment {
    //     // gaat shadow dom uitzetten
    //     return this;
    // }
}
```