### PR TITLE
feat: FLUX-521 - vl-upload - getRejectedFiles() toegevoegd

### DIFF
--- a/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
+++ b/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
@@ -42,6 +42,10 @@ De volgende publieke methodes zijn beschikbaar op het `VlUploadComponent`:
 
 Geeft een lijst van geaccepteerde bestanden terug.
 
+### getRejectedFiles(): DropzoneFile[]
+
+Geeft een lijst van geweigerde bestanden terug.
+
 ### addFile(file: File): void
 
 Handmatig bestand toevoegen aan de lijst van opgeladen bestanden zonder achterliggende upload

--- a/libs/components/src/form/upload/vl-upload.component.cy.ts
+++ b/libs/components/src/form/upload/vl-upload.component.cy.ts
@@ -352,6 +352,17 @@ describe('cypress-component - form components - vl-upload', () => {
         cy.get('@handleQueueComplete').should('have.been.called');
     });
 
+    it('should return rejected files via `getRejectedFiles()` public method', () => {
+        cy.mount(html` <vl-upload accepted-files="txt"></vl-upload>`);
+
+        cy.get('vl-upload').shadow().find('input[type=file]').selectFile(pdfFileFixturePath, { force: true });
+        cy.get('vl-upload').then((upload) => {
+            const rejectedFiles = (<HTMLElement & { getRejectedFiles(): File[] }>upload[0]).getRejectedFiles();
+            expect(rejectedFiles.length).to.equal(1);
+            expect(rejectedFiles[0].name).to.equal('file.pdf');
+        });
+    });
+
     it('should only allow one file by default', () => {
         const errorMessage = 'U mag maar 1 bestand tegelijk uploaden';
         cy.mount(html` <vl-upload error-message-max-files=${errorMessage}></vl-upload>`);

--- a/libs/components/src/form/upload/vl-upload.component.ts
+++ b/libs/components/src/form/upload/vl-upload.component.ts
@@ -318,6 +318,10 @@ export class VlUploadComponent extends FormControl {
         return this.dropzoneInstance?.getAcceptedFiles() || [];
     }
 
+    getRejectedFiles(): DropzoneFile[] {
+        return this.dropzoneInstance?.getRejectedFiles() || [];
+    }
+
     /**
      * Handmatig bestand toevoegen aan de lijst van opgeladen bestanden zonder achterliggende upload
      */


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-521)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC223)
