### PR TITLE
feat: FLUX-507 - vl-rich-data-table - header uitlijning verbeterd

### DIFF
--- a/libs/components/src/block/rich-data-table/stories/vl-rich-data-table.stories.ts
+++ b/libs/components/src/block/rich-data-table/stories/vl-rich-data-table.stories.ts
@@ -141,7 +141,7 @@ const TemplateFilter = story(
                 <vl-search-filter slot="filter" alt>
                     <form>
                         <section>
-                            <vl-title type="h2" alt no-space-bottom="">Doorzoek projecten</vl-title>
+                            <vl-title type="h2" no-space-bottom>Doorzoek projecten</vl-title>
                             <div>
                                 <vl-form-label for="filterOpId" label="Project id" light></vl-form-label>
                                 <vl-input-field id="filterOpId" type="text" name="id" block></vl-input-field>
@@ -212,7 +212,7 @@ const TemplateFilterPaging = story(
                 <vl-search-filter slot="filter" alt>
                     <form>
                         <section>
-                            <vl-title type="h2" alt no-space-bottom="">Doorzoek projecten</vl-title>
+                            <vl-title type="h2" no-space-bottom>Doorzoek projecten</vl-title>
                             <div>
                                 <vl-form-label for="filterOpId" label="Project id" light></vl-form-label>
                                 <vl-input-field id="filterOpId" type="text" name="id" block></vl-input-field>

--- a/libs/components/src/block/rich-data/stories/vl-rich-data.stories.ts
+++ b/libs/components/src/block/rich-data/stories/vl-rich-data.stories.ts
@@ -51,7 +51,7 @@ const pagerTemplate = ({filterClosable, filterClosed, filterMaxWidth}: typeof ri
             <vl-search-filter slot="filter" alt>
                 <form>
                     <section>
-                        <vl-title type="h2" alt no-space-bottom="">Doorzoek projecten</vl-title>
+                        <vl-title type="h2" no-space-bottom>Doorzoek projecten</vl-title>
                         <div>
                             <vl-form-label for="filterOpId" label="Project id" light></vl-form-label>
                             <vl-input-field id="filterOpId" type="text" name="id" block></vl-input-field>

--- a/libs/components/src/block/rich-data/vl-rich-data.flux-css.ts
+++ b/libs/components/src/block/rich-data/vl-rich-data.flux-css.ts
@@ -1,7 +1,7 @@
 import { vlMediaScreenSmall } from '@domg-wc/styles';
 import { css, CSSResult } from 'lit';
 
-export const vlRichDataFluxStyles: CSSResult = css`    
+export const vlRichDataFluxStyles: CSSResult = css`
     #search-results {
         margin-bottom: 2.4rem;
     }
@@ -14,15 +14,11 @@ export const vlRichDataFluxStyles: CSSResult = css`
         margin-right: 10px;
     }
 
-    #filter-slot-container {
-        margin-top: 8px;
-    }
-
     .vl-rich-data {
         display: grid;
-        /* 
-            Linker kolom krijgt de kleinste waarde: 
-            - ofwel 12/4 kolom (100% / 3) 
+        /*
+            Linker kolom krijgt de kleinste waarde:
+            - ofwel 12/4 kolom (100% / 3)
             - ofwel de ingestelde max-width
         */
         grid-template-columns: min(calc(100% / 3), var(--vl-rich-data-filter-max-width)) 1fr;
@@ -33,7 +29,7 @@ export const vlRichDataFluxStyles: CSSResult = css`
             'pager-area pager-area';
         gap: var(--vl-grid-col-gap);
 
-        &:has(#search[hidden]), 
+        &:has(#search[hidden]),
         &:has(#search.vl-u-hidden) {
             grid-template-columns: 0 1fr;
         }
@@ -49,14 +45,14 @@ export const vlRichDataFluxStyles: CSSResult = css`
             }
         }
 
-        ${ 
+        ${
             // Edge case als je op mobiel van portait naar landscape mode gaat terwijl de filter open staat. (zie storybook "Large mobile (L)" viewport)
-            css`&:has(> #filter-slot) { 
+            css`&:has(> #filter-slot) {
                 grid-template-columns: min(calc(100% / 3), calc(var(--vl-page--max-width-wide) / 3)) 1fr !important;
-            }` 
+            }`
         }
 
-        #toggle-filter, 
+        #toggle-filter,
         #open-filter {
             grid-area: toggle-area;
         }

--- a/libs/components/src/block/search-filter/vl-search-filter.global.css.ts
+++ b/libs/components/src/block/search-filter/vl-search-filter.global.css.ts
@@ -28,6 +28,8 @@ export const searchFilterGlobalStyles: CSSResult = css`
         vl-title::part(h2) {
             font-size: 1.6rem;
             letter-spacing: 0.1rem;
+            text-transform: uppercase;
+            line-height: 2.7rem;
 
             @media screen and (max-width: ${vlMediaScreenSmall}px) {
                 font-size: 1.4rem;
@@ -107,5 +109,11 @@ export const searchFilterGlobalStyles: CSSResult = css`
                 right: 0;
             }
         }
+    }
+
+    vl-rich-data form.vl-search-filter--form,
+    vl-rich-data-table form.vl-search-filter--form {
+        padding-left: 0;
+        padding-top: 0;
     }
 `;


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-507
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC200

om dit in orde te krijgen deed ik het volgende:
- de eerste vl-title van een search-filter mag geen 'alt' attribute meer hebben, hij styled nu uppercase met de juiste line-height (identiek als deze van de titel van de rich-data-table), extra titels eronder moeten 'alt' hebben om extra verticale witruimte te krijgen
- de filter-slot-container kreeg vroeger een margin-top van 8px, dat lijkt me geen specifieke rede te hebben, dus geschrapt om de witruimte bovenaan te verkleinen
- bij gebruik van de search-filter in een vl-rich-data of in een vl-rich-data-table is er nu bovenaan en links geen padding meer, de rechtse padding en de padding onderaan zijn behouden
