### PR TITLE
feat: FLUX-522 - vl-select-rich search strategies (default / exact-and / exact-or)

### DIFF
--- a/libs/components/src/form/select-rich/index.ts
+++ b/libs/components/src/form/select-rich/index.ts
@@ -1,2 +1,8 @@
 export { VlSelectRichComponent } from './vl-select-rich.component';
-export { type SelectRichOption, SelectRichPosition } from './vl-select-rich.model';
+export { type SelectRichOption, SelectRichPosition, SelectSearchStrategy } from './vl-select-rich.model';
+export {
+    type SelectRichSearchMatcher,
+    exactAndMatcher,
+    exactOrMatcher,
+    getSearchMatcher,
+} from './vl-select-rich.search-matchers';

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
@@ -2,7 +2,7 @@ import { CATEGORIES, CONTROLS, getSelectControlOptions, TYPES } from '@resources
 import { ArgTypes } from '@storybook/web-components-vite';
 import { formControlArgs, formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
 import { selectRichDefaults } from '../vl-select-rich.defaults';
-import { SelectRichPosition } from '../vl-select-rich.model';
+import { SelectRichPosition, SelectSearchStrategy } from '../vl-select-rich.model';
 import { action } from 'storybook/actions';
 
 type SelectRichArgs = typeof formControlArgs &
@@ -108,6 +108,17 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: selectRichArgs.searchPlaceholder },
+        },
+    },
+    searchStrategy: {
+        name: 'search-strategy',
+        description: 'De zoek strategie die gebruikt wordt bij het zoeken in de opties.<br>Dit attribuut is reactief.',
+        control: { type: CONTROLS.SELECT },
+        options: Object.values(SelectSearchStrategy),
+        table: {
+            type: { summary: getSelectControlOptions(Object.values(SelectSearchStrategy)) },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: selectRichArgs.searchStrategy },
         },
     },
     initialOptions: {

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
@@ -7,6 +7,22 @@ import FormControlPublicMethods from '../../form-control/stories/form-control.pu
 <FluxComponentMetaData id="components-form-select-rich" />
 
 
+## Inhoudstafel
+
+ - [Doel](#doel)
+ - [Voorbeeld](#voorbeeld)
+ - [Configuratie](#configuratie)
+ - [Publieke methodes](#publieke-methodes)
+ - [Styles](#styles)
+ - [Events](#events)
+ - [Select opties](#select-opties)
+ - [Accessibility](#accessibility)
+ - [Varianten](#varianten)
+ - [Zoek strategieën](#zoek-strategieën)
+ - [Validatie](#validatie)
+ - [Referenties](#referenties)
+
+
 ## Doel
 
 Gebruik de `select-rich` component om een uitgebreid select of multiselect veld toe te voegen aan een pagina.<br/>
@@ -156,7 +172,7 @@ Indien er minder dan 7 opties zijn raden we aan checkboxes of radio buttons te g
 
 De zoekfunctie is standaard geactiveerd voor de multiselect.
 
-<Canvas of={VlSelectRichStories.SelectRichSearch} />
+<Canvas of={VlSelectRichStories.SelectRichDefault} />
 
 <details>
     <summary>options</summary>
@@ -291,6 +307,40 @@ Indien de 'required' boolean op true staat, moet je een value programmatorisch s
         { label: 'Rio Piedras', value: 'rio piedras', disabled: true }
 ]`} language="ts" dark={true} />
 </details>
+
+
+## Zoek strategieën
+
+Het `search-strategy` attribuut (reactief) bepaalt hoe de zoekfunctie werkt bij het filteren van opties.<br/>
+Er zijn drie zoek strategieën beschikbaar: `default`, `exact-and` en `exact-or`.<br/>
+
+### default
+
+De standaard zoek strategie gebruikt de native Choices.js fuzzy matching van [Fuse.js](https://www.fusejs.io/).<br/>
+Dit betekent dat de zoekterm niet exact hoeft voor te komen in de optie.
+
+### exact-and
+
+Bij de `exact-and` strategie moeten **alle** zoekwoorden exact voorkomen in het label of value van een optie
+(substring match). Bij invoer van meerdere woorden, worden alleen de opties getoond die alle woorden bevatten
+(AND-logica).
+
+**Voorbeeld:** Als je zoekt op "standaard gent", wordt alleen "De Standaard van Gent" getoond, omdat dit de enige optie
+is die zowel "standaard" als "gent" bevat.
+
+Deze strategie is geschikt wanneer je precies wil kunnen filteren op meerdere criteria tegelijk.
+
+### exact-or
+
+Bij de `exact-or` strategie moet **minstens één** zoekwoord exact voorkomen in het label of value van een optie
+(substring match). Wanneer je meerdere woorden invoert, worden alle opties getoond die één of meer woorden bevatten
+(OR-logica).
+
+**Voorbeeld:** Als je zoekt op "standaard gent", worden alle opties getoond die "standaard" **of** "gent" bevatten,
+zoals "De Standaard van gisteren", "De Standaard van morgen", "De Standaard van Berchem", "De Standaard van Gent"
+en "Brussel Antwerpen Gent".
+
+Deze strategie is geschikt wanneer je breed wil kunnen zoeken op meerdere termen tegelijk.
 
 
 ## Validatie

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
@@ -42,6 +42,7 @@ const SelectRichTemplate = story(
         noResultsText,
         noChoicesText,
         searchPlaceholder,
+        searchStrategy,
         onVlChange,
         onVlInput,
         onVlSelectSearch,
@@ -66,6 +67,7 @@ const SelectRichTemplate = story(
             no-results-text=${noResultsText}
             no-choices-text=${noChoicesText}
             search-placeholder=${searchPlaceholder}
+            search-strategy=${searchStrategy}
             @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-select-search=${onVlSelectSearch}
@@ -91,20 +93,60 @@ SelectRichDefault.args = {
     ],
 };
 
-export const SelectRichSearch = SelectRichTemplate.bind({});
-SelectRichSearch.storyName = 'vl-select-rich - search';
-SelectRichSearch.args = {
-    id: 'geboorteplaats',
-    name: 'geboorteplaats',
-    placeholder: 'Kies je geboorteplaats',
+export const SelectRichSearchStrategyDefault = SelectRichTemplate.bind({});
+SelectRichSearchStrategyDefault.storyName = 'vl-select-rich - search default';
+SelectRichSearchStrategyDefault.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
     search: true,
+    searchStrategy: 'default',
+    resultLimit: 20,
     options: [
-        { label: 'Hasselt', value: 'hasselt' },
-        { label: 'Turnhout', value: 'turnhout' },
-        { label: 'Knokke-Heist', value: 'knokke-heist' },
-        { label: 'Waregem', value: 'waregem' },
-        { label: 'Lier', value: 'lier' },
-        { label: 'Rio Piedras', value: 'rio piedras' },
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ],
+};
+
+export const SelectRichSearchStrategyExactAnd = SelectRichTemplate.bind({});
+SelectRichSearchStrategyExactAnd.storyName = 'vl-select-rich - search exact-and';
+SelectRichSearchStrategyExactAnd.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
+    search: true,
+    searchStrategy: 'exact-and',
+    resultLimit: 20,
+    options: [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ],
+};
+
+export const SelectRichSearchStrategyExactOr = SelectRichTemplate.bind({});
+SelectRichSearchStrategyExactOr.storyName = 'vl-select-rich - search exact-or';
+SelectRichSearchStrategyExactOr.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
+    search: true,
+    searchStrategy: 'exact-or',
+    resultLimit: 20,
+    options: [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
     ],
 };
 

--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -1706,3 +1706,317 @@ describe('cypress-component - form components - vl-select-rich - multiple in for
         });
     });
 });
+
+describe('cypress-component - form components - vl-select-rich - search strategies', () => {
+    const newspaperOptions: SelectRichOption[] = [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ];
+
+    it('should use default fuzzy search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="default"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Test fuzzy search - typo should still find results
+        cy.get('vl-select-rich').shadow().find('input').type('standrd');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length.greaterThan', 0);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should use exact-and search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Search for "morgen standaard" - should only find "De Standaard van morgen" (1 result)
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('De Standaard van morgen');
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should use exact-or search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Search for "morgen standaard" - should find all items with "morgen" OR "standaard" (5 results)
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should switch from default to exact-and strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                id="test-select"
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="default"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // With default strategy, fuzzy search should work
+        cy.get('vl-select-rich').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length.greaterThan', 0);
+
+        // Clear search
+        cy.get('vl-select-rich').shadow().find('input').clear();
+
+        // Switch to exact-and strategy
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.setAttribute('search-strategy', 'exact-and');
+        });
+
+        // Search with exact-and - both words must be present
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should switch from exact-and to exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // With exact-and, should find 1 result
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+
+        // Clear search
+        cy.get('vl-select-rich').shadow().find('input').clear();
+
+        // Switch to exact-or strategy
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.setAttribute('search-strategy', 'exact-or');
+        });
+
+        // Search with exact-or - any word can be present
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should handle adding characters with exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Search for "morgen" - should find 2 results
+        cy.get('vl-select-rich').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 2);
+
+        // Add " standaard" - should find 5 results (OR logic)
+        cy.get('vl-select-rich').shadow().find('input').type(' standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should handle removing characters with exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Search for "morgen standaard" - should find 5 results
+        cy.get('vl-select-rich').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        // Remove " standaard" by clearing and typing "morgen" - should find 2 results
+        cy.get('vl-select-rich').shadow().find('input').clear();
+        cy.get('vl-select-rich').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 2);
+
+        // Clear completely - should show all 6 options
+        cy.get('vl-select-rich').shadow().find('input').clear();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 6);
+
+        cy.checkA11y('vl-select-rich');
+    });
+
+    it('should handle adding and removing characters with exact-and strategy', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+
+        // Search for "standaard" - should find 4 results
+        cy.get('vl-select-rich').shadow().find('input').type('standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 4);
+
+        // Add " gent" - should find 1 result (AND logic)
+        cy.get('vl-select-rich').shadow().find('input').type(' gent');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('De Standaard van Gent');
+
+        // Remove " gent" - should find 4 results again
+        cy.get('vl-select-rich').shadow().find('input').clear();
+        cy.get('vl-select-rich').shadow().find('input').type('standaard');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 4);
+
+        cy.checkA11y('vl-select-rich');
+    });
+});

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -12,6 +12,7 @@ import { vlSelectRichFluxStyles } from './styles/vl-select-rich.flux-css';
 import selectStyle from './styles/vl-select.dv-css';
 import { selectRichDefaults } from './vl-select-rich.defaults';
 import { SelectRichOption } from './vl-select-rich.model';
+import { getSearchMatcher, SelectRichSearchMatcher } from './vl-select-rich.search-matchers';
 
 @webComponent('vl-select-rich')
 export class VlSelectRichComponent extends FormControl {
@@ -30,6 +31,10 @@ export class VlSelectRichComponent extends FormControl {
     private resultLimit = selectRichDefaults.resultLimit;
     private noResultsText = selectRichDefaults.noResultsText;
     private noChoicesText = selectRichDefaults.noChoicesText;
+    private searchStrategy = selectRichDefaults.searchStrategy;
+    // Search matcher
+    private searchMatcher: SelectRichSearchMatcher | null = null;
+    private nativeSearchMethod: ((value: string) => number | null) | null = null;
     // State
     private value: FormValue = null;
     private dropdownInitialised = false;
@@ -77,6 +82,7 @@ export class VlSelectRichComponent extends FormControl {
             noResultsText: { type: String, attribute: 'no-results-text' },
             noChoicesText: { type: String, attribute: 'no-choices-text' },
             searchPlaceholder: { type: String, attribute: 'search-placeholder' },
+            searchStrategy: { type: String, attribute: 'search-strategy' },
             value: {
                 type: FormData,
                 state: true,
@@ -138,6 +144,9 @@ export class VlSelectRichComponent extends FormControl {
         // Fix voor Choices.js search event dat niet afgevuurd wordt als de search value verwijderd wordt.
         this.choices?.input?.element?.addEventListener('input', this.onSearchInput);
 
+        // Installeer de search wrapper die dynamisch de juiste matcher gebruikt
+        this.installSearchWrapper();
+
         this.initialised = true;
     };
 
@@ -182,6 +191,11 @@ export class VlSelectRichComponent extends FormControl {
 
         if (changedProperties.has('resultLimit')) {
             this.choices.config.searchResultLimit = this.resultLimit;
+        }
+
+        if (changedProperties.has('searchStrategy')) {
+            // Update de matcher - de wrapper zal automatisch de juiste gebruiken
+            this.searchMatcher = getSearchMatcher(this.searchStrategy);
         }
     }
 
@@ -246,6 +260,23 @@ export class VlSelectRichComponent extends FormControl {
             return;
         }
         this.options = structuredClone(options);
+    }
+
+    /**
+     * Registreert een custom search matcher voor het zoeken in de opties.
+     * Gebruik null om terug te keren naar het native Choices.js gedrag.
+     * @param matcher - De search matcher functie die gebruikt moet worden, of null voor native gedrag
+     * @example
+     * ```typescript
+     * import { exactAndMatcher } from './vl-select-rich.search-matchers';
+     * selectRichComponent.setSearchMatcher(exactAndMatcher);
+     * // Of terug naar native gedrag:
+     * selectRichComponent.setSearchMatcher(null);
+     * ```
+     */
+    setSearchMatcher(matcher: SelectRichSearchMatcher | null): void {
+        this.searchMatcher = matcher;
+        // De wrapper functie zal automatisch de juiste matcher gebruiken
     }
 
     /**
@@ -508,6 +539,29 @@ export class VlSelectRichComponent extends FormControl {
         const value = (event?.target as HTMLInputElement)?.value;
         this.dispatchEvent(new CustomEvent('vl-select-search', { bubbles: true, composed: true, detail: { value } }));
     };
+
+    /**
+     * Installeert een wrapper functie die dynamisch tussen native en custom search schakelt.
+     * Deze wrapper blijft altijd aanwezig en roept de juiste matcher aan op basis van searchMatcher.
+     */
+    private installSearchWrapper(): void {
+        if (!this.choices) {
+            return;
+        }
+
+        // Sla de originele native search methode op
+        this.nativeSearchMethod = (this.choices as any)._searchChoices.bind(this.choices);
+
+        // Installeer een permanente wrapper die dynamisch de juiste matcher gebruikt
+        (this.choices as any)._searchChoices = (value: string) => {
+            // Als er een custom matcher is, gebruik die
+            if (this.searchMatcher) {
+                return this.searchMatcher(this.choices!, value);
+            }
+            // Anders gebruik de native Choices.js methode
+            return this.nativeSearchMethod!(value);
+        };
+    }
 }
 
 declare global {

--- a/libs/components/src/form/select-rich/vl-select-rich.defaults.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.defaults.ts
@@ -1,5 +1,5 @@
 import { formControlDefaults } from '../form-control/form-control.defaults';
-import { SelectRichOption, SelectRichPosition } from './vl-select-rich.model';
+import { SelectRichOption, SelectRichPosition, SelectSearchStrategy } from './vl-select-rich.model';
 
 export const selectRichDefaults = {
     ...formControlDefaults,
@@ -14,4 +14,5 @@ export const selectRichDefaults = {
     noResultsText: 'Geen resultaten gevonden' as string,
     noChoicesText: 'Geen resterende opties gevonden' as string,
     searchPlaceholder: 'Zoek item' as string,
+    searchStrategy: SelectSearchStrategy.DEFAULT as SelectSearchStrategy,
 } as const;

--- a/libs/components/src/form/select-rich/vl-select-rich.model.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.model.ts
@@ -14,3 +14,12 @@ export const SelectRichPosition = {
 } as const;
 
 export type SelectRichPosition = (typeof SelectRichPosition)[keyof typeof SelectRichPosition];
+
+export const SelectSearchStrategy = {
+    DEFAULT: 'default',
+    EXACT_AND: 'exact-and',
+    EXACT_OR: 'exact-or',
+} as const;
+
+export type SelectSearchStrategy =
+    (typeof SelectSearchStrategy)[keyof typeof SelectSearchStrategy];

--- a/libs/components/src/form/select-rich/vl-select-rich.search-matchers.spec.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.search-matchers.spec.ts
@@ -1,0 +1,272 @@
+import Choices from 'choices.js';
+import { exactOrMatcher, exactAndMatcher } from './vl-select-rich.search-matchers';
+
+describe('jest - components - vl-select-rich - search-matchers', () => {
+    let mockChoices: Partial<Choices>;
+
+    beforeEach(() => {
+        // Console logging afzetten
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        // Mock Choices.js structure
+        mockChoices = {
+            config: {
+                noResultsText: 'Geen resultaten gevonden',
+            },
+        } as any;
+
+        // Mock internal Choices.js properties
+        (mockChoices as any)._currentValue = '';
+        (mockChoices as any)._highlightPosition = 0;
+        (mockChoices as any)._isSearching = false;
+        (mockChoices as any)._notice = null;
+        (mockChoices as any)._searcher = {
+            isEmptyIndex: jest.fn().mockReturnValue(false),
+            index: jest.fn(),
+        };
+        const testChoices = [
+            {
+                label: 'De Morgen van gisteren',
+                value: 'De Morgen van gisteren',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van gisteren',
+                value: 'De Standaard van gisteren',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van morgen',
+                value: 'De Standaard van morgen',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van Berchem',
+                value: 'De Standaard van Berchem',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van Gent',
+                value: 'De Standaard van Gent',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'Brussel Antwerpen Gent',
+                value: 'Brussel Antwerpen Gent',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+        ];
+
+        (mockChoices as any)._store = {
+            choices: testChoices,
+            searchableChoices: testChoices,
+            dispatch: jest.fn(),
+        };
+        (mockChoices as any)._displayNotice = jest.fn();
+        (mockChoices as any)._clearNotice = jest.fn();
+    });
+
+    describe('exactOrMatcher', () => {
+        it('should return null for empty search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, '');
+            expect(result).toBeNull();
+        });
+
+        it('should return null for whitespace-only search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, '   ');
+            expect(result).toBeNull();
+        });
+
+        it('should find all choices containing "morgen" OR "standaard" with OR logic', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen standaard');
+
+            // Verify dispatch was called with filtered results
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Morgen van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Berchem' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                ]),
+            });
+
+            // Should return 5 results (all that contain either "morgen" or "standaard")
+            expect(result).toBe(5);
+        });
+
+        it('should find choices containing "morgen" with single word search', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Morgen van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should find choices containing "gent" with single word search', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'Brussel Antwerpen Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should find choices containing "brussel" OR "gent" with OR logic', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'brussel gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'Brussel Antwerpen Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should return 0 results when no matches found', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'xyz');
+
+            expect((mockChoices as any)._displayNotice).toHaveBeenCalledWith(
+                'Geen resultaten gevonden',
+                'no-results'
+            );
+            expect(result).toBe(0);
+        });
+
+        it('should skip disabled choices', () => {
+            (mockChoices as any)._store.choices[0].disabled = true;
+
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            // Should only find "De Standaard van morgen" (not "De Morgen van gisteren" because it's disabled)
+            expect(result).toBe(1);
+        });
+
+        it('should NOT skip inactive choices (we determine activity ourselves)', () => {
+            (mockChoices as any)._store.choices[0].active = false;
+
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            // Should find both choices with "morgen", even if one is marked inactive by Choices.js
+            // We ignore the active flag and determine ourselves what matches
+            expect(result).toBe(2);
+        });
+
+        it('should be case insensitive', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'MORGEN');
+
+            expect(result).toBe(2);
+        });
+
+        it('should handle multiple spaces in search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen    standaard');
+
+            expect(result).toBe(5);
+        });
+    });
+
+    describe('exactAndMatcher', () => {
+        it('should find only choices containing BOTH "morgen" AND "standaard"', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'morgen standaard');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                ]),
+            });
+
+            // Should return only 1 result (only "De Standaard van morgen" contains both)
+            expect(result).toBe(1);
+        });
+
+        it('should find choices containing both "standaard" AND "gent"', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'standaard gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(1);
+        });
+
+        it('should return 0 when searching for words that never appear together', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'morgen brussel');
+
+            expect(result).toBe(0);
+        });
+    });
+
+    describe('exactOrMatcher vs exactAndMatcher', () => {
+        it('OR should return more results than AND for multi-word search', () => {
+            const orResult = exactOrMatcher(mockChoices as Choices, 'morgen standaard');
+
+            // Reset _currentValue zodat de volgende matcher niet denkt dat het dezelfde zoekterm is
+            (mockChoices as any)._currentValue = '';
+
+            const andResult = exactAndMatcher(mockChoices as Choices, 'morgen standaard');
+
+            expect(orResult).not.toBeNull();
+            expect(andResult).not.toBeNull();
+            expect(orResult!).toBeGreaterThan(andResult!);
+            expect(orResult).toBe(5); // OR: all with "morgen" OR "standaard"
+            expect(andResult).toBe(1); // AND: only "De Standaard van morgen" has both
+        });
+    });
+});

--- a/libs/components/src/form/select-rich/vl-select-rich.search-matchers.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.search-matchers.ts
@@ -1,0 +1,124 @@
+import Choices from 'choices.js';
+import { SelectSearchStrategy } from './vl-select-rich.model';
+
+/**
+ * Type definitie voor een search matcher functie.
+ */
+export type SelectRichSearchMatcher = (choices: Choices, searchValue: string) => number | null;
+
+/**
+ * Helper functie voor exacte search matching met configureerbare match logica.
+ * @param matchLogic - Functie die bepaalt of een choice matcht op basis van zoekwoorden
+ * @returns Een search matcher functie
+ */
+const createExactMatcher = (
+    matchLogic: (searchWords: string[], searchText: string) => boolean
+): SelectRichSearchMatcher => {
+    return (choices: Choices, searchValue: string) => {
+        const newValue = searchValue.trim().replace(/\s{2,}/g, ' ');
+
+        // Als de zoekterm leeg is of gelijk aan de huidige waarde, stop
+        if (!newValue.length || newValue === (choices as any)._currentValue) {
+            return null;
+        }
+
+        const searcher = (choices as any)._searcher;
+        const store = (choices as any)._store;
+
+        // Gebruik ALTIJD alle choices (niet alleen searchableChoices die al gefilterd kunnen zijn)
+        // Dit zorgt ervoor dat we altijd op de volledige lijst zoeken, niet incrementeel
+        const allChoices = store.choices.filter((choice: any) => !choice.placeholder);
+
+        // Herindexeer de searcher met alle choices bij elke zoekopdracht
+        if (searcher.isEmptyIndex()) {
+            searcher.index(allChoices);
+        }
+
+        // Split de zoekterm in woorden
+        const searchWords = newValue.toLowerCase().split(/\s+/).filter((word: string) => word.length > 0);
+
+        const results = allChoices
+            .filter((choice: any) => {
+                // Check alleen disabled, niet active - want we bepalen zelf wat actief is
+                // (choice.active kan nog false zijn van een vorige zoekopdracht)
+                if (choice.disabled) {
+                    return false;
+                }
+
+                // Zoek in label en value
+                const label = choice.label?.toLowerCase() || '';
+                const choiceValue = choice.value?.toLowerCase() || '';
+                const searchText = `${label} ${choiceValue}`;
+
+                // Pas de opgegeven match logica toe
+                return matchLogic(searchWords, searchText);
+            })
+            .map((choice: any, index: number) => ({
+                item: choice,
+                score: 0,
+                rank: index + 1,
+            }));
+
+        // Update de huidige waarde en state
+        (choices as any)._currentValue = newValue;
+        (choices as any)._highlightPosition = 0;
+        (choices as any)._isSearching = true;
+
+        // Toon "geen resultaten" bericht als er geen matches zijn
+        const notice = (choices as any)._notice;
+        const noticeType = notice && notice.type;
+
+        if (noticeType !== 'addChoice') {
+            if (!results.length) {
+                (choices as any)._displayNotice((choices as any).config.noResultsText, 'no-results');
+            } else {
+                (choices as any)._clearNotice();
+            }
+        }
+
+        // Dispatch de gefilterde resultaten naar de store
+        (choices as any)._store.dispatch({
+            type: 'FILTER_CHOICES',
+            results: results,
+        });
+
+        return results.length;
+    };
+};
+
+/**
+ * Exacte AND-search matcher: alle zoekwoorden moeten exact voorkomen (substring match).
+ * Bij meerdere woorden moeten ALLE woorden voorkomen in het label of value (AND-logica).
+ * Geen fuzzy matching - alleen exacte substring matches.
+ */
+export const exactAndMatcher: SelectRichSearchMatcher = createExactMatcher(
+    (searchWords, searchText) => searchWords.every((word) => searchText.includes(word))
+);
+
+/**
+ * Exacte OR-search matcher: minstens één zoekwoord moet exact voorkomen (substring match).
+ * Bij meerdere woorden moet MINSTENS ÉÉN woord voorkomen in het label of value (OR-logica).
+ * Geen fuzzy matching - alleen exacte substring matches.
+ */
+export const exactOrMatcher: SelectRichSearchMatcher = createExactMatcher(
+    (searchWords, searchText) => searchWords.some((word) => searchText.includes(word))
+);
+
+/**
+ * Map van strategy types naar matcher functies.
+ * Voor 'default' wordt geen matcher gebruikt - het native Choices.js gedrag wordt behouden.
+ */
+const searchMatcherMap: Record<string, SelectRichSearchMatcher> = {
+    [SelectSearchStrategy.EXACT_AND]: exactAndMatcher,
+    [SelectSearchStrategy.EXACT_OR]: exactOrMatcher,
+};
+
+/**
+ * Geeft de search matcher functie op basis van het type.
+ * Voor 'default' wordt null geretourneerd om het native Choices.js gedrag te gebruiken.
+ * @param type - Het type van de search strategy ('default', 'exact-and' of 'exact-or')
+ * @returns De bijbehorende search matcher functie, of null voor native gedrag
+ */
+export const getSearchMatcher = (type: SelectSearchStrategy): SelectRichSearchMatcher | null => {
+    return type === SelectSearchStrategy.DEFAULT ? null : (searchMatcherMap[type] || null);
+};

--- a/libs/map/src/components/select-location/stories/vl-select-location.stories-arg.ts
+++ b/libs/map/src/components/select-location/stories/vl-select-location.stories-arg.ts
@@ -11,6 +11,7 @@ type SelectLocationArgs = typeof selectLocationDefaults;
 const minimalSelectRichDefaults = { ...selectRichDefaults };
 delete minimalSelectRichDefaults.multiple;
 delete minimalSelectRichDefaults.search;
+delete minimalSelectRichDefaults.searchStrategy;
 
 export const selectLocationDefaults = {
     ...minimalSelectRichDefaults,
@@ -25,6 +26,7 @@ export const selectLocationArgs: SelectLocationArgs = {
 const minimalSelectRichArgTypes = { ...selectRichArgTypes };
 delete minimalSelectRichArgTypes.multiple;
 delete minimalSelectRichArgTypes.search;
+delete minimalSelectRichArgTypes.searchStrategy;
 
 export const selectLocationArgTypes: ArgTypes<SelectLocationArgs> = {
     ...minimalSelectRichArgTypes,

--- a/libs/map/src/components/select-location/vl-select-location.ts
+++ b/libs/map/src/components/select-location/vl-select-location.ts
@@ -18,6 +18,9 @@ export class VlSelectLocationComponent extends VlSelectRichComponent {
         this.placeholder = placeholder;
         this.search = true;
         this.searchPlaceholder = searchPlaceholder;
+        // deactiveer de custom search matchers omdat de API al de filtering doet - de searchMatcher zou de
+        // API-resultaten nog eens filteren, wat tot verkeerde resultaten leidt
+        this.setSearchMatcher(null);
     }
 
     /**
@@ -82,6 +85,17 @@ export class VlSelectLocationComponent extends VlSelectRichComponent {
         super.disconnectedCallback();
 
         this.removeEventListener('vl-select-search', this.debouncedOnSearch);
+    }
+
+    updated(changedProperties: Map<string, unknown>): void {
+        super.updated(changedProperties);
+
+        // voor deze component (VlSelectLocationComponent) moet de searchMatcher altijd null blijven omdat de API al
+        // de filtering doet - een custom search matcher zou de API-resultaten nog eens filteren, wat tot verkeerde
+        // resultaten leidt
+        if (changedProperties.has('searchStrategy')) {
+            this.setSearchMatcher(null);
+        }
     }
 
     private onSearch = (event: CustomEvent<{ value?: string }>[]) => {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-522
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC205

Een configureerbaar searchStrategy attribuut toegevoegd:
 - 'default': native Fuse.js (fuzzy search)
 - 'exact-and': alle woorden moeten voorkomen (AND-logica)
 - 'exact-or': minstens 1 woord moet voorkomen (OR-logica)

De implementatie gebruikt een dynamische wrapper die schakelt tussen native en custom matchers. Hij filtert altijd op alle opties (niet incrementeel) voor correcte resultaten bij het toevoegen/verwijderen van characters.

Tests: 18 Jest unit tests + 7 Cypress e2e tests