### PR TITLE
fix: FLUX-540 - vl-select-rich-next - search strategies (default / exact-and / exact-or)

### DIFF
--- a/libs/form/src/next/select-rich/index.ts
+++ b/libs/form/src/next/select-rich/index.ts
@@ -1,2 +1,8 @@
 export { VlSelectRichComponent } from './vl-select-rich.component';
-export { type SelectRichOption, SelectRichPosition } from './vl-select-rich.model';
+export { type SelectRichOption, SelectRichPosition, SelectSearchStrategy } from './vl-select-rich.model';
+export {
+    type SelectRichSearchMatcher,
+    exactAndMatcher,
+    exactOrMatcher,
+    getSearchMatcher,
+} from './vl-select-rich.search-matchers';

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories-arg.ts
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories-arg.ts
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { ArgTypes } from '@storybook/web-components';
 import { formControlArgs, formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
 import { selectRichDefaults } from '../vl-select-rich.defaults';
-import { SelectRichPosition } from '../vl-select-rich.model';
+import { SelectRichPosition, SelectSearchStrategy } from '../vl-select-rich.model';
 
 type SelectRichArgs = typeof formControlArgs &
     typeof selectRichDefaults & {
@@ -108,6 +108,17 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: selectRichArgs.searchPlaceholder },
+        },
+    },
+    searchStrategy: {
+        name: 'search-strategy',
+        description: 'De zoek strategie die gebruikt wordt bij het zoeken in de opties.<br>Dit attribuut is reactief.',
+        control: { type: CONTROLS.SELECT },
+        options: Object.values(SelectSearchStrategy),
+        table: {
+            type: { summary: getSelectControlOptions(Object.values(SelectSearchStrategy)) },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: selectRichArgs.searchStrategy },
         },
     },
     initialOptions: {

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories-doc.mdx
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories-doc.mdx
@@ -276,6 +276,39 @@ Indien de 'required' boolean op true staat, moet je een value programmatorisch s
 ]`} language="ts" dark={true}/>
 </details>
 
+## Zoek strategieën
+
+Het `search-strategy` attribuut (reactief) bepaalt hoe de zoekfunctie werkt bij het filteren van opties.<br/>
+Er zijn drie zoek strategieën beschikbaar: `default`, `exact-and` en `exact-or`.<br/>
+
+### default
+
+De standaard zoek strategie gebruikt de native Choices.js fuzzy matching van [Fuse.js](https://www.fusejs.io/).<br/>
+Dit betekent dat de zoekterm niet exact hoeft voor te komen in de optie.
+
+### exact-and
+
+Bij de `exact-and` strategie moeten **alle** zoekwoorden exact voorkomen in het label of value van een optie
+(substring match). Bij invoer van meerdere woorden, worden alleen de opties getoond die alle woorden bevatten
+(AND-logica).
+
+**Voorbeeld:** Als je zoekt op "standaard gent", wordt alleen "De Standaard van Gent" getoond, omdat dit de enige optie
+is die zowel "standaard" als "gent" bevat.
+
+Deze strategie is geschikt wanneer je precies wil kunnen filteren op meerdere criteria tegelijk.
+
+### exact-or
+
+Bij de `exact-or` strategie moet **minstens één** zoekwoord exact voorkomen in het label of value van een optie
+(substring match). Wanneer je meerdere woorden invoert, worden alle opties getoond die één of meer woorden bevatten
+(OR-logica).
+
+**Voorbeeld:** Als je zoekt op "standaard gent", worden alle opties getoond die "standaard" **of** "gent" bevatten,
+zoals "De Standaard van gisteren", "De Standaard van morgen", "De Standaard van Berchem", "De Standaard van Gent"
+en "Brussel Antwerpen Gent".
+
+Deze strategie is geschikt wanneer je breed wil kunnen zoeken op meerdere termen tegelijk.
+
 ## Validatie
 
 Meer info over validatie binnen onze form componenten vind je hier:

--- a/libs/form/src/next/select-rich/stories/vl-select-rich.stories.ts
+++ b/libs/form/src/next/select-rich/stories/vl-select-rich.stories.ts
@@ -42,6 +42,7 @@ const SelectRichTemplate = story(
         noResultsText,
         noChoicesText,
         searchPlaceholder,
+        searchStrategy,
         onVlChange,
         onVlInput,
         onVlSelectSearch,
@@ -66,6 +67,7 @@ const SelectRichTemplate = story(
             no-results-text=${noResultsText}
             no-choices-text=${noChoicesText}
             search-placeholder=${searchPlaceholder}
+            search-strategy=${searchStrategy}
             @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-select-search=${onVlSelectSearch}
@@ -105,6 +107,63 @@ SelectRichSearch.args = {
         { label: 'Waregem', value: 'waregem' },
         { label: 'Lier', value: 'lier' },
         { label: 'Rio Piedras', value: 'rio piedras' },
+    ],
+};
+
+export const SelectRichSearchStrategyDefault = SelectRichTemplate.bind({});
+SelectRichSearchStrategyDefault.storyName = 'vl-select-rich-next - search default';
+SelectRichSearchStrategyDefault.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
+    search: true,
+    searchStrategy: 'default',
+    resultLimit: 20,
+    options: [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ],
+};
+
+export const SelectRichSearchStrategyExactAnd = SelectRichTemplate.bind({});
+SelectRichSearchStrategyExactAnd.storyName = 'vl-select-rich-next - search exact-and';
+SelectRichSearchStrategyExactAnd.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
+    search: true,
+    searchStrategy: 'exact-and',
+    resultLimit: 20,
+    options: [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ],
+};
+
+export const SelectRichSearchStrategyExactOr = SelectRichTemplate.bind({});
+SelectRichSearchStrategyExactOr.storyName = 'vl-select-rich-next - search exact-or';
+SelectRichSearchStrategyExactOr.args = {
+    id: 'krant',
+    name: 'krant',
+    placeholder: 'Kies een krant',
+    search: true,
+    searchStrategy: 'exact-or',
+    resultLimit: 20,
+    options: [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
     ],
 };
 

--- a/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.cy.ts
@@ -1805,3 +1805,298 @@ describe('component - vl-select-rich - multiple - in form', () => {
         });
     });
 });
+
+describe('component - vl-select-rich-next - search strategies', () => {
+    const newspaperOptions: SelectRichOption[] = [
+        { label: 'De Morgen van gisteren', value: 'De Morgen van gisteren' },
+        { label: 'De Standaard van gisteren', value: 'De Standaard van gisteren' },
+        { label: 'De Standaard van morgen', value: 'De Standaard van morgen' },
+        { label: 'De Standaard van Berchem', value: 'De Standaard van Berchem' },
+        { label: 'De Standaard van Gent', value: 'De Standaard van Gent' },
+        { label: 'Brussel Antwerpen Gent', value: 'Brussel Antwerpen Gent' },
+    ];
+
+    it('should use default fuzzy search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="default"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('standrd');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length.greaterThan', 0);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should use exact-and search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('De Standaard van morgen');
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should use exact-or search strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should switch from default to exact-and strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                id="test-select"
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="default"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length.greaterThan', 0);
+
+        cy.get('vl-select-rich-next').shadow().find('input').clear();
+
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.setAttribute('search-strategy', 'exact-and');
+        });
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should switch from exact-and to exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+
+        cy.get('vl-select-rich-next').shadow().find('input').clear();
+
+        cy.get('vl-select-rich-next').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.setAttribute('search-strategy', 'exact-or');
+        });
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should handle adding characters with exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 2);
+
+        cy.get('vl-select-rich-next').shadow().find('input').type(' standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should handle removing characters with exact-or strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-or"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 5);
+
+        cy.get('vl-select-rich-next').shadow().find('input').clear();
+        cy.get('vl-select-rich-next').shadow().find('input').type('morgen');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 2);
+
+        cy.get('vl-select-rich-next').shadow().find('input').clear();
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 6);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+
+    it('should handle adding and removing characters with exact-and strategy', () => {
+        cy.mount(
+            html`<vl-select-rich-next
+                label="krant"
+                placeholder="Kies een krant"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${newspaperOptions}
+            ></vl-select-rich-next>`
+        );
+        cy.injectAxe();
+
+        cy.checkA11y('vl-select-rich-next');
+        cy.get('vl-select-rich-next').shadow().find('.vl-select__inner').click();
+
+        cy.get('vl-select-rich-next').shadow().find('input').type('standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 4);
+
+        cy.get('vl-select-rich-next').shadow().find('input').type(' gent');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 1);
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .contains('De Standaard van Gent');
+
+        cy.get('vl-select-rich-next').shadow().find('input').clear();
+        cy.get('vl-select-rich-next').shadow().find('input').type('standaard');
+        cy.get('vl-select-rich-next')
+            .shadow()
+            .find('.vl-select__list')
+            .find('.vl-select__item')
+            .should('have.length', 4);
+
+        cy.checkA11y('vl-select-rich-next');
+    });
+});

--- a/libs/form/src/next/select-rich/vl-select-rich.component.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.component.ts
@@ -12,6 +12,7 @@ import { vlSelectRichFluxStyles } from './styles/vl-select-rich.uig-css';
 import selectStyle from './styles/vl-select.dv-css';
 import { selectRichDefaults } from './vl-select-rich.defaults';
 import { SelectRichOption } from './vl-select-rich.model';
+import { getSearchMatcher, SelectRichSearchMatcher } from './vl-select-rich.search-matchers';
 
 @webComponent('vl-select-rich-next')
 export class VlSelectRichComponent extends FormControl {
@@ -30,6 +31,9 @@ export class VlSelectRichComponent extends FormControl {
     private resultLimit = selectRichDefaults.resultLimit;
     private noResultsText = selectRichDefaults.noResultsText;
     private noChoicesText = selectRichDefaults.noChoicesText;
+    private searchStrategy = selectRichDefaults.searchStrategy;
+    private searchMatcher: SelectRichSearchMatcher | null = null;
+    private nativeSearchMethod: ((value: string) => number | null) | null = null;
     // State
     private value: FormValue = null;
     private dropdownInitialised = false;
@@ -67,6 +71,7 @@ export class VlSelectRichComponent extends FormControl {
             noResultsText: { type: String, attribute: 'no-results-text' },
             noChoicesText: { type: String, attribute: 'no-choices-text' },
             searchPlaceholder: { type: String, attribute: 'search-placeholder' },
+            searchStrategy: { type: String, attribute: 'search-strategy' },
             value: { type: FormData, state: true, hasChanged: this.compareValue },
         };
     }
@@ -124,6 +129,8 @@ export class VlSelectRichComponent extends FormControl {
 
             // Fix voor Choices.js search event dat niet afgevuurd wordt als de search value verwijderd wordt.
             this.choices?.input?.element?.addEventListener('input', this.onSearchInput);
+
+            this.installSearchWrapper();
         }, 0);
 
         this.initialised = true;
@@ -170,6 +177,10 @@ export class VlSelectRichComponent extends FormControl {
 
         if (changedProperties.has('resultLimit')) {
             this.choices.config.searchResultLimit = this.resultLimit;
+        }
+
+        if (changedProperties.has('searchStrategy')) {
+            this.searchMatcher = getSearchMatcher(this.searchStrategy);
         }
     }
 
@@ -234,6 +245,10 @@ export class VlSelectRichComponent extends FormControl {
             return;
         }
         this.options = structuredClone(options);
+    }
+
+    setSearchMatcher(matcher: SelectRichSearchMatcher | null): void {
+        this.searchMatcher = matcher;
     }
 
     /**
@@ -496,6 +511,24 @@ export class VlSelectRichComponent extends FormControl {
         const value = (event?.target as HTMLInputElement)?.value;
         this.dispatchEvent(new CustomEvent('vl-select-search', { bubbles: true, composed: true, detail: { value } }));
     };
+
+    private installSearchWrapper(): void {
+        if (!this.choices) {
+            return;
+        }
+
+        // Capture the original method from the prototype to avoid infinite recursion.
+        // Using the instance directly would capture the wrapper after it's installed.
+        const originalSearchChoices =
+            Object.getPrototypeOf(this.choices)._searchChoices ?? (this.choices as any)._searchChoices;
+        this.nativeSearchMethod = originalSearchChoices.bind(this.choices);
+        (this.choices as any)._searchChoices = (value: string) => {
+            if (this.searchMatcher) {
+                return this.searchMatcher(this.choices!, value);
+            }
+            return this.nativeSearchMethod!(value);
+        };
+    }
 }
 
 declare global {

--- a/libs/form/src/next/select-rich/vl-select-rich.defaults.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.defaults.ts
@@ -1,5 +1,5 @@
 import { formControlDefaults } from '../form-control/form-control.defaults';
-import { SelectRichOption, SelectRichPosition } from './vl-select-rich.model';
+import { SelectRichOption, SelectRichPosition, SelectSearchStrategy } from './vl-select-rich.model';
 
 export const selectRichDefaults = {
     ...formControlDefaults,
@@ -14,4 +14,5 @@ export const selectRichDefaults = {
     noResultsText: 'Geen resultaten gevonden' as string,
     noChoicesText: 'Geen resterende opties gevonden' as string,
     searchPlaceholder: 'Zoek item' as string,
+    searchStrategy: SelectSearchStrategy.DEFAULT as SelectSearchStrategy,
 } as const;

--- a/libs/form/src/next/select-rich/vl-select-rich.model.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.model.ts
@@ -14,3 +14,11 @@ export const SelectRichPosition = {
 } as const;
 
 export type SelectRichPosition = (typeof SelectRichPosition)[keyof typeof SelectRichPosition];
+
+export const SelectSearchStrategy = {
+    DEFAULT: 'default',
+    EXACT_AND: 'exact-and',
+    EXACT_OR: 'exact-or',
+} as const;
+
+export type SelectSearchStrategy = (typeof SelectSearchStrategy)[keyof typeof SelectSearchStrategy];

--- a/libs/form/src/next/select-rich/vl-select-rich.search-matchers.spec.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.search-matchers.spec.ts
@@ -1,0 +1,259 @@
+import Choices from 'choices.js';
+import { exactOrMatcher, exactAndMatcher } from './vl-select-rich.search-matchers';
+
+describe('jest - form-next - vl-select-rich - search-matchers', () => {
+    let mockChoices: Partial<Choices>;
+
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        mockChoices = {
+            config: {
+                noResultsText: 'Geen resultaten gevonden',
+            },
+        } as any;
+
+        (mockChoices as any)._currentValue = '';
+        (mockChoices as any)._highlightPosition = 0;
+        (mockChoices as any)._isSearching = false;
+        (mockChoices as any)._notice = null;
+        (mockChoices as any)._searcher = {
+            isEmptyIndex: jest.fn().mockReturnValue(false),
+            index: jest.fn(),
+        };
+        const testChoices = [
+            {
+                label: 'De Morgen van gisteren',
+                value: 'De Morgen van gisteren',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van gisteren',
+                value: 'De Standaard van gisteren',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van morgen',
+                value: 'De Standaard van morgen',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van Berchem',
+                value: 'De Standaard van Berchem',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'De Standaard van Gent',
+                value: 'De Standaard van Gent',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+            {
+                label: 'Brussel Antwerpen Gent',
+                value: 'Brussel Antwerpen Gent',
+                active: true,
+                disabled: false,
+                placeholder: false,
+            },
+        ];
+
+        (mockChoices as any)._store = {
+            choices: testChoices,
+            searchableChoices: testChoices,
+            dispatch: jest.fn(),
+        };
+        (mockChoices as any)._displayNotice = jest.fn();
+        (mockChoices as any)._clearNotice = jest.fn();
+    });
+
+    describe('exactOrMatcher', () => {
+        it('should return null for empty search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, '');
+            expect(result).toBeNull();
+        });
+
+        it('should return null for whitespace-only search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, '   ');
+            expect(result).toBeNull();
+        });
+
+        it('should find all choices containing "morgen" OR "standaard" with OR logic', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen standaard');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Morgen van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Berchem' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(5);
+        });
+
+        it('should find choices containing "morgen" with single word search', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Morgen van gisteren' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should find choices containing "gent" with single word search', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'Brussel Antwerpen Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should find choices containing "brussel" OR "gent" with OR logic', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'brussel gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'Brussel Antwerpen Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(2);
+        });
+
+        it('should return 0 results when no matches found', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'xyz');
+
+            expect((mockChoices as any)._displayNotice).toHaveBeenCalledWith('Geen resultaten gevonden', 'no-results');
+            expect(result).toBe(0);
+        });
+
+        it('should skip disabled choices', () => {
+            (mockChoices as any)._store.choices[0].disabled = true;
+
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            expect(result).toBe(1);
+        });
+
+        it('should NOT skip inactive choices (we determine activity ourselves)', () => {
+            (mockChoices as any)._store.choices[0].active = false;
+
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen');
+
+            expect(result).toBe(2);
+        });
+
+        it('should be case insensitive', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'MORGEN');
+
+            expect(result).toBe(2);
+        });
+
+        it('should handle multiple spaces in search value', () => {
+            const result = exactOrMatcher(mockChoices as Choices, 'morgen    standaard');
+
+            expect(result).toBe(5);
+        });
+    });
+
+    describe('exactAndMatcher', () => {
+        it('should find only choices containing BOTH "morgen" AND "standaard"', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'morgen standaard');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van morgen' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(1);
+        });
+
+        it('should find choices containing both "standaard" AND "gent"', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'standaard gent');
+
+            expect((mockChoices as any)._store.dispatch).toHaveBeenCalledWith({
+                type: 'FILTER_CHOICES',
+                results: expect.arrayContaining([
+                    expect.objectContaining({
+                        item: expect.objectContaining({ label: 'De Standaard van Gent' }),
+                    }),
+                ]),
+            });
+
+            expect(result).toBe(1);
+        });
+
+        it('should return 0 when searching for words that never appear together', () => {
+            const result = exactAndMatcher(mockChoices as Choices, 'morgen brussel');
+
+            expect(result).toBe(0);
+        });
+    });
+
+    describe('exactOrMatcher vs exactAndMatcher', () => {
+        it('OR should return more results than AND for multi-word search', () => {
+            const orResult = exactOrMatcher(mockChoices as Choices, 'morgen standaard');
+
+            (mockChoices as any)._currentValue = '';
+
+            const andResult = exactAndMatcher(mockChoices as Choices, 'morgen standaard');
+
+            expect(orResult).not.toBeNull();
+            expect(andResult).not.toBeNull();
+            expect(orResult!).toBeGreaterThan(andResult!);
+            expect(orResult).toBe(5);
+            expect(andResult).toBe(1);
+        });
+    });
+});

--- a/libs/form/src/next/select-rich/vl-select-rich.search-matchers.ts
+++ b/libs/form/src/next/select-rich/vl-select-rich.search-matchers.ts
@@ -1,0 +1,83 @@
+import Choices from 'choices.js';
+import { SelectSearchStrategy } from './vl-select-rich.model';
+
+export type SelectRichSearchMatcher = (choices: Choices, searchValue: string) => number | null;
+
+const createExactMatcher = (
+    matchLogic: (searchWords: string[], searchText: string) => boolean
+): SelectRichSearchMatcher => {
+    return (choices: Choices, searchValue: string) => {
+        const newValue = searchValue.trim().replace(/\s{2,}/g, ' ');
+
+        if (!newValue.length || newValue === (choices as any)._currentValue) {
+            return null;
+        }
+
+        const searcher = (choices as any)._searcher;
+        const store = (choices as any)._store;
+        const allChoices = store.choices.filter((choice: any) => !choice.placeholder);
+
+        if (searcher.isEmptyIndex()) {
+            searcher.index(allChoices);
+        }
+
+        const searchWords = newValue.toLowerCase().split(/\s+/).filter((word: string) => word.length > 0);
+
+        const results = allChoices
+            .filter((choice: any) => {
+                if (choice.disabled) {
+                    return false;
+                }
+
+                const label = choice.label?.toLowerCase() || '';
+                const choiceValue = choice.value?.toLowerCase() || '';
+                const searchText = `${label} ${choiceValue}`;
+
+                return matchLogic(searchWords, searchText);
+            })
+            .map((choice: any, index: number) => ({
+                item: choice,
+                score: 0,
+                rank: index + 1,
+            }));
+
+        (choices as any)._currentValue = newValue;
+        (choices as any)._highlightPosition = 0;
+        (choices as any)._isSearching = true;
+
+        const notice = (choices as any)._notice;
+        const noticeType = notice && notice.type;
+
+        if (noticeType !== 'addChoice') {
+            if (!results.length) {
+                (choices as any)._displayNotice((choices as any).config.noResultsText, 'no-results');
+            } else {
+                (choices as any)._clearNotice();
+            }
+        }
+
+        (choices as any)._store.dispatch({
+            type: 'FILTER_CHOICES',
+            results: results,
+        });
+
+        return results.length;
+    };
+};
+
+export const exactAndMatcher: SelectRichSearchMatcher = createExactMatcher(
+    (searchWords, searchText) => searchWords.every((word) => searchText.includes(word))
+);
+
+export const exactOrMatcher: SelectRichSearchMatcher = createExactMatcher(
+    (searchWords, searchText) => searchWords.some((word) => searchText.includes(word))
+);
+
+const searchMatcherMap: Record<string, SelectRichSearchMatcher> = {
+    [SelectSearchStrategy.EXACT_AND]: exactAndMatcher,
+    [SelectSearchStrategy.EXACT_OR]: exactOrMatcher,
+};
+
+export const getSearchMatcher = (type: SelectSearchStrategy): SelectRichSearchMatcher | null => {
+    return type === SelectSearchStrategy.DEFAULT ? null : searchMatcherMap[type] || null;
+};


### PR DESCRIPTION
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC221)
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-540)

---

> kopie van https://github.com/milieuinfo/flux-web-components/pull/680 voor `develop-v1`

---
Een configureerbaar searchStrategy attribuut toegevoegd:
 - 'default': native Fuse.js (fuzzy search)
 - 'exact-and': alle woorden moeten voorkomen (AND-logica)
 - 'exact-or': minstens 1 woord moet voorkomen (OR-logica)

De implementatie gebruikt een dynamische wrapper die schakelt tussen native en custom matchers.
Hij filtert altijd op alle opties (niet incrementeel) voor correcte resultaten bij het toevoegen/verwijderen van characters.

Tests: 18 Jest unit tests + 7 Cypress e2e tests