### PR TITLE
feat: FLUX-519 - vl-grid- vl-column--start-auto & varianten toegevoegd

### DIFF
--- a/libs/styles/src/layout/grid/column/vl-column-l.css.ts
+++ b/libs/styles/src/layout/grid/column/vl-column-l.css.ts
@@ -39,6 +39,9 @@ export const columnLargeStyles = (): CSSResult => css`
         grid-column-end: span 12;
     }
 
+    &.vl-column--start-auto {
+        grid-column-start: auto;
+    }
     &.vl-column--start-1 {
         grid-column-start: 1;
     }

--- a/libs/styles/src/layout/grid/column/vl-column-m.css.ts
+++ b/libs/styles/src/layout/grid/column/vl-column-m.css.ts
@@ -39,6 +39,9 @@ export const columnMediumStyles = (): CSSResult => css`
         grid-column-end: span 12;
     }
 
+    &.vl-column--m-start-auto {
+        grid-column-start: auto;
+    }
     &.vl-column--m-start-1 {
         grid-column-start: 1;
     }

--- a/libs/styles/src/layout/grid/column/vl-column-s.css.ts
+++ b/libs/styles/src/layout/grid/column/vl-column-s.css.ts
@@ -39,6 +39,9 @@ export const columnSmallStyles = (): CSSResult => css`
         grid-column-end: span 12;
     }
 
+    &.vl-column--s-start-auto {
+        grid-column-start: auto;
+    }
     &.vl-column--s-start-1 {
         grid-column-start: 1;
     }

--- a/libs/styles/src/layout/grid/column/vl-column-xs.css.ts
+++ b/libs/styles/src/layout/grid/column/vl-column-xs.css.ts
@@ -39,6 +39,9 @@ export const columnExtraSmallStyles = (): CSSResult => css`
         grid-column-end: span 12;
     }
 
+    &.vl-column--xs-start-auto {
+        grid-column-start: auto;
+    }
     &.vl-column--xs-start-1 {
         grid-column-start: 1;
     }

--- a/libs/styles/src/layout/grid/stories/vl-grid.stories-doc.mdx
+++ b/libs/styles/src/layout/grid/stories/vl-grid.stories-doc.mdx
@@ -100,6 +100,11 @@ Voor het specifiëren van kolommen is er `vl-column--1` t.e.m. `vl-column--12` m
 Om de start van een kolom te verschuiven is er `vl-column--start-1` t.e.m. `vl-column--start-12` met de
 responsieve varianten `vl-column--X-start-N` waarbij X [m, s, xs] kan zijn. Een kolom met `vl-column--start-2` zal starten in de tweede kolom en N kolommen breed zijn, zoals gedefinieerd met `vl-column--N`.
 
+Om een kolom start positie te resetten naar de automatische flow is er `vl-column--start-auto` met de
+responsieve varianten `vl-column--X-start-auto` waarbij X [m, s, xs] kan zijn. Dit is nuttig wanneer je een
+expliciete start positie hebt op grotere schermen maar wil terugkeren naar de natuurlijke flow op kleinere
+schermen (zie laatste rij in onderstaand voorbeeld).
+
 <Canvas of={VlGridStories.GridColumnStart} />
 
 ### **vl-column - justify-self / align-self**

--- a/libs/styles/src/layout/grid/stories/vl-grid.stories.ts
+++ b/libs/styles/src/layout/grid/stories/vl-grid.stories.ts
@@ -117,7 +117,7 @@ export const GridColumnStart = () => html`
             }
         }
 
-        .vl-grid {
+        .vl-grid.grid-column-start-story {
             --vl-column-min-height: 20px;
             grid-template-rows: 20px;
             padding: 1vmax;
@@ -139,9 +139,18 @@ export const GridColumnStart = () => html`
                 background-color: mediumspringgreen;
                 border: lightseagreen 2px solid;
             }
+
+            .sb-reset-example {
+                background-color: lightcoral;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 0.8rem;
+                text-align: center;
+            }
         }
     </style>
-    <div class="vl-grid">
+    <div class="vl-grid grid-column-start-story">
         <div class="vl-column vl-column--1 vl-column--start-12 vl-column--m-4 vl-column--m-start-9"></div>
         <div class="vl-column vl-column--2 vl-column--start-11 vl-column--m-4 vl-column--m-start-9"></div>
         <div class="vl-column vl-column--3 vl-column--start-10 vl-column--m-4 vl-column--m-start-9"></div>
@@ -154,6 +163,9 @@ export const GridColumnStart = () => html`
         <div class="vl-column vl-column--10 vl-column--start-3 vl-column--m-start-1 vl-column--m-12"></div>
         <div class="vl-column vl-column--11 vl-column--start-2 vl-column--m-start-1 vl-column--m-12"></div>
         <div class="vl-column vl-column--12 vl-column--start-1"></div>
+        <div class="vl-column sb-reset-example vl-column--4 vl-column--start-9 vl-column--m-6 vl-column--m-start-auto">
+            start-9 → m-start-auto
+        </div>
     </div>
 `;
 GridColumnStart.storyName = 'vl-grid - column start';


### PR DESCRIPTION
Momenteel zijn er geen klasse om bij onze `vl-grid`, `grid-column-start: auto` in te stellen, terwijl dit wel moet kunnen als je op verschillende media queries andere `grid-column-start` op `auto` / `initial` wil instellen.

[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-519)

Had dit nodig voor de `vl-side-navigation-next`
