### PR TITLE
fix: FLUX-573 - vl-map-features-layer - vermijden dat er een fout komt bij een lege geometrie

### DIFF
--- a/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.cy.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.cy.ts
@@ -53,6 +53,18 @@ const mapAutoExtentFixture = html`
     </vl-map>
 `;
 
+const mapAutoExtentEmptyGeometryFixture = html`
+    <vl-map lambert2008>
+        <vl-map-features-layer
+            name="testlaag"
+            features='{"type":"FeatureCollection","features":[{"type":"Feature","geometry":null,"properties":null,"id":1}]}'
+            auto-extent
+            projection-code="EPSG:31370"
+        >
+        </vl-map-features-layer>
+    </vl-map>
+`;
+
 const mapAutoExtentMaxZoomFixture = html`
     <vl-map lambert2008>
         <vl-map-features-layer
@@ -341,6 +353,19 @@ describe('cypress-component - map - vl-map-features-layer', () => {
                     ],
                 });
                 expect(vlMapFeaturesLayer.layer.getSource().getFeatures()).to.be.lengthOf(2);
+            });
+        });
+    });
+
+    it('zoomen naar extent met lege geometrie gooit geen fout', () => {
+        cy.mount(mapAutoExtentEmptyGeometryFixture);
+        cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {
+            cy.wrap(vlMap.ready).then(() => {
+                const initialCenter = vlMap.map.getView().getCenter();
+                expect(vlMapFeaturesLayer.boundingBox).to.be.undefined;
+                cy.wrap(vlMapFeaturesLayer.zoomToExtent(null)).then(() => {
+                    expect(vlMap.map.getView().getCenter()).to.deep.equal(initialCenter);
+                });
             });
         });
     });

--- a/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.ts
@@ -1,4 +1,5 @@
 import { webComponent } from '@domg-wc/common';
+import { isEmpty as isEmptyExtent } from 'ol/extent';
 import OlGeoJSON from 'ol/format/GeoJSON';
 import OlPoint from 'ol/geom/Point';
 import OlClusterSource from 'ol/source/Cluster';
@@ -182,7 +183,10 @@ export class VlMapFeaturesLayer extends VlMapVectorLayer {
 
     get boundingBox() {
         if (this.__featuresSource && this.__featuresSource.getFeatures().length > 0) {
-            return this.__featuresSource.getExtent();
+            const extent = this.__featuresSource.getExtent();
+            if (!isEmptyExtent(extent)) {
+                return extent;
+            }
         }
     }
 


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-573
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC252