### PR TITLE
fix: FLUX-307 - vl-map - typescript fouten in de component testen opgelost

### DIFF
--- a/libs/map/src/components/layer-style/vl-map-layer-style.ts
+++ b/libs/map/src/components/layer-style/vl-map-layer-style.ts
@@ -88,7 +88,7 @@ export class VlMapLayerStyle extends BaseHTMLElement {
     }
 
     get _styleFunction() {
-        return (feature) => {
+        return (feature): OlStyle => {
             const geometry = feature instanceof Feature && feature?.getGeometry();
 
             if (
@@ -102,9 +102,9 @@ export class VlMapLayerStyle extends BaseHTMLElement {
                 });
             }
 
-            const baseStyle = new OlStyle({
+            return new OlStyle({
                 fill: new OlStyleFill({
-                    color: this.color,
+                    color: this.canvasPattern ?? this.color,
                 }),
                 stroke: new OlStyleStroke({
                     color: this.borderColor,
@@ -112,17 +112,6 @@ export class VlMapLayerStyle extends BaseHTMLElement {
                 }),
                 text: this._getTextStyle(feature),
             });
-
-            if (this.canvasPattern) {
-                const patternStyle = new OlStyle({
-                    fill: new OlStyleFill({
-                        color: this.canvasPattern,
-                    }),
-                });
-                return [baseStyle, patternStyle];
-            }
-
-            return baseStyle;
         };
     }
 
@@ -198,8 +187,13 @@ export class VlMapLayerStyle extends BaseHTMLElement {
         const img = new Image();
         img.onload = async () => {
             const canvas = document.createElement('canvas');
+            canvas.width = img.width || 1;
+            canvas.height = img.height || 1;
             const ctx = canvas.getContext('2d');
-            this.canvasPattern = ctx.createPattern(img, 'repeat');
+            ctx.fillStyle = this.color;
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(img, 0, 0);
+            this.canvasPattern = ctx.createPattern(canvas, 'repeat');
 
             await this.mapElement?.ready;
             (this.parentElement as any)?._layer?.getSource()?.changed();


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-307
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC242
