### PR TITLE
FLUX-541, FLUX-279, FLUX-552 - vl-side-navigation-next verbeteringen

### DIFF
--- a/apps/playground-react/src/app/app.tsx
+++ b/apps/playground-react/src/app/app.tsx
@@ -35,6 +35,12 @@ export const VlTitle = createComponent({
     react: React,
 });
 
+export const VlSideNavigationLayout = createComponent({
+    tagName: 'vl-side-navigation-layout-next',
+    elementClass: VlSideNavigationLayoutComponent,
+    react: React,
+});
+
 const sideNavContent = (
     <div slot="content">
         <div id="side-nav-example-content">
@@ -53,7 +59,7 @@ const sideNavContent = (
                     Usage
                 </VlTitle>
                 <p>
-                    Use <code>vl-side-navigation-layout</code> to combine the grid layout with an automatic side
+                    Use <code>vl-side-navigation-layout-next</code> to combine the grid layout with an automatic side
                     navigation. Put your main content in a div with <code>slot="content"</code> and give the content
                     root an id that you pass as <code>heading-root-selector</code>. Use <code>vl-title</code> or native
                     h2/h3 with <code>id</code> attributes for each section.
@@ -146,13 +152,13 @@ const sideNavContent = (
 export function App() {
     return (
         <main style={{ padding: 0 }}>
-            <vl-side-navigation-layout
-                content-block
-                heading-root-selector="#side-nav-example-content"
-                navigation-title="On this page"
+            <VlSideNavigationLayout
+                contentBlock
+                headingRootSelector="#side-nav-example-content"
+                navigationTitle="On this page"
             >
                 {sideNavContent}
-            </vl-side-navigation-layout>
+            </VlSideNavigationLayout>
         </main>
     );
 }
@@ -183,7 +189,7 @@ declare global {
                 open: boolean;
                 'custom-css': string;
             };
-            'vl-side-navigation-layout': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+            'vl-side-navigation-layout-next': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
                 'content-block'?: boolean;
                 'heading-root-selector'?: string;
                 'navigation-title'?: string;

--- a/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-layout.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-layout.stories.cy.ts
@@ -5,25 +5,25 @@ const sideNavigationLayoutCustomTocUrl =
 const sideNavigationLayoutWithStepsUrl =
     'http://localhost:8080/iframe.html?id=components-block-next-side-navigation-layout--side-navigation-layout-with-steps&viewMode=story';
 
-describe('cypress-e2e - block components - vl-side-navigation-layout - default story', () => {
+describe('cypress-e2e - block components - vl-side-navigation-layout-next - default story', () => {
     it('should render', () => {
         cy.visit(sideNavigationLayoutDefaultUrl);
 
-        cy.get('vl-side-navigation-layout').shadow().find('navigation-part');
-        cy.get('vl-side-navigation-layout').shadow().find('content-part');
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('nav');
+        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part');
+        cy.get('vl-side-navigation-layout-next').shadow().find('content-part');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
         cy.get('#default-content-1').should('contain', 'Content 1');
         cy.get('#default-content-2').should('contain', 'Content 2');
         cy.get('#default-content-3').should('contain', 'Content 3');
     });
 });
 
-describe('cypress-e2e - block components - vl-side-navigation-layout - custom toc story', () => {
+describe('cypress-e2e - block components - vl-side-navigation-layout-next - custom toc story', () => {
     it('should render', () => {
         cy.visit(sideNavigationLayoutCustomTocUrl);
 
-        cy.get('vl-side-navigation-layout').shadow().find('navigation-part');
-        cy.get('vl-side-navigation-layout').shadow().find('content-part');
+        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part');
+        cy.get('vl-side-navigation-layout-next').shadow().find('content-part');
         cy.get('vl-side-navigation-next').find('vl-link').should('have.length.greaterThan', 0);
         cy.get('#custom-intro').should('contain', 'Over deze pagina');
         cy.get('#custom-aanvraag').should('contain', 'Hoe indienen');
@@ -35,28 +35,15 @@ describe('cypress-e2e - block components - vl-side-navigation-layout - custom to
 
         cy.get('vl-side-navigation-next').find('vl-button.toggle-button').should('have.length', 2);
     });
-
-    it('should toggle nested items when clicking toggle button', () => {
-        cy.visit(sideNavigationLayoutCustomTocUrl);
-
-        // Initially all nested ul elements should be hidden (initialized by the component)
-        cy.get('vl-side-navigation-next').find('ul > li > ul').should('have.attr', 'hidden');
-
-        // Click the first toggle button to expand
-        cy.get('vl-side-navigation-next').find('vl-button.toggle-button').first().click();
-
-        // The first nested ul should now be visible
-        cy.get('vl-side-navigation-next').find('ul > li').first().find('> ul').should('not.have.attr', 'hidden');
-    });
 });
 
-describe('cypress-e2e - block components - vl-side-navigation-layout - with steps story', () => {
+describe('cypress-e2e - block components - vl-side-navigation-layout-next - with steps story', () => {
     it('should render', () => {
         cy.visit(sideNavigationLayoutWithStepsUrl);
 
-        cy.get('vl-side-navigation-layout').shadow().find('navigation-part');
-        cy.get('vl-side-navigation-layout').shadow().find('content-part');
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('nav');
+        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part');
+        cy.get('vl-side-navigation-layout-next').shadow().find('content-part');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
         cy.get('vl-steps').should('exist');
         cy.get('#vl-steps-vl-step-1').should('contain', 'Stap 1: eerste actie');
         cy.get('#vl-steps-vl-step-2').should('contain', 'Stap 2: tweede actie');

--- a/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-next.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-next.stories.cy.ts
@@ -1,9 +1,9 @@
 const sideNavigationNextDefaultUrl =
-    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation-next--side-navigation-default&viewMode=story';
+    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation--side-navigation-default&viewMode=story';
 const sideNavigationNextCompactUrl =
-    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation-next--side-navigation-compact&viewMode=story';
+    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation--side-navigation-compact&viewMode=story';
 const sideNavigationNextCustomTocUrl =
-    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation-next--side-navigation-with-custom-toc&viewMode=story';
+    'http://localhost:8080/iframe.html?id=components-block-next-side-navigation--side-navigation-with-custom-toc&viewMode=story';
 
 describe('cypress-e2e - block components - vl-side-navigation-next - default story', () => {
     it('should render', () => {

--- a/apps/storybook/.storybook/flux-meta-data/json/components-block.meta-data.json
+++ b/apps/storybook/.storybook/flux-meta-data/json/components-block.meta-data.json
@@ -486,9 +486,9 @@
             "planningInfo": "[Van v2 naar v3 - beschikbaar](/docs/planning-van-v2-naar-v3-beschikbaar--documentatie#side-navigation)"
         }
     },
-    "components-block-next-side-navigation-next": {
+    "components-block-next-side-navigation": {
         "name": "side-navigation",
-        "docs": "components-block-next-side-navigation-next--documentatie",
+        "docs": "components-block-next-side-navigation--documentatie",
         "condition": {
             "base": "LitElement",
             "generation": "v3-next",
@@ -522,7 +522,7 @@
         }, "evolution": {
             "vStatus": "v3-next",
             "legacyText": "[vl-side-navigation](/docs/components-block-side-navigation--documentatie)",
-            "nextText": "vl-side-navigation-layout",
+            "nextText": "vl-side-navigation-layout-next",
             "planningInfo": "[Van v2 naar v3 - beschikbaar](/docs/planning-van-v2-naar-v3-beschikbaar--documentatie#side-navigation)"
         }
     },

--- a/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
+++ b/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
@@ -142,8 +142,8 @@ Deze component is niet compatibel met de oude [Side Navigation [legacy]](/docs/c
         <td>[Side Navigation Layout](/docs/components-next-side-navigation-side-navigation-layout--documentatie)</td>
         <td>release v2.9.0</td>
         <td>components/block/next</td>
-        <td><code>{`<vl-side-navigation-layout>`}</code></td>
+        <td><code>{`<vl-side-navigation-layout-next>`}</code></td>
         <td>components/block</td>
-        <td><code>{`<vl-side-navigation-layout>`}</code></td>
+        <td><code>{`<vl-side-navigation-layout-next>`}</code></td>
     </tr>
 </table>

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.mdx
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.mdx
@@ -1,0 +1,24 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as sideNavigationLayoutWithProzaMessageStories from './side-navigation-layout-with-proza-message.stories';
+
+<Meta of={sideNavigationLayoutWithProzaMessageStories} />
+
+# Side Navigation Layout Met Proza Message
+
+In dit voorbeeld wordt `vl-side-navigation-layout` gecombineerd met `vl-proza-message`. De titels in de content worden
+gevuld via Proza berichten en verschijnen zo ook in de side navigation.
+
+Dit voorbeeld toont ook:
+
+- titels gevuld via `vl-proza-message` binnen `vl-title`
+- automatische side navigation op basis van de standaard headingniveaus
+
+## Componenten
+
+- [vl-side-navigation-layout](/docs/components-block-next-side-navigation-layout--documentatie)
+- [vl-proza-message](/docs/components-block-proza-message--documentatie)
+- [vl-proza-message-preloader](/docs/components-block-proza-message-proza-message-preloader--documentatie)
+
+## Demo
+
+<Canvas of={sideNavigationLayoutWithProzaMessageStories.LayoutMetProzaMessage} sourceState="shown" />

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.mdx
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.mdx
@@ -5,7 +5,7 @@ import * as sideNavigationLayoutWithProzaMessageStories from './side-navigation-
 
 # Side Navigation Layout Met Proza Message
 
-In dit voorbeeld wordt `vl-side-navigation-layout` gecombineerd met `vl-proza-message`. De titels in de content worden
+In dit voorbeeld wordt `vl-side-navigation-layout-next` gecombineerd met `vl-proza-message`. De titels in de content worden
 gevuld via Proza berichten en verschijnen zo ook in de side navigation.
 
 Dit voorbeeld toont ook:
@@ -15,7 +15,7 @@ Dit voorbeeld toont ook:
 
 ## Componenten
 
-- [vl-side-navigation-layout](/docs/components-block-next-side-navigation-layout--documentatie)
+- [vl-side-navigation-layout-next](/docs/components-block-next-side-navigation-layout--documentatie)
 - [vl-proza-message](/docs/components-block-proza-message--documentatie)
 - [vl-proza-message-preloader](/docs/components-block-proza-message-proza-message-preloader--documentatie)
 

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.stories.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.stories.ts
@@ -1,0 +1,213 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { VlTitleComponent } from '@domg-wc/components/atom';
+import { VlProzaMessage, VlProzaMessagePreloader } from '@domg-wc/components/block';
+import { VlSideNavigationLayoutComponent } from '@domg-wc/components/block/next';
+import { Meta } from '@storybook/web-components-vite';
+import { html } from 'lit-html';
+
+registerWebComponents([
+    VlSideNavigationLayoutComponent,
+    VlProzaMessagePreloader,
+    VlProzaMessage,
+    VlTitleComponent,
+]);
+
+const prozaDomain = 'side-navigation-layout-proza-message';
+
+const sideNavigationLayoutWithProzaMessageHTML = html`
+    <section class="vl-section">
+        <div class="vl-content-block vl-content-block--full-width">
+            <vl-proza-message-preloader domain="side-navigation-layout-proza-message"></vl-proza-message-preloader>
+            <vl-side-navigation-layout
+                content-block
+                heading-root-selector="#side-navigation-layout-content"
+            >
+                <div slot="content" id="side-navigation-layout-content">
+                    <vl-title type="h1" id="side-navigation-main-title">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="page-title"
+                        ></vl-proza-message>
+                    </vl-title>
+
+                    <vl-title type="h2" id="section-1">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-1-title"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent sed libero ac nibh dictum
+                        viverra. Donec a arcu non lorem viverra vestibulum.
+                    </p>
+                    <p>
+                        Mauris commodo, dolor sit amet faucibus accumsan, dui nisl suscipit mi, sed vulputate risus ante
+                        vitae velit. Donec feugiat fermentum nibh.
+                    </p>
+
+                    <vl-title type="h3" id="section-1-sub-1">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-1-sub-1"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Integer malesuada lorem vitae lorem volutpat, ut feugiat risus pulvinar. Curabitur mattis elit
+                        sit amet turpis vestibulum, non vulputate nisi maximus.
+                    </p>
+                    <p>
+                        Vivamus lacinia sem vel dui ultrices, a porttitor erat vulputate. Curabitur viverra facilisis
+                        ligula, in sodales eros varius sit amet.
+                    </p>
+
+                    <vl-title type="h3" id="section-1-sub-2">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-1-sub-2"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Nulla facilisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+                        curae; Aenean feugiat convallis lorem.
+                    </p>
+                    <p>
+                        Nunc consequat, magna non luctus congue, leo sem porta mauris, ut varius elit massa sed libero.
+                        Quisque luctus erat a massa pretium ullamcorper.
+                    </p>
+
+                    <vl-title type="h3" id="section-1-sub-3">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-1-sub-3"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Sed ac vulputate neque. Quisque at augue non augue pulvinar porttitor. Fusce suscipit ipsum mi,
+                        et aliquet magna sodales id.
+                    </p>
+
+                    <vl-title type="h2" id="section-2">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-2-title"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Donec et erat vel est sodales viverra. Duis et justo sed neque convallis commodo. In in augue
+                        non massa laoreet placerat.
+                    </p>
+                    <p>
+                        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+                        Integer consequat porttitor mauris, vitae congue elit elementum vel.
+                    </p>
+
+                    <vl-title type="h3" id="section-2-sub-1">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-2-sub-1"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Phasellus in elit neque. Etiam dictum, velit et ultrices molestie, enim ligula varius nisi, id
+                        ullamcorper leo purus eget dolor.
+                    </p>
+
+                    <vl-title type="h3" id="section-2-sub-2">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-2-sub-2"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Morbi tincidunt lorem ut erat iaculis, vitae vestibulum lorem semper. Donec non lorem quis
+                        libero posuere egestas in non justo.
+                    </p>
+
+                    <vl-title type="h3" id="section-2-sub-3">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-2-sub-3"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Cras lacinia tortor augue, in feugiat justo condimentum in. Aenean malesuada lorem at nisl
+                        feugiat, vitae semper arcu mattis.
+                    </p>
+
+                    <vl-title type="h2" id="section-3">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-3-title"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Curabitur non malesuada purus. Nulla molestie, massa in varius luctus, purus orci commodo urna,
+                        vitae faucibus nisl velit ac lectus.
+                    </p>
+                    <vl-title type="h3" id="section-3-sub-1">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-3-sub-1"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        In de side navigation zie je automatisch de standaard headingniveaus van de layout op basis van
+                        deze contentstructuur.
+                    </p>
+                    <vl-title type="h3" id="section-3-sub-2">
+                        <vl-proza-message
+                            domain="side-navigation-layout-proza-message"
+                            code="section-3-sub-2"
+                        ></vl-proza-message>
+                    </vl-title>
+                    <p>
+                        Alle sectietitels in dit voorbeeld worden via Proza geladen, zodat dezelfde content zowel in de
+                        pagina als in de side navigation consistent blijft.
+                    </p>
+                </div>
+            </vl-side-navigation-layout>
+        </div>
+    </section>
+`;
+
+const preloadProzaMessages = () => {
+    VlProzaMessagePreloader.__setPreloadedMessagesCacheForDomain(
+        prozaDomain,
+        Promise.resolve({
+            'page-title': 'Side navigation layout met proza message',
+            'section-1-title': 'Ontwerpprincipes',
+            'section-1-sub-1': 'Consistente headings',
+            'section-1-sub-2': 'Scanbare content',
+            'section-1-sub-3': 'Toegankelijkheid',
+            'section-2-title': 'Implementatie',
+            'section-2-sub-1': 'Preloaden van berichten',
+            'section-2-sub-2': 'Vullen van titels',
+            'section-2-sub-3': 'Validatie',
+            'section-3-title': 'Resultaat',
+            'section-3-sub-1': 'Wat je in de side navigation ziet',
+            'section-3-sub-2': 'Samenvatting',
+        })
+    );
+    VlProzaMessage.__setToegelatenOperatiesCacheForDomain(prozaDomain, Promise.resolve({ update: false }));
+};
+
+export default {
+    title: 'Ontwerp/Side Navigation/Layout Met Proza Message',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            story: {
+                inline: false,
+                iframeHeight: 860,
+            },
+        },
+    },
+} as Meta;
+
+export const LayoutMetProzaMessage = () => {
+    preloadProzaMessages();
+
+    return sideNavigationLayoutWithProzaMessageHTML;
+};
+
+LayoutMetProzaMessage.storyName = 'vl-side-navigation-layout - met proza message';

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.stories.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_layout-with-proza-message/side-navigation-layout-with-proza-message.stories.ts
@@ -18,7 +18,7 @@ const sideNavigationLayoutWithProzaMessageHTML = html`
     <section class="vl-section">
         <div class="vl-content-block vl-content-block--full-width">
             <vl-proza-message-preloader domain="side-navigation-layout-proza-message"></vl-proza-message-preloader>
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 content-block
                 heading-root-selector="#side-navigation-layout-content"
             >
@@ -165,7 +165,7 @@ const sideNavigationLayoutWithProzaMessageHTML = html`
                         pagina als in de side navigation consistent blijft.
                     </p>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         </div>
     </section>
 `;
@@ -192,7 +192,7 @@ const preloadProzaMessages = () => {
 };
 
 export default {
-    title: 'Ontwerp/Side Navigation/Layout Met Proza Message',
+    title: 'Patronen/Pagina Opbouw/Side Navigation Met Proza Message',
     parameters: {
         layout: 'fullscreen',
         docs: {
@@ -210,4 +210,4 @@ export const LayoutMetProzaMessage = () => {
     return sideNavigationLayoutWithProzaMessageHTML;
 };
 
-LayoutMetProzaMessage.storyName = 'vl-side-navigation-layout - met proza message';
+LayoutMetProzaMessage.storyName = 'vl-side-navigation-layout-next - met proza message';

--- a/libs/components/src/block/block.web-types.json
+++ b/libs/components/src/block/block.web-types.json
@@ -1213,7 +1213,7 @@
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-next-side-navigation-next--documentatie"
                 },
                 {
-                    "name": "vl-side-navigation-layout",
+                    "name": "vl-side-navigation-layout-next",
                     "description": "<span style=\"color: rgb(25,140,25)\">[next-component]</span><br/>De side navigation layout bouwt automatisch een inhoudstafel op voor een gestructureerde tekst met behulp van de\n[side navigation](/docs/components-next-side-navigation-side-navigation--documentatie).",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-next-side-navigation-layout--documentatie",
                     "attributes": [

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-doc.mdx
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-doc.mdx
@@ -18,11 +18,11 @@ import { VlSideNavigationLayoutComponent } from '@domg-wc/components/block/next'
 ```
 
 ```html
-<vl-side-navigation-layout>
+<vl-side-navigation-layout-next>
     <div slot="content">
         <!-- Je content met headings en bijhorende id's-->
     </div>
-</vl-side-navigation-layout>
+</vl-side-navigation-layout-next>
 ```
 
 ## Gebruik

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
@@ -50,7 +50,7 @@ export const SideNavigationLayoutDefault = story(
     sideNavigationLayoutArgs,
     ({ compact, contentBlock, navigationTitle, excludeSelectors }) => {
         return html`
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
                 heading-root-selector="#story-default-content"
@@ -93,17 +93,17 @@ export const SideNavigationLayoutDefault = story(
                         </section>
                     </div>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `;
     }
 );
-SideNavigationLayoutDefault.storyName = 'vl-side-navigation-layout - default';
+SideNavigationLayoutDefault.storyName = 'vl-side-navigation-layout-next - default';
 
 export const SideNavigationLayoutWithSteps = story(
     sideNavigationLayoutArgs,
     ({ compact, contentBlock, maxDepth, excludeSelectors }) => {
         return html`
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
                 max-depth=${maxDepth}
@@ -165,11 +165,11 @@ export const SideNavigationLayoutWithSteps = story(
                         </vl-step>
                     </vl-steps>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `;
     }
 );
-SideNavigationLayoutWithSteps.storyName = 'vl-side-navigation-layout - met steps';
+SideNavigationLayoutWithSteps.storyName = 'vl-side-navigation-layout-next - met steps';
 SideNavigationLayoutWithSteps.parameters = {
     docs: {
         story: {
@@ -183,7 +183,7 @@ export const SideNavigationLayoutTwoLayouts = story(
     sideNavigationLayoutArgs,
     ({ compact, contentBlock, excludeSelectors }) => {
         return html`
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
                 heading-root-selector="#content-subsidies"
@@ -251,9 +251,9 @@ export const SideNavigationLayoutTwoLayouts = story(
                         </section>
                     </div>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
             <hr class="vl-separator-slash vl-padding--medium vl-margin--medium" />
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
                 heading-root-selector="#content-diensten"
@@ -318,11 +318,11 @@ export const SideNavigationLayoutTwoLayouts = story(
                         </section>
                     </div>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `;
     }
 );
-SideNavigationLayoutTwoLayouts.storyName = 'vl-side-navigation-layout - twee layouts met eigen content';
+SideNavigationLayoutTwoLayouts.storyName = 'vl-side-navigation-layout-next - twee layouts met eigen content';
 SideNavigationLayoutTwoLayouts.parameters = {
     docs: {
         story: {
@@ -336,7 +336,7 @@ export const SideNavigationLayoutWithCustomToc = story(
     sideNavigationLayoutArgs,
     ({ compact, contentBlock, excludeSelectors }) => {
         return html`
-            <vl-side-navigation-layout
+            <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
                 heading-root-selector="#story-custom-toc-content"
@@ -420,8 +420,8 @@ export const SideNavigationLayoutWithCustomToc = story(
                         </section>
                     </div>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `;
     }
 );
-SideNavigationLayoutWithCustomToc.storyName = 'vl-side-navigation-layout - custom table of contents';
+SideNavigationLayoutWithCustomToc.storyName = 'vl-side-navigation-layout-next - custom table of contents';

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
@@ -383,7 +383,9 @@ export const SideNavigationLayoutWithCustomToc = story(
                             </ul>
                         </li>
                         <li>
-                            <vl-link href="#custom-termijnen">3. Termijnen</vl-link>
+                            <div class="nav-item-wrapper">
+                                <vl-link href="#custom-termijnen">3. Termijnen</vl-link>
+                            </div>
                         </li>
                     </ul>
                 </vl-side-navigation-next>

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-doc.mdx
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-doc.mdx
@@ -3,7 +3,7 @@ import * as SideNavigationStories from './vl-side-navigation.stories';
 
 # Side Navigation Next
 
-<FluxComponentMetaData id="components-block-next-side-navigation-next"/>
+<FluxComponentMetaData id="components-block-next-side-navigation"/>
 
 ## Doel
 

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories.ts
@@ -12,8 +12,8 @@ import sideNavigationDoc from './vl-side-navigation.stories-doc.mdx';
 import { toggleCustomTocChildren } from '../vl-side-navigation-custom-toc.utils';
 
 export default {
-    id: 'components-block-next-side-navigation-next',
-    title: 'Components - Block/next/side-navigation-next',
+    id: 'components-block-next-side-navigation',
+    title: 'Components - Block/next/side-navigation',
     tags: ['autodocs'],
     args: sideNavigationArgs,
     argTypes: sideNavigationArgTypes,

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
@@ -223,10 +223,7 @@ function getSectionLinkForUl(ul: Element): Element | null {
  * @param slottedElements - Elements assigned to the TOC slot (e.g. <ul>, fragment children)
  * @param activeHeadingId - ID of the heading currently considered active (e.g. from IntersectionObserver)
  */
-export function applyExpandCollapseToCustomToc(
-    slottedElements: Element[],
-    activeHeadingId: string
-): void {
+export function applyExpandCollapseToCustomToc(slottedElements: Element[], activeHeadingId: string): void {
     const activeLink = findLinkByHeadingId(slottedElements, activeHeadingId);
     const pathUls = activeLink ? getAncestorUlsForLink(activeLink) : new Set<HTMLUListElement>();
 
@@ -242,7 +239,7 @@ export function applyExpandCollapseToCustomToc(
     for (const root of slottedElements) {
         const nestedUls = root.querySelectorAll('li > ul');
         nestedUls.forEach((ul) => {
-            // keep sections visible if they are on the active path OR currently contain focus
+            // keep sections visible if on the active path or currently contain focus
             const isOnActivePath = pathUls.has(ul as HTMLUListElement);
             const containsFocusedElement =
                 typeof document !== 'undefined' && document.activeElement
@@ -253,11 +250,6 @@ export function applyExpandCollapseToCustomToc(
                 ul.removeAttribute('hidden');
             } else {
                 ul.setAttribute('hidden', '');
-            }
-
-            const sectionLink = getSectionLinkForUl(ul);
-            if (sectionLink) {
-                sectionLink.setAttribute('aria-expanded', String(shouldShow));
             }
 
             const li = ul.parentElement;

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
@@ -89,7 +89,7 @@ registerWebComponents([
 
 const mountSideNavigationLayout = () => {
     return cy.mount(html`
-        <vl-side-navigation-layout>
+        <vl-side-navigation-layout-next>
             <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
             <div slot="content" style="min-height: 2000px;">
                 <section id="content-1" style="margin-top: 100px; min-height: 400px;">
@@ -121,13 +121,13 @@ const mountSideNavigationLayout = () => {
                     </p>
                 </section>
             </div>
-        </vl-side-navigation-layout>
+        </vl-side-navigation-layout-next>
     `);
 };
 
 const mountSideNavigationLayoutOnlyContent = () => {
     return cy.mount(html`
-        <vl-side-navigation-layout>
+        <vl-side-navigation-layout-next>
             <div slot="content" style="min-height: 2000px;">
                 <section id="content-1" style="margin-top: 100px; min-height: 400px;">
                     <vl-title type="h2" id="content-1-heading">Content 1</vl-title>
@@ -158,13 +158,13 @@ const mountSideNavigationLayoutOnlyContent = () => {
                     </p>
                 </section>
             </div>
-        </vl-side-navigation-layout>
+        </vl-side-navigation-layout-next>
     `);
 };
 
 const mountSideNavigationLayoutWithCustomToc = () => {
     return cy.mount(html`
-        <vl-side-navigation-layout heading-root-selector="#custom-toc-content">
+        <vl-side-navigation-layout-next heading-root-selector="#custom-toc-content">
             <vl-side-navigation-next slot="navigation">
                 <ul style="list-style: none; padding: 0; margin: 0;">
                     <li style="margin-bottom: 8px;">
@@ -259,31 +259,31 @@ const mountSideNavigationLayoutWithCustomToc = () => {
                     </section>
                 </div>
             </div>
-        </vl-side-navigation-layout>
+        </vl-side-navigation-layout-next>
     `);
 };
 
 const getSideNavigation = (isAutoNav: boolean) => {
     return isAutoNav
-        ? cy.get('vl-side-navigation-layout').shadow().find('vl-side-navigation-next')
-        : cy.get('vl-side-navigation-layout').find('vl-side-navigation-next');
+        ? cy.get('vl-side-navigation-layout-next').shadow().find('vl-side-navigation-next')
+        : cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next');
 };
 
 const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => {
     it('should mount', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout').should('exist');
+        cy.get('vl-side-navigation-layout-next').should('exist');
     });
 
     it('should render navigation and content slots', () => {
         mountFn();
         getSideNavigation(false).should('exist');
-        cy.get('vl-side-navigation-layout').find('[slot="content"]').should('exist');
+        cy.get('vl-side-navigation-layout-next').find('[slot="content"]').should('exist');
     });
 
     it('should apply grid classes to navigation', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('navigation-part')
             .should('have.class', 'vl-column')
@@ -294,7 +294,7 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
 
     it('should apply grid classes to content', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('content-part')
             .should('have.class', 'vl-column')
@@ -302,24 +302,24 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
             .should('have.class', 'vl-column--m-9');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should apply order-1 class to navigation by default', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('navigation-part')
             .shouldHaveComputedStyle({ style: 'order', value: '1' });
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should be accessible', () => {
         mountFn();
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should have aria-controls on toggle buttons pointing to nested ul elements', () => {
@@ -434,7 +434,7 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
 
     it('should apply vl-content-block class when content-block attribute is set', () => {
         cy.mount(html`
-            <vl-side-navigation-layout content-block>
+            <vl-side-navigation-layout-next content-block>
                 <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
                 <div slot="content">
                     <section>
@@ -442,23 +442,23 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
                         <p>Test paragraph</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('layout-container')
             .should('have.class', 'vl-grid')
             .should('have.class', 'vl-content-block');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should not apply vl-content-block class when content-block attribute is not set', () => {
         mountFn();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('layout-container')
             .should('have.class', 'vl-grid')
@@ -474,13 +474,13 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
         getSideNavigation(false).shadow().find('nav a[href="#content-2-heading"].active').should('exist');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should maintain layout during scrolling', () => {
         mountFn();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .shadow()
             .find('navigation-part')
             .then(($nav) => {
@@ -489,14 +489,14 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
                 cy.get('#content-2-heading').scrollIntoView();
                 cy.wait(300);
 
-                cy.get('vl-side-navigation-layout')
+                cy.get('vl-side-navigation-layout-next')
                     .shadow()
                     .find('navigation-part')
                     .should('have.attr', 'class', initialClasses);
             });
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should support keyboard navigation through TOC items', () => {
@@ -546,17 +546,17 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
 const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => {
     it('should apply full width classes on mobile viewport', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout').shadow().find('navigation-part').should('have.class', 'vl-column--s-12');
-        cy.get('vl-side-navigation-layout').shadow().find('content-part').should('have.class', 'vl-column--s-12');
+        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part').should('have.class', 'vl-column--s-12');
+        cy.get('vl-side-navigation-layout-next').shadow().find('content-part').should('have.class', 'vl-column--s-12');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should be accessible on mobile viewport', () => {
         mountFn();
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should update navigation when scrolling on mobile viewport', () => {
@@ -570,7 +570,7 @@ const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => 
         getSideNavigation(false).shadow().find('nav a[href="#content-2-heading"].active').should('exist');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should have role="dialog" and aria-modal when in overlay mode (mobile)', () => {
@@ -646,7 +646,7 @@ const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => 
 };
 
 // explicit navigation slot tests
-describe('cypress-component - block components - vl-side-navigation-layout', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
@@ -654,7 +654,7 @@ describe('cypress-component - block components - vl-side-navigation-layout', () 
     runDesktopTests(mountSideNavigationLayout, false);
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - mobile viewport', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - mobile viewport', () => {
     beforeEach(() => {
         cy.viewport(375, 667);
     });
@@ -663,7 +663,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - mob
 });
 
 // auto-generated navigation tests
-describe('cypress-component - block components - vl-side-navigation-layout - only content (auto navigation)', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - only content (auto navigation)', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
@@ -671,7 +671,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - onl
     runDesktopTests(mountSideNavigationLayoutOnlyContent, true);
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - only content (auto navigation) - mobile viewport', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - only content (auto navigation) - mobile viewport', () => {
     beforeEach(() => {
         cy.viewport(375, 667);
     });
@@ -680,20 +680,20 @@ describe('cypress-component - block components - vl-side-navigation-layout - onl
 });
 
 // custom table of contents tests
-describe('cypress-component - block components - vl-side-navigation-layout - with custom TOC', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - with custom TOC', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
 
     it('should mount with custom TOC', () => {
         mountSideNavigationLayoutWithCustomToc();
-        cy.get('vl-side-navigation-layout').should('exist');
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').should('exist');
+        cy.get('vl-side-navigation-layout-next').should('exist');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').should('exist');
     });
 
     it('should render custom TOC with vl-link components', () => {
         mountSideNavigationLayoutWithCustomToc();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link')
             .should('have.length.greaterThan', 0);
@@ -701,15 +701,15 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
 
     it('should render custom TOC with links', () => {
         mountSideNavigationLayoutWithCustomToc();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-intro"]')
             .should('exist');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-aanvraag"]')
             .should('exist');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-termijnen"]')
             .should('exist');
@@ -718,7 +718,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should navigate when clicking custom TOC links', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-aanvraag"]')
             .click();
@@ -738,7 +738,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
         cy.get('#custom-aanvraag').scrollIntoView();
         cy.wait(500);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-aanvraag"].active')
             .should('exist');
@@ -750,7 +750,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
         cy.wait(500);
         cy.get('#custom-vereisten').scrollIntoView();
         // Wait for IntersectionObserver to update and apply expand state to parent section
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-intro"]')
             .parent('li')
@@ -760,7 +760,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
 
         cy.get('#custom-termijnen').scrollIntoView();
         // Wait for IntersectionObserver to update and collapse parent section
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link[href="#custom-intro"]')
             .parent('li')
@@ -771,19 +771,19 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should be accessible with custom TOC', () => {
         mountSideNavigationLayoutWithCustomToc();
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should have aria-labelledby on table-of-contents with custom TOC', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
             .should('have.attr', 'aria-labelledby', 'side-navigation-title');
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#side-navigation-title')
@@ -793,7 +793,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should have role="region" with custom TOC in sidebar mode', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
@@ -805,14 +805,14 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should support keyboard navigation through custom TOC items', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
 
         cy.press(Cypress.Keyboard.Keys.TAB);
-        cy.get('vl-side-navigation-layout').find('vl-link').first().shadow().find('a').should('have.focus');
+        cy.get('vl-side-navigation-layout-next').find('vl-link').first().shadow().find('a').should('have.focus');
 
         cy.press(Cypress.Keyboard.Keys.TAB);
         // Next is the child link
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-link[href="#custom-vereisten"]')
             .shadow()
             .find('a')
@@ -820,7 +820,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
 
         cy.press(Cypress.Keyboard.Keys.TAB);
         // Now the second top-level link
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-link[href="#custom-aanvraag"]')
             .shadow()
             .find('a')
@@ -830,12 +830,12 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should navigate to section when pressing Enter on custom TOC link', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
         cy.press(Cypress.Keyboard.Keys.TAB); // First link
         cy.press(Cypress.Keyboard.Keys.TAB); // Second link
         cy.press(Cypress.Keyboard.Keys.TAB); // Third link
         cy.press(Cypress.Keyboard.Keys.TAB); // Fourth link
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-link[href="#custom-termijnen"]')
             .shadow()
             .find('a')
@@ -851,14 +851,14 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     });
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - with custom TOC - mobile viewport', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - with custom TOC - mobile viewport', () => {
     beforeEach(() => {
         cy.viewport(375, 667);
     });
 
     it('should render custom TOC on mobile viewport', () => {
         mountSideNavigationLayoutWithCustomToc();
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .find('vl-link')
             .should('have.length.greaterThan', 0);
@@ -867,13 +867,13 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should be accessible on mobile viewport with custom TOC', () => {
         mountSideNavigationLayoutWithCustomToc();
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should have role="dialog" and aria-modal with custom TOC in mobile viewport', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
@@ -885,9 +885,9 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     it('should support keyboard navigation on mobile viewport with custom TOC', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').click({ force: true });
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB);
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#close-button')
@@ -896,11 +896,11 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
             .should('have.focus');
 
         cy.press(Cypress.Keyboard.Keys.TAB);
-        cy.get('vl-side-navigation-layout').find('vl-link').first().shadow().find('a').should('have.focus');
+        cy.get('vl-side-navigation-layout-next').find('vl-link').first().shadow().find('a').should('have.focus');
 
         cy.press(Cypress.Keyboard.Keys.TAB);
         // Next is the child link
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-link[href="#custom-vereisten"]')
             .shadow()
             .find('a')
@@ -908,7 +908,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
 
         cy.press(Cypress.Keyboard.Keys.TAB);
         // Now the second top-level link
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-link[href="#custom-aanvraag"]')
             .shadow()
             .find('a')
@@ -919,9 +919,9 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
         mountSideNavigationLayoutWithCustomToc();
 
         // Establish focus context, then close overlay via keyboard
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('nav').click({ force: true });
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav').click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB);
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#close-button')
@@ -929,7 +929,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
             .find('button')
             .should('have.focus');
         cy.press(Cypress.Keyboard.Keys.SPACE);
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
@@ -938,7 +938,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
         // Open overlay via keyboard
         cy.press(Cypress.Keyboard.Keys.TAB);
         cy.press(Cypress.Keyboard.Keys.TAB);
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#show-toc-button')
@@ -950,12 +950,12 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
         cy.wait(50);
 
         // Verify overlay open and ARIA
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
             .should('not.have.attr', 'hidden');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
@@ -966,55 +966,55 @@ describe('cypress-component - block components - vl-side-navigation-layout - wit
     });
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - compact attribute', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - compact attribute', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
 
     it('should force compact view when compact attribute is set', () => {
         cy.mount(html`
-            <vl-side-navigation-layout compact>
+            <vl-side-navigation-layout-next compact>
                 <div slot="content" style="min-height: 2000px;">
                     <section id="compact-test-content" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="compact-test-heading">Compact Test Content</vl-title>
                         <p>Testing compact attribute on layout component.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout').should('have.attr', 'compact');
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').should('have.attr', 'compact');
+        cy.get('vl-side-navigation-layout-next').should('have.attr', 'compact');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').should('have.attr', 'compact');
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#show-toc-button')
             .should('exist');
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 
     it('should have proper ARIA labels on navigation elements in compact mode', () => {
         cy.mount(html`
-            <vl-side-navigation-layout compact>
+            <vl-side-navigation-layout-next compact>
                 <div slot="content" style="min-height: 2000px;">
                     <section id="compact-test-content" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="compact-test-heading">Compact Test Content</vl-title>
                         <p>Testing compact attribute on layout component.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('nav')
             .should('have.attr', 'aria-label');
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#close-button')
@@ -1022,7 +1022,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - com
             .find('button')
             .should('have.attr', 'aria-label');
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('#show-toc-button')
@@ -1033,17 +1033,17 @@ describe('cypress-component - block components - vl-side-navigation-layout - com
 
     it('should have role="dialog" and aria-modal when compact attribute is set', () => {
         cy.mount(html`
-            <vl-side-navigation-layout compact>
+            <vl-side-navigation-layout-next compact>
                 <div slot="content" style="min-height: 2000px;">
                     <section id="compact-test-content" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="compact-test-heading">Compact Test Content</vl-title>
                         <p>Testing compact attribute on layout component.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('table-of-contents')
@@ -1053,28 +1053,28 @@ describe('cypress-component - block components - vl-side-navigation-layout - com
     });
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - navigation-title', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - navigation-title', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
 
     it('should pass navigation-title from layout to vl-side-navigation-next', () => {
         cy.mount(html`
-            <vl-side-navigation-layout navigation-title="Inhoud van deze pagina">
+            <vl-side-navigation-layout-next navigation-title="Inhoud van deze pagina">
                 <div slot="content" style="min-height: 2000px;">
                     <section id="toc-title-content" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="toc-title-heading">Content</vl-title>
                         <p>Testing navigation-title pass-through.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout').should('have.attr', 'navigation-title', 'Inhoud van deze pagina');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next').should('have.attr', 'navigation-title', 'Inhoud van deze pagina');
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .should('have.attr', 'navigation-title', 'Inhoud van deze pagina');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('.navigation-title')
@@ -1082,14 +1082,14 @@ describe('cypress-component - block components - vl-side-navigation-layout - nav
     });
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - max-depth', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - max-depth', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
 
     it('should work with max-depth attribute', () => {
         cy.mount(html`
-            <vl-side-navigation-layout max-depth="1">
+            <vl-side-navigation-layout-next max-depth="1">
                 <div slot="content" style="min-height: 2000px;">
                     <section id="content-1" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="content-1-heading">Content 1</vl-title>
@@ -1100,16 +1100,16 @@ describe('cypress-component - block components - vl-side-navigation-layout - max
                         <p>Lorem ipsum dolor sit amet.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout').should('have.attr', 'max-depth', '1');
-        cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').should('have.attr', 'max-depth', '1');
+        cy.get('vl-side-navigation-layout-next').should('have.attr', 'max-depth', '1');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').should('have.attr', 'max-depth', '1');
     });
 
     it('should find headings with max-depth set to 0', () => {
         cy.mount(html`
-            <vl-side-navigation-layout max-depth="0">
+            <vl-side-navigation-layout-next max-depth="0">
                 <div slot="content" style="min-height: 2000px;">
                     <section id="content-1" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="content-1-heading">Content 1</vl-title>
@@ -1120,15 +1120,15 @@ describe('cypress-component - block components - vl-side-navigation-layout - max
                         <p>Lorem ipsum dolor sit amet.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('nav a[href="#content-1-heading"]')
             .should('exist');
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('nav a[href="#content-2-heading"]')
@@ -1137,7 +1137,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - max
 
     it('should be accessible with max-depth', () => {
         cy.mount(html`
-            <vl-side-navigation-layout max-depth="2">
+            <vl-side-navigation-layout-next max-depth="2">
                 <div slot="content" style="min-height: 2000px;">
                     <section id="content-1" style="margin-top: 100px; min-height: 400px;">
                         <vl-title type="h2" id="content-1-heading">Content 1</vl-title>
@@ -1148,22 +1148,22 @@ describe('cypress-component - block components - vl-side-navigation-layout - max
                         <p>Lorem ipsum dolor sit amet.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
         cy.injectAxe();
-        cy.checkA11y('vl-side-navigation-layout');
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 });
 
-describe('cypress-component - block components - vl-side-navigation-layout - slotted content with light-DOM-only custom element', () => {
+describe('cypress-component - block components - vl-side-navigation-layout-next - slotted content with light-DOM-only custom element', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
     });
 
     it('should pick up headings inside light-DOM-only custom element and keep TOC in document order', () => {
         cy.mount(html`
-            <vl-side-navigation-layout content-block>
+            <vl-side-navigation-layout-next content-block>
                 <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
                 <div slot="content" style="min-height: 2000px;">
                     <section style="margin-top: 100px; min-height: 200px;">
@@ -1176,13 +1176,13 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
                         <p>Content that appears last in the page.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
         // Wait for slot assignment and deferred TOC scan (requestAnimationFrame)
         cy.wait(150);
 
-        const nav = () => cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         // Heading inside light-DOM-only custom element must appear in TOC
         nav().find('a[href="#details-vaststelling"]').should('exist').and('contain', 'Details vaststelling');
@@ -1213,7 +1213,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
      */
     it('should maintain document order when headings are found through shadow DOM, nested light DOM, and direct slotted content', () => {
         cy.mount(html`
-            <vl-side-navigation-layout content-block>
+            <vl-side-navigation-layout-next content-block>
                 <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
                 <div slot="content" style="min-height: 2000px;">
                     <!-- Section 1: Shadow DOM component with h2 heading -->
@@ -1231,13 +1231,13 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
                         <p>Content that appears last in the page.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
         // Wait for slot assignment and deferred TOC scan
         cy.wait(150);
 
-        const nav = () => cy.get('vl-side-navigation-layout').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         // All headings must appear in TOC
         nav().find('a[href="#laatste-vaststelling"]').should('exist').and('contain', 'Laatste vaststelling');
@@ -1276,7 +1276,7 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
 
     it('should resolve heading text from nested shadow DOM content inside vl-title', () => {
         cy.mount(html`
-            <vl-side-navigation-layout content-block>
+            <vl-side-navigation-layout-next content-block>
                 <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
                 <div slot="content" style="min-height: 1200px;">
                     <section style="margin-top: 100px; min-height: 300px;">
@@ -1286,12 +1286,12 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
                         <p>Content under a heading with shadow-rendered text.</p>
                     </section>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         `);
 
         cy.wait(150);
 
-        cy.get('vl-side-navigation-layout')
+        cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .shadow()
             .find('nav a[href="#shadow-heading"]')

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
@@ -5,6 +5,7 @@ import { VlButtonComponent } from '../../../atom/button';
 import { VlIconComponent } from '../../../atom/icon';
 import { VlLinkComponent } from '../../../atom/link';
 import { VlTitleComponent } from '../../../atom/title';
+import { VlProzaMessage, VlProzaMessagePreloader } from '../../proza-message';
 import { VlSideNavigationLayoutComponent } from './vl-side-navigation-layout.component';
 import { VlSideNavigationComponent } from './vl-side-navigation.component';
 
@@ -64,6 +65,17 @@ class TocTestNestedLightDomWrapper extends LitElement {
     }
 }
 
+/**
+ * Shadow DOM custom element that renders text without any light DOM text nodes.
+ * Used to verify TOC labels can resolve text rendered in nested shadow roots.
+ */
+@customElement('toc-test-shadow-text')
+class TocTestShadowText extends LitElement {
+    render() {
+        return html`<span>Tekst uit shadow root</span>`;
+    }
+}
+
 registerWebComponents([
     VlSideNavigationLayoutComponent,
     VlSideNavigationComponent,
@@ -71,6 +83,8 @@ registerWebComponents([
     VlLinkComponent,
     VlButtonComponent,
     VlIconComponent,
+    VlProzaMessagePreloader,
+    VlProzaMessage,
 ]);
 
 const mountSideNavigationLayout = () => {
@@ -1258,5 +1272,193 @@ describe('cypress-component - block components - vl-side-navigation-layout - slo
             .find('ul a[href="#details-vaststelling"]')
             .should('exist')
             .and('contain', 'Details vaststelling');
+    });
+
+    it('should resolve heading text from nested shadow DOM content inside vl-title', () => {
+        cy.mount(html`
+            <vl-side-navigation-layout content-block>
+                <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
+                <div slot="content" style="min-height: 1200px;">
+                    <section style="margin-top: 100px; min-height: 300px;">
+                        <vl-title type="h2" id="shadow-heading">
+                            <toc-test-shadow-text></toc-test-shadow-text>
+                        </vl-title>
+                        <p>Content under a heading with shadow-rendered text.</p>
+                    </section>
+                </div>
+            </vl-side-navigation-layout>
+        `);
+
+        cy.wait(150);
+
+        cy.get('vl-side-navigation-layout')
+            .find('vl-side-navigation-next')
+            .shadow()
+            .find('nav a[href="#shadow-heading"]')
+            .should('exist')
+            .and('contain', 'Tekst uit shadow root');
+    });
+});
+
+const prozaDomain = 'side-navigation-layout-proza-message-test';
+
+const preloadProzaMessages = () => {
+    VlProzaMessagePreloader.__setPreloadedMessagesCacheForDomain(
+        prozaDomain,
+        Promise.resolve({
+            'page-title': 'Side navigation met proza message',
+            'section-1-title': 'Ontwerpprincipes',
+            'section-1-sub-1': 'Consistente headings',
+            'section-1-sub-2': 'Scanbare content',
+            'section-2-title': 'Implementatie',
+            'section-2-sub-1': 'Preloaden van berichten',
+            'section-3-title': 'Resultaat',
+        })
+    );
+    VlProzaMessage.__setToegelatenOperatiesCacheForDomain(prozaDomain, Promise.resolve({ update: false }));
+};
+
+const mountSideNavigationLayoutWithProzaMessage = () => {
+    preloadProzaMessages();
+
+    return cy.mount(html`
+        <vl-proza-message-preloader domain="${prozaDomain}"></vl-proza-message-preloader>
+        <vl-side-navigation-layout-next content-block heading-root-selector="#proza-content">
+            <div slot="content" id="proza-content" style="min-height: 2000px;">
+                <vl-title type="h1" id="proza-main-title">
+                    <vl-proza-message domain="${prozaDomain}" code="page-title"></vl-proza-message>
+                </vl-title>
+
+                <vl-title type="h2" id="proza-section-1">
+                    <vl-proza-message domain="${prozaDomain}" code="section-1-title"></vl-proza-message>
+                </vl-title>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+                <vl-title type="h3" id="proza-section-1-sub-1">
+                    <vl-proza-message domain="${prozaDomain}" code="section-1-sub-1"></vl-proza-message>
+                </vl-title>
+                <p>Integer malesuada lorem vitae lorem volutpat.</p>
+
+                <vl-title type="h3" id="proza-section-1-sub-2">
+                    <vl-proza-message domain="${prozaDomain}" code="section-1-sub-2"></vl-proza-message>
+                </vl-title>
+                <p>Nulla facilisi. Vestibulum ante ipsum primis in faucibus.</p>
+
+                <vl-title type="h2" id="proza-section-2">
+                    <vl-proza-message domain="${prozaDomain}" code="section-2-title"></vl-proza-message>
+                </vl-title>
+                <p>Donec et erat vel est sodales viverra.</p>
+
+                <vl-title type="h3" id="proza-section-2-sub-1">
+                    <vl-proza-message domain="${prozaDomain}" code="section-2-sub-1"></vl-proza-message>
+                </vl-title>
+                <p>Phasellus in elit neque.</p>
+
+                <vl-title type="h2" id="proza-section-3">
+                    <vl-proza-message domain="${prozaDomain}" code="section-3-title"></vl-proza-message>
+                </vl-title>
+                <p>Curabitur non malesuada purus.</p>
+            </div>
+        </vl-side-navigation-layout-next>
+    `);
+};
+
+describe('cypress-component - block components - vl-side-navigation-layout-next - with proza message', () => {
+    beforeEach(() => {
+        cy.viewport(1440, 900);
+    });
+
+    afterEach(() => {
+        VlProzaMessagePreloader.clearCache();
+        VlProzaMessage.clearCache();
+    });
+
+    it('should mount with proza message headings', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+        cy.get('vl-side-navigation-layout-next').should('exist');
+    });
+
+    it('should resolve proza message text in the auto-generated TOC', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+
+        cy.wait(300);
+
+        const nav = () =>
+            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+
+        nav().find('a[href="#proza-section-1"]').should('exist').and('contain', 'Ontwerpprincipes');
+        nav().find('a[href="#proza-section-2"]').should('exist').and('contain', 'Implementatie');
+        nav().find('a[href="#proza-section-3"]').should('exist').and('contain', 'Resultaat');
+    });
+
+    it('should resolve proza message text for nested h3 headings in the TOC', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+
+        cy.wait(300);
+
+        const nav = () =>
+            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+
+        nav().find('a[href="#proza-section-1-sub-1"]').should('exist').and('contain', 'Consistente headings');
+        nav().find('a[href="#proza-section-1-sub-2"]').should('exist').and('contain', 'Scanbare content');
+        nav().find('a[href="#proza-section-2-sub-1"]').should('exist').and('contain', 'Preloaden van berichten');
+    });
+
+    it('should maintain correct TOC hierarchy with proza message headings', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+
+        cy.wait(300);
+
+        const nav = () =>
+            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+
+        // Verify first top-level section exists
+        nav().find('a[href="#proza-section-1"]').should('exist').and('contain', 'Ontwerpprincipes');
+
+        // Verify nested items under first section
+        nav()
+            .find('ul > li')
+            .first()
+            .find('ul a[href="#proza-section-1-sub-1"]')
+            .should('exist')
+            .and('contain', 'Consistente headings');
+
+        nav()
+            .find('ul > li')
+            .first()
+            .find('ul a[href="#proza-section-1-sub-2"]')
+            .should('exist')
+            .and('contain', 'Scanbare content');
+
+        // Verify last top-level section exists
+        nav().find('a[href="#proza-section-3"]').should('exist').and('contain', 'Resultaat');
+    });
+
+    it('should navigate to proza message section when clicking TOC link', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+
+        cy.wait(300);
+
+        cy.get('vl-side-navigation-layout-next')
+            .find('vl-side-navigation-next')
+            .shadow()
+            .find('nav a[href="#proza-section-2"]')
+            .click();
+
+        cy.wait(600);
+
+        cy.get('#proza-section-2').then(($el) => {
+            const rect = $el[0].getBoundingClientRect();
+            expect(rect.top).to.be.lessThan(900);
+        });
+    });
+
+    it('should be accessible with proza message headings', () => {
+        mountSideNavigationLayoutWithProzaMessage();
+
+        cy.wait(300);
+
+        cy.injectAxe();
+        cy.checkA11y('vl-side-navigation-layout-next');
     });
 });

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
@@ -401,8 +401,8 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
 
         // Mock prefers-reduced-motion: reduce
         cy.window().then((win) => {
-            const originalMatchMedia = win.matchMedia;
-            win.matchMedia = (query: string) => {
+            const originalMatchMedia = win.matchMedia.bind(win);
+            cy.stub(win, 'matchMedia').callsFake((query: string) => {
                 if (query === '(prefers-reduced-motion: reduce)') {
                     return {
                         matches: true,
@@ -415,8 +415,8 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
                         dispatchEvent: () => true,
                     } as MediaQueryList;
                 }
-                return originalMatchMedia.call(win, query);
-            };
+                return originalMatchMedia(query);
+            });
         });
 
         // Click a link and verify scroll behavior
@@ -636,6 +636,9 @@ const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => 
         mountFn();
         // TODO: onderstaande functionaliteit werkt ook met Enter (in de browser) maar niet binnen Cypress testen - te onderzoeken
         getSideNavigation(false).shadow().find('table-of-contents').should('not.have.attr', 'hidden');
+        
+        // Establish focus context, then close overlay via keyboard
+        getSideNavigation(false).shadow().find('nav').click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB);
         cy.press(Cypress.Keyboard.Keys.SPACE);
         getSideNavigation(false).shadow().find('table-of-contents').should('have.attr', 'hidden');

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
@@ -15,7 +15,7 @@ registerWebComponents([VlSideNavigationComponent]);
  *
  * Uses light DOM rendering to ensure VL grid classes work properly.
  */
-@webComponent('vl-side-navigation-layout')
+@webComponent('vl-side-navigation-layout-next')
 export class VlSideNavigationLayoutComponent extends BaseLitElement {
     @property({ type: Boolean, attribute: 'compact' })
     compact = false;
@@ -273,6 +273,6 @@ export class VlSideNavigationLayoutComponent extends BaseLitElement {
 
 declare global {
     interface HTMLElementTagNameMap {
-        'vl-side-navigation-layout': VlSideNavigationLayoutComponent;
+        'vl-side-navigation-layout-next': VlSideNavigationLayoutComponent;
     }
 }

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
@@ -1,8 +1,8 @@
 import { BaseLitElement, findNodesForSlot, registerWebComponents, webComponent } from '@domg-wc/common';
 import { vlContentBlockStyles, vlGridStyles, vlMediaScreenSmall, vlSectionStyles } from '@domg-wc/styles';
 import { css, CSSResult, html, TemplateResult } from 'lit';
-import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { property } from 'lit/decorators.js';
+import { classMap, ClassInfo } from 'lit/directives/class-map.js';
 import { VlSideNavigationComponent } from './vl-side-navigation.component';
 
 registerWebComponents([VlSideNavigationComponent]);

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
@@ -46,17 +46,21 @@ export interface RenderConfig {
 }
 
 /**
- * renders a table of contents from a heading result.
+ * Renders a table of contents from a heading result or a pre-built tree.
+ * Accepts either a HeadingResult (builds the tree internally) or a pre-built HeadingTreeNode[]
+ * so callers can build the tree once and reuse it for cleanup and rendering.
  *
- * @param toc - HeadingResult object containing headings and elements
+ * @param tocOrTree - HeadingResult or pre-built HeadingTreeNode[]
  * @param config - configuration for rendering behavior (scroll, state, callbacks)
  * @returns template result for the table of contents
  */
 export const headingTableOfContentsTemplate = (
-    toc: HeadingResult,
+    tocOrTree: HeadingResult | HeadingTreeNode[],
     config: RenderConfig = { scroll: {}, state: {}, callbacks: {} }
 ): TemplateResult => {
-    return toc.headings.length > 0 ? renderHeadingTree(buildHeadingTree(toc.headings), config) : html``;
+    const tree =
+        'headings' in tocOrTree ? buildHeadingTree(tocOrTree.headings) : tocOrTree;
+    return tree.length > 0 ? renderHeadingTree(tree, config) : html``;
 };
 
 /**
@@ -135,9 +139,7 @@ const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): Templat
     const hasManualToggle = expandedHeadingIds?.has(node.item.id) ?? false;
     const hasManualCollapse = expandedHeadingIds?.has(`-${node.item.id}`) ?? false;
 
-    // show children if:
-    // - manually expanded, OR
-    // - (active or child-active) AND not manually collapsed
+    // show children if: manually expanded, OR (active or child-active) AND not manually collapsed
     const shouldShowChildren = hasManualToggle || ((isActive || isChildActive) && !hasManualCollapse);
 
     const displayText = node.item.text || node.item.id;
@@ -173,7 +175,7 @@ const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): Templat
 
     // render toggle button for parent items
     const toggleButton = hasChildren
-        ? html`<button
+            ? html`<button
               type="button"
               class="toggle-button"
               aria-expanded=${shouldShowChildren ? 'true' : 'false'}
@@ -183,7 +185,7 @@ const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): Templat
           >
               <i class="vl-icon vl-icon--arrow-right-fat ${shouldShowChildren ? 'showing-children' : ''}"></i>
           </button>`
-        : nothing;
+            : nothing;
 
     return html`
         <li>

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
@@ -54,7 +54,7 @@ export const findHeadings = (
     const seenIds = new Map<string, HeadingItem>();
 
     headingLevels.forEach(({ element, level }) => {
-        const text = element.textContent?.trim() ?? '';
+        const text = getHeadingText(element);
         const id = element.getAttribute('id')?.trim() ?? '';
 
         if (!id) {
@@ -77,6 +77,44 @@ export const findHeadings = (
         elements: headingItems.map(({ element }) => element),
         headings: headingItems,
     };
+};
+
+const getHeadingText = (element: HTMLElement): string => collectNodeText(element);
+
+const normalizeText = (text?: string | null): string => (text ?? '').replace(/\s+/g, ' ').trim();
+
+const collectNodeText = (node: Node, visited = new Set<Node>()): string => {
+    if (visited.has(node)) {
+        return '';
+    }
+    visited.add(node);
+
+    if (node.nodeType === Node.TEXT_NODE) {
+        return normalizeText(node.textContent);
+    }
+
+    if (!(node instanceof Element || node instanceof ShadowRoot)) {
+        return '';
+    }
+
+    const fragments: string[] = [];
+    // If an element has a shadow root, read its rendered tree via shadow root only.
+    // Reading both light DOM children and slotted shadow content causes duplicate text.
+    if (node instanceof Element && node.shadowRoot) {
+        const text = collectNodeText(node.shadowRoot, visited);
+        return normalizeText(text);
+    }
+
+    const children = node instanceof HTMLSlotElement ? node.assignedNodes({ flatten: true }) : Array.from(node.childNodes);
+
+    children.forEach((child) => {
+        const text = collectNodeText(child, visited);
+        if (text) {
+            fragments.push(text);
+        }
+    });
+
+    return normalizeText(fragments.join(' '));
 };
 
 /**

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
@@ -98,11 +98,17 @@ const collectNodeText = (node: Node, visited = new Set<Node>()): string => {
     }
 
     const fragments: string[] = [];
-    // If an element has a shadow root, read its rendered tree via shadow root only.
-    // Reading both light DOM children and slotted shadow content causes duplicate text.
+    // If an element has a shadow root, read its rendered tree; also include light DOM children
+    // (e.g. fallback or content not assigned to a slot). The shared visited set avoids duplicate
+    // text when the same nodes are reached via slot.assignedNodes() inside the shadow.
     if (node instanceof Element && node.shadowRoot) {
-        const text = collectNodeText(node.shadowRoot, visited);
-        return normalizeText(text);
+        const shadowText = collectNodeText(node.shadowRoot, visited);
+        const lightFragments: string[] = [shadowText];
+        node.childNodes.forEach((child) => {
+            const text = collectNodeText(child, visited);
+            if (text) lightFragments.push(text);
+        });
+        return normalizeText(lightFragments.join(' '));
     }
 
     const children = node instanceof HTMLSlotElement ? node.assignedNodes({ flatten: true }) : Array.from(node.childNodes);

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
@@ -99,6 +99,35 @@ export const vlSideNavigationLightDomStyles = css`
             ${activeStateStyles}
         }
 
+        /* Match auto-generated nav link text-decoration and font-weight for custom TOC */
+        a {
+            text-decoration: none;
+            font-weight: 500;
+
+            &:hover {
+                text-decoration: underline;
+            }
+
+            &:focus {
+                text-decoration: underline;
+                ${vlFocusOutlineMixin()}
+            }
+        }
+
+        vl-link::part(link) {
+            text-decoration: none;
+            font-weight: 500;
+
+            &:hover {
+                text-decoration: underline;
+            }
+
+            &:focus {
+                text-decoration: underline;
+                ${vlFocusOutlineMixin()}
+            }
+        }
+
         /* Custom TOC styles for slotted content */
         ul {
             list-style: none;
@@ -243,6 +272,7 @@ export const vlSideNavigationStyles = css`
         background-color: var(--vl-color--white);
         padding: var(--vl-spacing--small);
         overflow-y: auto;
+        font-size: var(--vl-font-size--small);
 
         a,
         button {

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -303,8 +303,8 @@ describe('cypress-component - block components - vl-side-navigation-next', () =>
 
         // Mock prefers-reduced-motion: reduce
         cy.window().then((win) => {
-            const originalMatchMedia = win.matchMedia;
-            win.matchMedia = (query: string) => {
+            const originalMatchMedia = win.matchMedia.bind(win);
+            cy.stub(win, 'matchMedia').callsFake((query: string) => {
                 if (query === '(prefers-reduced-motion: reduce)') {
                     return {
                         matches: true,
@@ -317,8 +317,8 @@ describe('cypress-component - block components - vl-side-navigation-next', () =>
                         dispatchEvent: () => true,
                     } as MediaQueryList;
                 }
-                return originalMatchMedia.call(win, query);
-            };
+                return originalMatchMedia(query);
+            });
         });
 
         // Click a link and verify scroll behavior is 'auto' (not smooth)
@@ -646,9 +646,8 @@ describe('cypress-component - block components - vl-side-navigation-next - with 
             .should('have.focus');
         cy.press(Cypress.Keyboard.Keys.ENTER);
 
-        cy.wait(100);
-
-        cy.get('#custom-termijnen').then(($el) => {
+        cy.location('hash').should('equal', '#custom-termijnen');
+        cy.get('#custom-termijnen').should(($el) => {
             const rect = $el[0].getBoundingClientRect();
             expect(rect.top).to.be.lessThan(900);
         });
@@ -835,7 +834,10 @@ describe('cypress-component - block components - vl-side-navigation-next - compa
 
         cy.get('vl-side-navigation-next').shadow().find('table-of-contents').should('not.have.attr', 'hidden');
 
+        // Establish focus context, then close overlay via keyboard
+        cy.get('vl-side-navigation-next').shadow().find('nav').click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB); // focus close button
+        cy.get('vl-side-navigation-next').shadow().find('#close-button').shadow().find('button').should('have.focus');
         cy.press(Cypress.Keyboard.Keys.SPACE);
         // Close moves focus to show-toc-button (async); no TAB so focus stays there
         cy.wait(50);

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -63,7 +63,6 @@ export class VlSideNavigationComponent extends BaseLitElement {
      */
     @property({ type: String, attribute: 'navigation-title' })
     navigationTitle = 'Op deze pagina';
-
     @state() private activeHeadingId: string = '';
     @state() private tocTemplate: TemplateResult = html``;
     @state() private hasCustomToc = false;
@@ -77,6 +76,8 @@ export class VlSideNavigationComponent extends BaseLitElement {
     private isTableOfContentsInitialized = false;
     private mediaQueryList?: MediaQueryList;
     private mediaQueryHandler = (e: MediaQueryListEvent) => this.handleMediaQueryChange(e);
+    private focusRecoveryMutationObserver?: MutationObserver;
+    private previousTocEffectivelyHidden = false;
 
     static get styles(): CSSResult[] {
         return [vlResetStyles, vlSideNavigationStyles, vlLinkStyles(), vlIconStyles];
@@ -142,6 +143,29 @@ export class VlSideNavigationComponent extends BaseLitElement {
         ) {
             this.refreshTableOfContents();
         }
+
+        // When the TOC panel becomes hidden (e.g. viewport resize to mobile), move focus to show button
+        const nowHidden = this.isTocEffectivelyHidden;
+        if (nowHidden && !this.previousTocEffectivelyHidden) {
+            this.updateComplete.then(() => this.handleTocVisibilityFocusRecovery());
+        }
+        this.previousTocEffectivelyHidden = nowHidden;
+
+        // When expand/collapse or active section changes, if the focused element is now hidden, move to logical neighbor
+        if (
+            (changedProperties.has('expandedHeadingIds') || changedProperties.has('activeHeadingId')) &&
+            this.isFocusInsideNav()
+        ) {
+            const el = this.getDeepActiveElement() as HTMLElement;
+            if (el) {
+                const hidden = el.offsetParent === null || el.hasAttribute('hidden') || el.getAttribute('aria-hidden') === 'true';
+                if (hidden) {
+                    // save a reference to the lost element before we lose it completely or focus moves
+                    const lostEl = el;
+                    this.updateComplete.then(() => this.moveFocusToLogicalNeighbor(lostEl));
+                }
+            }
+        }
     }
 
     override connectedCallback(): void {
@@ -150,12 +174,14 @@ export class VlSideNavigationComponent extends BaseLitElement {
             this.setupIntersectionObserver();
         }
         this.setupMediaQueryListener();
+        this.updateComplete.then(() => this.setupFocusRecoveryObserver());
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this.cleanupIntersectionObserver();
         this.cleanupMediaQueryListener();
+        this.cleanupFocusRecoveryObserver();
     }
 
     private setupMediaQueryListener(): void {
@@ -169,6 +195,170 @@ export class VlSideNavigationComponent extends BaseLitElement {
         if (this.mediaQueryList) {
             this.mediaQueryList.removeEventListener('change', this.mediaQueryHandler);
             this.mediaQueryList = undefined;
+        }
+    }
+
+    /**
+     * When the TOC panel becomes hidden (e.g. viewport resize to mobile or compact),
+     * move focus to the show button so the user does not lose context (focus on body).
+     */
+    private handleTocVisibilityFocusRecovery(): void {
+        if (!this.isTocEffectivelyHidden) return;
+        if (!this.isFocusInsideNav()) return;
+        const showButton = this.shadowRoot?.querySelector('#show-toc-button') as HTMLElement | null;
+        const button = showButton?.shadowRoot?.querySelector('button');
+        button?.focus();
+    }
+
+    /**
+     * Returns all focusable elements (a[href], button) inside the nav in tree order,
+     * including slotted content and elements inside shadow roots (e.g. vl-link).
+     */
+    private getFocusableElementsInNav(): HTMLElement[] {
+        const nav = this.shadowRoot?.querySelector('nav');
+        if (!nav) return [];
+        const focusables: HTMLElement[] = [];
+        const slot = nav.querySelector('slot');
+        if (slot && slot instanceof HTMLSlotElement) {
+            const assigned = slot.assignedElements({ flatten: true });
+            for (const el of assigned) {
+                this.collectFocusablesInTreeOrder(el, focusables);
+            }
+        }
+        const inNav = nav.querySelectorAll('a[href], button');
+        inNav.forEach((el) => {
+            if (el instanceof HTMLElement) focusables.push(el);
+        });
+        return focusables;
+    }
+
+    private collectFocusablesInTreeOrder(root: Element, out: HTMLElement[]): void {
+        if (root instanceof HTMLElement && (root.matches?.('a[href]') || root.matches?.('button'))) {
+            out.push(root);
+        }
+        const children: Element[] = [];
+        if (root instanceof HTMLSlotElement) {
+            children.push(...root.assignedElements({ flatten: true }));
+        } else if (root.shadowRoot) {
+            children.push(...Array.from(root.shadowRoot.children));
+        }
+        children.push(...Array.from(root.children));
+        for (const child of children) {
+            this.collectFocusablesInTreeOrder(child, out);
+        }
+    }
+
+    private getDeepActiveElement(): Element | null {
+        if (typeof document === 'undefined') return null;
+        let active = document.activeElement;
+        while (active && active.shadowRoot && active.shadowRoot.activeElement) {
+            active = active.shadowRoot.activeElement;
+        }
+        return active;
+    }
+
+    /**
+     * Whether the current focus is inside the TOC nav (shadow content or slotted content).
+     */
+    private isFocusInsideNav(): boolean {
+        const nav = this.shadowRoot?.querySelector('nav');
+        if (!nav) return false;
+        const active = this.getDeepActiveElement();
+        if (!active) return false;
+        if (nav.contains(active)) return true;
+        const slot = nav.querySelector('slot');
+        const assigned = slot instanceof HTMLSlotElement ? slot.assignedElements({ flatten: true }) : [];
+        return assigned.some((el) => el === active || el.contains(active));
+    }
+
+    /**
+     * When the focused element is removed or hidden, move focus to the next or previous
+     * visible nav item so screen reader users keep context (WCAG 2.4.3).
+     */
+    private moveFocusToLogicalNeighbor(lostFocusElement?: HTMLElement): void {
+        const focusables = this.getFocusableElementsInNav();
+        const visible = focusables.filter(
+            (el) =>
+                el.offsetParent !== null &&
+                !el.hasAttribute('hidden') &&
+                el.getAttribute('aria-hidden') !== 'true'
+        );
+        if (visible.length === 0) {
+            const showButton = this.shadowRoot?.querySelector('#show-toc-button') as HTMLElement | null;
+            showButton?.shadowRoot?.querySelector('button')?.focus();
+            return;
+        }
+
+        const focusTarget = (target: HTMLElement) => {
+            if (target.tagName.toLowerCase() === 'vl-link') {
+                target.shadowRoot?.querySelector('a')?.focus();
+            } else {
+                target.focus();
+            }
+        };
+
+        // 1. Try to focus the currently active heading's link
+        if (this.activeHeadingId) {
+            const activeLink = visible.find((el) => {
+                const href = el.getAttribute('href') || el.closest('vl-link')?.getAttribute('href');
+                return href === `#${this.activeHeadingId}`;
+            });
+            if (activeLink) {
+                focusTarget(activeLink);
+                return;
+            }
+        }
+
+        // 2. Fallback: find the nearest visible element before or after the lost element
+        if (lostFocusElement) {
+            const lostIndex = focusables.indexOf(lostFocusElement);
+            if (lostIndex !== -1) {
+                // Find nearest visible element looking backwards from the lost element
+                const before = focusables.slice(0, lostIndex).reverse().find((el) => visible.includes(el));
+                if (before) {
+                    focusTarget(before);
+                    return;
+                }
+                // If none backwards, look forwards from the lost element
+                const after = focusables.slice(lostIndex + 1).find((el) => visible.includes(el));
+                if (after) {
+                    focusTarget(after);
+                    return;
+                }
+            }
+        }
+
+        // 3. Ultimate fallback: first visible item
+        focusTarget(visible[0]);
+    }
+
+    private setupFocusRecoveryObserver(): void {
+        if (this.focusRecoveryMutationObserver) return;
+        this.focusRecoveryMutationObserver = new MutationObserver((mutations) => {
+            if (typeof document === 'undefined') return;
+            const active = this.getDeepActiveElement();
+            if (active !== document.body) return; // Only if focus was lost to body
+            const nav = this.shadowRoot?.querySelector('nav');
+            const removalInOurNav = mutations.some(
+                (m) =>
+                    m.removedNodes.length > 0 &&
+                    (nav?.contains(m.target as Node) || m.target === this)
+            );
+            if (removalInOurNav) {
+                this.moveFocusToLogicalNeighbor();
+            }
+        });
+        const nav = this.shadowRoot?.querySelector('nav');
+        if (nav) {
+            this.focusRecoveryMutationObserver.observe(nav, { childList: true, subtree: true });
+        }
+        this.focusRecoveryMutationObserver.observe(this, { childList: true, subtree: true });
+    }
+
+    private cleanupFocusRecoveryObserver(): void {
+        if (this.focusRecoveryMutationObserver) {
+            this.focusRecoveryMutationObserver.disconnect();
+            this.focusRecoveryMutationObserver = undefined;
         }
     }
 
@@ -229,9 +419,6 @@ export class VlSideNavigationComponent extends BaseLitElement {
             const newActiveId = topMostEntry.target.getAttribute('id');
             if (newActiveId && newActiveId !== this.activeHeadingId) {
                 this.activeHeadingId = newActiveId;
-                // clear manual toggle state when scrolling changes active heading
-                // this ensures navigation always reflects current scroll position
-                this.expandedHeadingIds.clear();
                 this.updateActiveLinks();
             }
         }
@@ -409,8 +596,25 @@ export class VlSideNavigationComponent extends BaseLitElement {
         if (!this.tableOfContentsStructure) return;
 
         const rootElement = this.headingRoot ?? (this.getRootNode() as Document | ShadowRoot);
+        const tree = buildHeadingTree(this.tableOfContentsStructure.headings);
 
-        this.tocTemplate = headingTableOfContentsTemplate(this.tableOfContentsStructure, {
+        // Clean up manual collapses for sections that are no longer active so they auto-expand on next scroll.
+        // We only want to keep negative IDs (manual collapses) if their section or a child is still active.
+        // If a user scrolls away from a manually collapsed section, we forget the manual collapse
+        // so that it will auto-expand the next time the user scrolls back to it. Positive IDs (manual expands) are always kept.
+        const stillManualCollapsed = Array.from(this.expandedHeadingIds).filter((id) => {
+            if (!id.startsWith('-')) return true;
+            const realId = id.substring(1);
+            const node = findNodeById(tree, realId);
+            const isActive = this.activeHeadingId === realId;
+            const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingId) : false;
+            return isActive || isChildActive;
+        });
+        if (stillManualCollapsed.length !== this.expandedHeadingIds.size) {
+            this.expandedHeadingIds = new Set(stillManualCollapsed);
+        }
+
+        this.tocTemplate = headingTableOfContentsTemplate(tree, {
             scroll: {
                 scrollRoot: rootElement,
                 scrollBehavior: this.effectiveScrollBehavior,
@@ -433,28 +637,27 @@ export class VlSideNavigationComponent extends BaseLitElement {
                         const isActive = this.activeHeadingId === headingId;
 
                         // build tree and find the node to check if any children are active
-                        const tree = buildHeadingTree(this.tableOfContentsStructure.headings);
                         const node = findNodeById(tree, headingId);
                         const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingId) : false;
 
                         const wouldBeAutoExpanded = isActive || isChildActive;
 
                         // toggle logic:
-                        // - if manually expanded: remove manual expand
-                        // - if manually collapsed: remove manual collapse
+                        // - if manually expanded: remove manual expand (and add manual collapse if active so it closes immediately)
+                        // - if manually collapsed: remove manual collapse and add manual expand
                         // - if auto-expanded: add manual collapse (negative ID)
                         // - if not showing: add manual expand (positive ID)
                         if (hasManualToggle) {
-                            // currently manually expanded -> collapse it
                             this.expandedHeadingIds.delete(headingId);
+                            if (wouldBeAutoExpanded) {
+                                this.expandedHeadingIds.add(`-${headingId}`);
+                            }
                         } else if (hasManualCollapse) {
-                            // currently manually collapsed -> allow auto-expand
                             this.expandedHeadingIds.delete(`-${headingId}`);
+                            this.expandedHeadingIds.add(headingId);
                         } else if (wouldBeAutoExpanded) {
-                            // currently auto-expanded -> manually collapse it
                             this.expandedHeadingIds.add(`-${headingId}`);
                         } else {
-                            // currently not showing -> manually expand it
                             this.expandedHeadingIds.add(headingId);
                         }
 

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -91,7 +91,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
         if (slottedElements.length > 0) {
             this.initializeCustomToc(slottedElements);
         } else {
-            const insideLayout = this.closest?.('vl-side-navigation-layout');
+            const insideLayout = this.closest?.('vl-side-navigation-layout-next');
             if (insideLayout) {
                 this.buildTableOfContents();
                 this.setupIntersectionObserver();

--- a/libs/components/src/block/steps/stories/vl-steps.stories.ts
+++ b/libs/components/src/block/steps/stories/vl-steps.stories.ts
@@ -175,7 +175,7 @@ export const StepsSideNavigation = story(
     stepsArgs,
     () => html`
         <section class="vl-section" id="steps-side-navigation-example">
-            <vl-side-navigation-layout>
+            <vl-side-navigation-layout-next>
                 <div slot="content">
                     <vl-steps>
                         <vl-step>
@@ -472,7 +472,7 @@ export const StepsSideNavigation = story(
                                 </vl-step>
                             </vl-steps>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         </section>
     `
 );

--- a/libs/components/src/block/steps/vl-steps.component.cy.ts
+++ b/libs/components/src/block/steps/vl-steps.component.cy.ts
@@ -591,7 +591,7 @@ describe('cypress-component - block components - vl-steps - simple-timeline', ()
 describe('cypress-component - block components - vl-steps - side-navigation', () => {
     const sideNavigationTemplate = html`
         <section class="vl-section" id="steps-side-navigation-example">
-            <vl-side-navigation-layout>
+            <vl-side-navigation-layout-next>
                 <div slot="content">
                     <vl-steps>
                         <vl-step>
@@ -647,7 +647,7 @@ describe('cypress-component - block components - vl-steps - side-navigation', ()
                         </vl-step>
                     </vl-steps>
                 </div>
-            </vl-side-navigation-layout>
+            </vl-side-navigation-layout-next>
         </section>
     `;
 

--- a/libs/components/src/compliance/accessibility/vl-accessibility.component.ts
+++ b/libs/components/src/compliance/accessibility/vl-accessibility.component.ts
@@ -120,7 +120,7 @@ export class VlAccessibility extends BaseLitElement {
         return html`
             <div>
                 <slot name="header">${header(props)}</slot> ${title(props)}
-                <vl-side-navigation-layout
+                <vl-side-navigation-layout-next
                     content-block
                     heading-root-selector="#content"
                     min-level="2"
@@ -128,7 +128,7 @@ export class VlAccessibility extends BaseLitElement {
                     max-depth="0"
                 >
                     ${content(props)}
-                </vl-side-navigation-layout>
+                </vl-side-navigation-layout-next>
             </div>
         `;
     }

--- a/libs/components/src/compliance/cookie-statement/vl-cookie-statement.component.cy.ts
+++ b/libs/components/src/compliance/cookie-statement/vl-cookie-statement.component.cy.ts
@@ -93,8 +93,8 @@ describe('cypress-component - compliance components - vl-cookie-statement - defa
             .contains('Hoe kan ik het gebruik van cookies op deze onlinediensten weigeren of beheren?');
     });
 
-    it('should have a vl-side-navigation-layout', () => {
-        cy.get('vl-cookie-statement').shadow().find('vl-side-navigation-layout');
+    it('should have a vl-side-navigation-layout-next', () => {
+        cy.get('vl-cookie-statement').shadow().find('vl-side-navigation-layout-next');
     });
 
     it('should have default version', () => {

--- a/libs/components/src/compliance/cookie-statement/vl-cookie-statement.component.ts
+++ b/libs/components/src/compliance/cookie-statement/vl-cookie-statement.component.ts
@@ -86,7 +86,7 @@ export class VlCookieStatement extends BaseHTMLElement {
                 </section>
 
                 <section class="vl-section">
-                    <vl-side-navigation-layout content-block max-depth="1">
+                    <vl-side-navigation-layout-next content-block max-depth="1">
                         <div slot="content" class="vl-grid vl-stacked-large">
                             <div class="vl-column vl-column--12 vl-column--m-12">
                                 <vl-title type="h2" id="cookie-policy">Cookiebeleid</vl-title>
@@ -212,7 +212,7 @@ export class VlCookieStatement extends BaseHTMLElement {
                                 <slot></slot>
                             </div>
                         </div>
-                    </vl-side-navigation-layout>
+                    </vl-side-navigation-layout-next>
                 </section>
 
                 <section class="vl-section vl-section--overlap">

--- a/libs/components/src/compliance/privacy/child/content.component.ts
+++ b/libs/components/src/compliance/privacy/child/content.component.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 
 export const privacyContentSection = () => html`
-    <vl-side-navigation-layout content-block max-depth="0">
+    <vl-side-navigation-layout-next content-block max-depth="0">
         <div slot="content" class="vl-grid vl-stacked-large">
             <div class="vl-column vl-column--12 vl-column--m-12">
                 <vl-title type="h2" id="privacy-department">Het Departement Omgeving en uw privacy</vl-title>
@@ -654,5 +654,5 @@ export const privacyContentSection = () => html`
                 </div>
             </div>
         </div>
-    </vl-side-navigation-layout>
+    </vl-side-navigation-layout-next>
 `;

--- a/libs/components/src/compliance/privacy/vl-privacy.component.cy.ts
+++ b/libs/components/src/compliance/privacy/vl-privacy.component.cy.ts
@@ -104,7 +104,7 @@ describe('cypress-component - compliance components - vl-privacy - properties fu
             const have = active ? 'have' : 'not.have';
             cy.get('vl-privacy')
                 .shadow()
-                .find('vl-side-navigation-layout')
+                .find('vl-side-navigation-layout-next')
                 .find('vl-side-navigation-next')
                 .shadow()
                 .find(`a[href="${href}"]`)

--- a/libs/integrations/src/page-layout/page-layout-example.component.ts
+++ b/libs/integrations/src/page-layout/page-layout-example.component.ts
@@ -51,7 +51,7 @@ export class VlPageLayoutExample extends LitElement {
 
                         <section class="vl-section">
                             <div class="vl-content-block ${this.isFullWidth ? 'vl-content-block--full-width' : ''}">
-                                <vl-side-navigation-layout content-block heading-root-selector="#main-content">
+                                <vl-side-navigation-layout-next content-block heading-root-selector="#main-content">
                                     <div slot="content" id="main-content">
                                         <vl-title type="h1"
                                             >${this.isFullWidth ? 'Volledige breedte' : 'Standaard layout'}
@@ -153,7 +153,7 @@ export class VlPageLayoutExample extends LitElement {
                                             venenatis, tellus arcu molestie nunc.
                                         </vl-paragraph>
                                     </div>
-                                </vl-side-navigation-layout>
+                                </vl-side-navigation-layout-next>
                             </div>
                         </section>
                     </div>

--- a/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
@@ -186,7 +186,7 @@ export const buildWTConfigComponentsBlock: WTConfigArray = [
         '/docs/components-block-next-side-navigation-next--documentatie'
     ),
     buildWTConfig(
-        'vl-side-navigation-layout',
+        'vl-side-navigation-layout-next',
         sideNavigationLayoutArgTypes,
         '../../libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-doc.mdx',
         '/docs/components-block-next-side-navigation-layout--documentatie'

--- a/resources/generate-web-types/wt-validate-completeness/compare-wc-wt-components-block.ts
+++ b/resources/generate-web-types/wt-validate-completeness/compare-wc-wt-components-block.ts
@@ -7,13 +7,11 @@ const componentsBlockWCIgnore = [
     'vl-side-navigation-title', // base class
 ];
 const componentsBlockWCMismatch = [
-    'vl-cascader', // in next folder - verwacht een  suffix, maar deze componentsBlock heeft die niet
-    'vl-cascader-item', // in next folder - verwacht een  suffix, maar deze componentsBlock heeft die niet
+    'vl-side-navigation-layout', // in next folder - naam komt niet overeen met bestandsnaam (WT is vl-side-navigation-layout-next)
 ];
 const componentsBlockWTMismatch = [
-    'vl-cascader', // in next folder - verwacht een  suffix, maar die is er niet voor deze componentsBlock
-    'vl-cascader-item', // in next folder - verwacht een  suffix, maar die is er niet voor deze componentsBlock
     'vl-side-navigation-next', // in next folder - naam komt niet overeen met bestandsnaam
+    'vl-side-navigation-layout-next', // in next folder - naam komt niet overeen met bestandsnaam (WC is vl-side-navigation-layout)
     'vl-side-navigation-h1', // in vl-side-navigation-title.componentsBlock.ts
     'vl-side-navigation-h2', // in vl-side-navigation-title.componentsBlock.ts
     'vl-side-navigation-h3', // in vl-side-navigation-title.componentsBlock.ts


### PR DESCRIPTION
- feat: [FLUX-541](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-541) - vl-side-navigation-next - ondersteuning proza-message toegevoegd
- feat: [FLUX-541](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-541) - vl-side-navigation-layout-next - vl-side-navigation-layout hernoemd naar vl-side-navigation-layout-next
- feat: [FLUX-279](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-279)- vl-side-navigation-next - WCAG - focus behandeling verbeterd wanneer die verdwijnt tijdens scroll
- fix: [FLUX-552](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-552)- vl-side-navigation-next - styling gestroomlijnd

[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC224)