### PR TITLE
feat: FLUX-483 - vl-link - type-attribuut toegevoegd aan button-as-link

### DIFF
--- a/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
@@ -115,6 +115,18 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
             defaultValue: { summary: String(linkArgs.buttonAsLink) },
         },
     },
+    type: {
+        name: 'type',
+        description:
+            'Het type van de button.<br/>Werkt enkel in combinatie met het `button-as-link`-attribuut.',
+        control: { type: CONTROLS.SELECT },
+        options: ['button', 'submit', 'reset'],
+        table: {
+            type: { summary: `${TYPES.STRING}: 'button' | 'submit' | 'reset'` },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: linkArgs.type },
+        },
+    },
     defaultSlot: {
         name: '[default]',
         description: 'De content van de link.',

--- a/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
+++ b/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
@@ -67,6 +67,8 @@ Als richtlijn geldt:
   bvb. het sluiten van een modal, het gaan naar een volgende stap, het openklappen van een accordion, enzovoort.
 - gebruik een `<a>`-element om te navigeren naar een andere pagina.
 
+Via het `type`-attribuut kan je het type van de onderliggende `<button>` instellen. De standaardwaarde is `button`.
+
 <Canvas of={VlLinkStories.ButtonStyledAsLink} />
 
 ## Toegankelijkheid

--- a/libs/components/src/atom/link/stories/vl-link.stories.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories.ts
@@ -24,7 +24,7 @@ export default {
 
 const LinkTemplate = story(
     linkArgs,
-    ({ href, bold, small, large, error, external, buttonAsLink, icon, iconPlacement, defaultSlot, label }) =>
+    ({ href, bold, small, large, error, external, buttonAsLink, type, icon, iconPlacement, defaultSlot, label }) =>
         html`
             <vl-link
                 href=${href}
@@ -34,6 +34,7 @@ const LinkTemplate = story(
                 ?error=${error}
                 ?external=${external}
                 ?button-as-link=${buttonAsLink}
+                type=${type}
                 icon=${icon}
                 icon-placement=${iconPlacement}
                 label=${label}

--- a/libs/components/src/atom/link/vl-link.component.cy.ts
+++ b/libs/components/src/atom/link/vl-link.component.cy.ts
@@ -221,4 +221,22 @@ describe('cypress-component - atom components - vl-link - button as link', () =>
         cy.get('vl-link').shadow().find('button').find('slot');
         cy.get('vl-link').contains('Vlaanderen');
     });
+
+    it('should have default type button', () => {
+        cy.mount(html`<vl-link button-as-link>Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('button').should('have.attr', 'type', 'button');
+    });
+
+    it('should set type submit', () => {
+        cy.mount(html`<vl-link button-as-link type="submit">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('button').should('have.attr', 'type', 'submit');
+    });
+
+    it('should set type reset', () => {
+        cy.mount(html`<vl-link button-as-link type="reset">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('button').should('have.attr', 'type', 'reset');
+    });
 });

--- a/libs/components/src/atom/link/vl-link.component.ts
+++ b/libs/components/src/atom/link/vl-link.component.ts
@@ -21,6 +21,7 @@ export class VlLinkComponent extends BaseLitElement {
     private icon = linkDefaults.icon;
     private iconPlacement = linkDefaults.iconPlacement;
     private buttonAsLink = linkDefaults.buttonAsLink;
+    private type = linkDefaults.type;
 
     static get styles(): CSSResult[] {
         return [vlLinkFluxStyles, vlLinkStyles(), vlLinkIconStyles, buttonAsLinkStyles, vlIconStyles];
@@ -39,6 +40,7 @@ export class VlLinkComponent extends BaseLitElement {
             icon: { type: String },
             iconPlacement: { type: String, attribute: 'icon-placement' },
             buttonAsLink: { type: Boolean, attribute: 'button-as-link' },
+            type: { type: String },
         };
     }
 
@@ -83,6 +85,7 @@ export class VlLinkComponent extends BaseLitElement {
             : html`
                   <button
                       class="vl-button-as-link ${classMap(classes)}"
+                      type=${this.type}
                       part="button"
                       aria-label=${this.label || nothing}
                       aria-haspopup=${ifDefined(

--- a/libs/components/src/atom/link/vl-link.defaults.ts
+++ b/libs/components/src/atom/link/vl-link.defaults.ts
@@ -11,4 +11,5 @@ export const linkDefaults = {
     icon: '' as string,
     iconPlacement: '' as ICON_PLACEMENT,
     buttonAsLink: false as boolean,
+    type: 'button' as 'button' | 'submit' | 'reset',
 } as const;


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-483
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC281 ✅ 