### PR TITLE
feat: FLUX-484 - vl-info-tile - toestaan van te krimpen

### DIFF
--- a/libs/components/src/block/info-tile/vl-info-tile.flux-css.ts
+++ b/libs/components/src/block/info-tile/vl-info-tile.flux-css.ts
@@ -6,7 +6,7 @@ export const vlInfoTyleFluxStyles: CSSResult = css`
         flex-direction: row;
     }
     :host .vl-info-tile__header__wrapper {
-        flex: 1 0 auto;
+        flex: 1 1 auto;
         display: flex;
         justify-content: space-between;
     }


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-484
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC210

flex-shrink stond af (0), dit op (1) zetten lost het probleem op

Je kan dit testen door in Storybook een lange tekst in het subtitle slot te steken en dan je scherm bvb. smal te maken.