### PR TITLE
feat: FLUX-574 - vl-icon - role="img" toevoegen indien aria-label gebruikt wordt

### DIFF
--- a/libs/components/src/atom/icon/vl-icon.component.cy.ts
+++ b/libs/components/src/atom/icon/vl-icon.component.cy.ts
@@ -17,6 +17,8 @@ describe('cypress-component - atom components - vl-icon', () => {
 
         // Test dat het icoon als decoratief beschouwd wordt indien er geen label is meegegeven.
         cy.get('vl-icon').shadow().find('span.vl-icon').should('have.attr', 'aria-hidden', 'true');
+        cy.get('vl-icon').shadow().find('span.vl-icon').should('not.have.attr', 'role');
+        cy.get('vl-icon').shadow().find('span.vl-icon').should('not.have.attr', 'aria-label');
 
         cy.checkA11y('vl-icon');
     });
@@ -77,6 +79,7 @@ describe('cypress-component - atom components - vl-icon', () => {
         cy.get('vl-icon')
             .shadow()
             .find('span.vl-icon')
+            .should('have.attr', 'role', 'img')
             .should('have.attr', 'aria-label', 'Dit is een toegankelijk label');
         cy.get('vl-icon').shadow().find('span.vl-icon').should('not.have.attr', 'aria-hidden');
     });

--- a/libs/components/src/atom/icon/vl-icon.component.ts
+++ b/libs/components/src/atom/icon/vl-icon.component.ts
@@ -60,6 +60,7 @@ export class VlIconComponent extends BaseLitElement {
             <span
                 class=${classMap(classes)}
                 tabindex=${ifDefined(this.clickable ? '0' : undefined)}
+                role=${ifDefined(this.label ? 'img' : undefined)}
                 aria-label=${ifDefined(this.label ? this.label : undefined)}
                 aria-hidden=${ifDefined(this.label ? undefined : 'true')}
                 part="icon"


### PR DESCRIPTION
[jira](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-574)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC250)