### PR TITLE
fix: FLUX-592 - vl-spotlight, vl-infotext, vl-doormat - extern icoon inline na titel geplaatst

### DIFF
--- a/libs/components/src/block/doormat/vl-doormat.component.ts
+++ b/libs/components/src/block/doormat/vl-doormat.component.ts
@@ -57,12 +57,12 @@ export class VlDoormatComponent extends BaseLitElement {
                 <div class="vl-doormat__content">
                     <h2 class="vl-doormat__title">
                         <slot name="title"></slot>
+                        ${this.external ? this.renderExternalIcon() : nothing}
                     </h2>
                     <div class="vl-doormat__text">
                         <slot name="text"></slot>
                     </div>
                 </div>
-                ${this.external ? this.renderExternalIcon() : nothing}
             </a>
         `;
     }

--- a/libs/components/src/block/infotext/vl-infotext.component.ts
+++ b/libs/components/src/block/infotext/vl-infotext.component.ts
@@ -69,7 +69,6 @@ export class VlInfotextComponent extends BaseLitElement {
                 aria-label=${this.linkLabel || nothing}
             >
                 ${this.renderContent()}
-                ${this.external ? this.renderExternalIcon() : nothing}
             </a>`;
         }
 
@@ -85,6 +84,7 @@ export class VlInfotextComponent extends BaseLitElement {
             <div class="vl-infotext__value">${this.value}</div>
             <div class="vl-infotext__text">
                 <slot name="text"></slot>
+                ${this.external && this.href ? this.renderExternalIcon() : nothing}
             </div>
             <slot name="value" hidden></slot>
         `;

--- a/libs/components/src/block/spotlight/vl-spotlight.component.ts
+++ b/libs/components/src/block/spotlight/vl-spotlight.component.ts
@@ -111,7 +111,7 @@ export class VlSpotlight extends BaseLitElement {
     }
 
     _getTitleTemplateWithValue(value: any) {
-        return html`<h3 class="vl-spotlight__title">${value}</h3>`;
+        return html`<h3 class="vl-spotlight__title">${value}${this.external ? this.__renderExternalIcon() : nothing}</h3>`;
     }
 
     _getSubTitleTemplateWithValue(value: any) {
@@ -156,7 +156,6 @@ export class VlSpotlight extends BaseLitElement {
                     ${this.__processHeader()} ${this.__processSlotTitle()} ${this.__processSlotSubTitle()}
                     ${this.__processSlotContent()} ${this.__processSlotText()}
                 </article>
-                ${this.external ? this.__renderExternalIcon() : nothing}
             </a>`;
         }
         return html`


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-592