### PR TITLE
feat: FLUX-509 - vl-map-wmts-layer - TileMatrix uit de capabilities halen

### DIFF
--- a/apps/storybook-e2e/src/e2e/map/layer/wmts-layer/vl-map-wmts-layer.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/layer/wmts-layer/vl-map-wmts-layer.stories.cy.ts
@@ -1,0 +1,22 @@
+const mapWmtsLayerDefaultUrl =
+    'http://localhost:8080/iframe.html?id=map-layer-wmts-layer--map-wmts-layer-default&viewMode=story';
+const mapWmtsLayerFromCapabilitiesUrl =
+    'http://localhost:8080/iframe.html?id=map-layer-wmts-layer--map-wmts-layer-from-capabilities&viewMode=story';
+
+describe('cypress-e2e - map - vl-map-wmts-layer - default story', () => {
+    it('should fetch WMTS tiles', () => {
+        cy.visit(mapWmtsLayerDefaultUrl);
+
+        cy.intercept('GET', 'https://geo.api.vlaanderen.be/GRB/wmts*').as('getWmts');
+        cy.wait('@getWmts');
+    });
+});
+
+describe('cypress-e2e - map - vl-map-wmts-layer - from-capabilities story', () => {
+    it('should fetch WMTS capabilities', () => {
+        cy.visit(mapWmtsLayerFromCapabilitiesUrl);
+
+        cy.intercept('GET', 'https://www.dov.vlaanderen.be/geoserver/klimaat/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities').as('getCapabilities');
+        cy.wait('@getCapabilities');
+    });
+});

--- a/libs/map/src/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
+++ b/libs/map/src/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories-arg.ts
@@ -8,6 +8,7 @@ export const mapWmtsLayerArgs = {
     url: '',
     matrixSet: 'BPL2008VL',
     matrixPrefix: false,
+    fromCapabilities: false,
 };
 
 export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
@@ -50,6 +51,17 @@ export const mapWmtsLayerArgTypes: ArgTypes<typeof mapWmtsLayerArgs> = {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: String(mapWmtsLayerArgs.matrixPrefix) },
+        },
+    },
+    fromCapabilities: {
+        name: 'from-capabilities',
+        description:
+            'Haalt de TileMatrix configuratie op uit de WMTS GetCapabilities response.<br>Dit attribuut is niet' +
+            ' reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: 'false' },
         },
     },
 };

--- a/libs/map/src/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories.ts
+++ b/libs/map/src/components/layer/wmts-layer/stories/vl-map-wmts-layer.stories.ts
@@ -22,7 +22,7 @@ export default {
 
 export const MapWmtsLayerDefault = story(
     mapWmtsLayerArgs,
-    ({ hidden, layer, maxResolution, minResolution, name, opacity, url }) =>
+    ({ hidden, layer, maxResolution, minResolution, name, opacity, url, fromCapabilities }) =>
         html`
             <vl-map lambert2008>
                 <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
@@ -34,6 +34,7 @@ export const MapWmtsLayerDefault = story(
                     name=${name}
                     opacity=${opacity}
                     url=${url}
+                    ?from-capabilities=${fromCapabilities}
                 >
                 </vl-map-wmts-layer>
             </vl-map>
@@ -44,4 +45,29 @@ MapWmtsLayerDefault.args = {
     name: 'GRB Wegenkaart',
     layer: 'grb_sel',
     url: 'https://geo.api.vlaanderen.be/GRB/wmts',
+};
+
+export const MapWmtsLayerFromCapabilities = story(
+    mapWmtsLayerArgs,
+    ({ hidden, maxResolution, minResolution, name, opacity }) =>
+        html`
+            <vl-map>
+                <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+                <vl-map-wmts-layer
+                    ?hidden=${hidden}
+                    layer="klimaat_doorgrondkaart"
+                    max-resolution=${maxResolution}
+                    min-resolution=${minResolution}
+                    name=${name}
+                    opacity=${opacity}
+                    url="https://www.dov.vlaanderen.be/geoserver/klimaat/gwc/service/wmts"
+                    from-capabilities
+                >
+                </vl-map-wmts-layer>
+            </vl-map>
+        `
+);
+MapWmtsLayerFromCapabilities.storyName = 'vl-map-wmts-layer - from-capabilities';
+MapWmtsLayerFromCapabilities.args = {
+    name: 'DOV Klimaat Doorgrondkaart',
 };

--- a/libs/map/src/components/layer/wmts-layer/vl-map-wmts-layer.cy.ts
+++ b/libs/map/src/components/layer/wmts-layer/vl-map-wmts-layer.cy.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 import OlWMTSSource from 'ol/source/WMTS';
 import OlWMTSTileGrid from 'ol/tilegrid/WMTS';
 import { VlMap } from '../../../vl-map';
+import { geoApiVlaanderenCapabilitiesXML } from '../../../utils/capabilities-response';
 import { VlMapWmtsLayer } from './vl-map-wmts-layer';
 
 registerWebComponents([VlMap, VlMapWmtsLayer]);
@@ -44,6 +45,18 @@ const wmtsLayerHiddenFixture = html`
             min-resolution="2"
             max-resolution="4"
             hidden
+        >
+        </vl-map-wmts-layer>
+    </vl-map>
+`;
+
+const wmtsLayerFromCapabilitiesFixture = html`
+    <vl-map lambert2008>
+        <vl-map-wmts-layer
+            url="https://geo.api.vlaanderen.be/GRB/wmts"
+            layer="grb_sel"
+            name="GRB Wegenkaart"
+            from-capabilities
         >
         </vl-map-wmts-layer>
     </vl-map>
@@ -157,6 +170,24 @@ describe('cypress-component - map - vl-map-wmts-layer', () => {
         cy.mount(wmtsLayerHiddenFixture);
         cy.runTestFor<VlMap>('vl-map', (vlMap) => {
             expect(getLayer(vlMap).layer.getVisible()).to.be.false;
+        });
+    });
+
+    it('met from-capabilities wordt de WMTS source aangemaakt vanuit de capabilities response', () => {
+        cy.intercept('GET', '**/wmts?SERVICE=WMTS&REQUEST=GetCapabilities', geoApiVlaanderenCapabilitiesXML).as(
+            'capabilities'
+        );
+        cy.mount(wmtsLayerFromCapabilitiesFixture);
+        cy.wait('@capabilities');
+        cy.runTestFor<VlMap>('vl-map', (vlMap) => {
+            cy.wrap(vlMap.ready).then(() => {
+                const layers = vlMap.map.getOverlayLayers();
+                expect(layers).to.be.lengthOf(1);
+                const layer = layers[0];
+                // @ts-ignore
+                const source = layer.getSource();
+                expect(source).to.be.instanceof(OlWMTSSource);
+            });
         });
     });
 });

