### PR TITLE
feat: FLUX-400 - vl-rich-data-table - gebruik van no-content slot verbeterd

### DIFF
--- a/libs/components/src/block/rich-data-table/vl-rich-data-table.component.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-table.component.ts
@@ -172,7 +172,7 @@ export class VlRichDataTable extends VlRichData {
     }
 
     get _hasResults(): boolean {
-        return Boolean(this._data);
+        return Boolean(this._data && this._data.data && this._data.data.length > 0);
     }
 
     get __captionElement(): HTMLTableCaptionElement | null | undefined {


### PR DESCRIPTION
[FLUX-400](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-400), [FLUX-538](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-538)
[bamboo](https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC260)