### PR TITLE
fix: FLUX-569 - vl-select-rich - native browser × knop overlapt eerste karakter in multiple select

### DIFF
--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -352,8 +352,10 @@ export class VlSelectRichComponent extends FormControl {
     }
 
     private setChoicesInputAttributes(): void {
-        if (this.choices?.input?.element) {
-            const inputElement = this.choices.input.element;
+        const inputElement =
+            this.choices?.input?.element ||
+            this.shadowRoot?.querySelector<HTMLInputElement>('input.vl-input-field');
+        if (inputElement) {
             inputElement.setAttribute('type', 'text');
             inputElement.classList.add('vl-input-field', 'vl-input-field-cloned');
             inputElement.setAttribute('autocomplete', 'off');


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-569