--- a/libs/map/src/components/layer/wmts-layer/vl-map-wmts-layer.ts
+++ b/libs/map/src/components/layer/wmts-layer/vl-map-wmts-layer.ts
@@ -1,8 +1,9 @@
 import { webComponent } from '@domg-wc/common';
 import * as OlExtent from 'ol/extent';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
 import OlTileLayer from 'ol/layer/Tile';
 import { Projection } from 'ol/proj';
-import OlWMTSSource from 'ol/source/WMTS';
+import OlWMTSSource, { optionsFromCapabilities } from 'ol/source/WMTS';
 import OlWMTSTileGrid from 'ol/tilegrid/WMTS';
 import { getLambert2008Code, getLambert2008Extent, getLambert72Code } from '../../../utils/capabilities';
 import { VlMap } from '../../../vl-map';
@@ -10,8 +11,12 @@ import { VlMapLayer } from '../vl-map-layer';
 
 @webComponent('vl-map-wmts-layer')
 export class VlMapWmtsLayer extends VlMapLayer {
-    connectedCallback() {
-        this._source = this.__createSource();
+    async connectedCallback() {
+        if (this.hasAttribute('from-capabilities')) {
+            this._source = await this.__createSourceFromCapabilities();
+        } else {
+            this._source = this.__createSource();
+        }
         this._layer = this._createLayer();
         return super.connectedCallback();
     }
@@ -49,6 +54,22 @@ export class VlMapWmtsLayer extends VlMapLayer {
         });
         layer.set('id', VlMapLayer._counter);
         return layer;
+    }
+
+    async __createSourceFromCapabilities(): Promise<OlWMTSSource> {
+        const resp = await fetch(`${this.url}?SERVICE=WMTS&REQUEST=GetCapabilities`);
+        const text = await resp.text();
+        const parser = new WMTSCapabilities();
+        const caps = parser.read(text);
+        const options = optionsFromCapabilities(caps, {
+            layer: this._wmtsLayer,
+            ...(this.hasAttribute('matrix-set') ? { matrixSet: this.__grbMatrixSet } : {}),
+            projection: this._projection,
+        });
+        if (!options) {
+            throw new Error(`De WMTS source kon niet aangemaakt worden vanuit de capabilities voor de layer '${this._wmtsLayer}'`);
+        }
+        return new OlWMTSSource(options);
     }
 
     __createSource() {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-509

'from-capabilities' attribuut toegevoegd aan vl-map-wmts-layer. Wanneer gezet wordt de WMTS GetCapabilities via het endpoint opgehaald en via de OpenLayers optionsFromCapabilities de source opgebouwd. Dit geeft correcte TileMatrix resolutions en matrixIds voor lagen waarbij de synthetisch berekende waarden niet overeenkomen met de werkelijke serverconfiguratie.
Zonder het attribuut gedraagt de component zich identiek als voorheen.