### PR TITLE
fix: FLUX-570 - correctie van 'side navigation met proza message' onder patronen

### DIFF
--- a/apps/storybook-e2e/src/e2e/patronen/navigatie/side-navigation/met-proza-message/side-navigation-met-proza-message.cy.ts
+++ b/apps/storybook-e2e/src/e2e/patronen/navigatie/side-navigation/met-proza-message/side-navigation-met-proza-message.cy.ts
@@ -1,0 +1,13 @@
+const storyUrl =
+    'http://localhost:8080/iframe.html?id=patronen-navigatie-side-navigation-met-proza-message--layout-met-proza-message&viewMode=story';
+
+describe('cypress-e2e - patronen - navigatie - side navigation - met proza message story', () => {
+    it('should render', () => {
+        cy.visit(storyUrl);
+
+        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part');
+        cy.get('vl-side-navigation-layout-next').shadow().find('content-part');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+        cy.get('vl-title[type="h1"]').should('contain', 'Side Navigation - met Proza Message');
+    });
+});

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_met-proza-message/side-navigation-met-proza-message.mdx
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_met-proza-message/side-navigation-met-proza-message.mdx
@@ -1,9 +1,9 @@
 import { Canvas, Meta } from '@storybook/addon-docs/blocks';
-import * as sideNavigationLayoutWithProzaMessageStories from './side-navigation-layout-with-proza-message.stories';
+import * as sideNavigationMetProzaMessageStories from './side-navigation-met-proza-message.stories';
 
-<Meta of={sideNavigationLayoutWithProzaMessageStories} />
+<Meta of={sideNavigationMetProzaMessageStories} />
 
-# Side Navigation Layout Met Proza Message
+# Side Navigation - met Proza Message
 
 In dit voorbeeld wordt `vl-side-navigation-layout-next` gecombineerd met `vl-proza-message`. De titels in de content worden
 gevuld via Proza berichten en verschijnen zo ook in de side navigation.
@@ -21,4 +21,4 @@ Dit voorbeeld toont ook:
 
 ## Demo
 
-<Canvas of={sideNavigationLayoutWithProzaMessageStories.LayoutMetProzaMessage} sourceState="shown" />
+<Canvas of={sideNavigationMetProzaMessageStories.SideNavigationMetProzaMessage} sourceState="shown" />

--- a/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_met-proza-message/side-navigation-met-proza-message.stories.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/side-navigation/1_met-proza-message/side-navigation-met-proza-message.stories.ts
@@ -5,6 +5,19 @@ import { VlSideNavigationLayoutComponent } from '@domg-wc/components/block/next'
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit-html';
 
+export default {
+    title: 'Patronen/Navigatie/Side Navigation/met proza message',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            story: {
+                inline: false,
+                iframeHeight: 860,
+            },
+        },
+    },
+} as Meta;
+
 registerWebComponents([
     VlSideNavigationLayoutComponent,
     VlProzaMessagePreloader,
@@ -174,7 +187,7 @@ const preloadProzaMessages = () => {
     VlProzaMessagePreloader.__setPreloadedMessagesCacheForDomain(
         prozaDomain,
         Promise.resolve({
-            'page-title': 'Side navigation layout met proza message',
+            'page-title': 'Side Navigation - met Proza Message',
             'section-1-title': 'Ontwerpprincipes',
             'section-1-sub-1': 'Consistente headings',
             'section-1-sub-2': 'Scanbare content',
@@ -191,23 +204,10 @@ const preloadProzaMessages = () => {
     VlProzaMessage.__setToegelatenOperatiesCacheForDomain(prozaDomain, Promise.resolve({ update: false }));
 };
 
-export default {
-    title: 'Patronen/Pagina Opbouw/Side Navigation Met Proza Message',
-    parameters: {
-        layout: 'fullscreen',
-        docs: {
-            story: {
-                inline: false,
-                iframeHeight: 860,
-            },
-        },
-    },
-} as Meta;
-
-export const LayoutMetProzaMessage = () => {
+export const SideNavigationMetProzaMessage = () => {
     preloadProzaMessages();
 
     return sideNavigationLayoutWithProzaMessageHTML;
 };
 
-LayoutMetProzaMessage.storyName = 'vl-side-navigation-layout-next - met proza message';
+SideNavigationMetProzaMessage.storyName = 'side-navigation - met proza message';


### PR DESCRIPTION
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC249

- het kwam onder 'pagina-opbouw' zie https://flux.omgeving.vlaanderen.be/release-v2/2.11.0/storybook/?path=/docs/patronen-pagina-opbouw-side-navigation-met-proza-message--documentatie terwijl het technisch onder 'navigatie' zit - die 2 moeten wel in-sync zijn
- de folder / sub-folder / story naam volgen een opzet, gelieve die aan te houden
- ook de titel van de pagina volgt die opzet
- het doel is ook niet te formuleren met feitelijke component namen, maar eerder functioneel - ja er kan over gediscussieerd worden of je dan 'zij navigatie' wil gebruik of 'proza bericht' en of je 'layout' in de titel wil