### PR TITLE
fix: FLUX-589 - vl-datepicker - min-date / max-date attributen werking / documentatie stroomlijnen

### DIFF
--- a/libs/components/src/form/datepicker/helpers.ts
+++ b/libs/components/src/form/datepicker/helpers.ts
@@ -9,17 +9,25 @@ export const extractTime = (date: Date): Date => {
 
 export const getDatepickerBoundary = (instance: VlDatepickerComponent, kind: 'max' | 'min'): Date | undefined => {
     const { type, format, maxDate, maxTime, minDate, minTime } = instance;
+    const parseDateBoundary = (dateString: string) => {
+        if (dateString === 'today') {
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            return today;
+        }
+        return flatpickr.parseDate(dateString, format);
+    };
 
     if (kind === 'max') {
         if (['date', 'date-time', 'range'].includes(type) && maxDate) {
-            return flatpickr.parseDate(maxDate, format);
+            return parseDateBoundary(maxDate);
         }
         if (type === 'time' && maxTime) {
             return flatpickr.parseDate(maxTime, format);
         }
     } else {
         if (['date', 'date-time', 'range'].includes(type) && minDate) {
-            return flatpickr.parseDate(minDate, format);
+            return parseDateBoundary(minDate);
         }
         if (type === 'time' && minTime) {
             return flatpickr.parseDate(minTime, format);

--- a/libs/components/src/form/datepicker/masks.ts
+++ b/libs/components/src/form/datepicker/masks.ts
@@ -1,7 +1,6 @@
-import flatpickr from 'flatpickr';
 import { MaskOptions } from '../models/cleave.model';
 
-export const createDateMask = (format: string, minDate?: string, maxDate?: string): MaskOptions | null => {
+export const createDateMask = (format: string): MaskOptions | null => {
     if (!format) return null;
     let maskOptions: MaskOptions | null = null;
     const delimiters = format.split(/[dmyY]/).filter((delimiter) => delimiter);
@@ -21,22 +20,6 @@ export const createDateMask = (format: string, minDate?: string, maxDate?: strin
         delimiters: delimiters,
         regex: new RegExp(`^[0-9]{${length}}$`),
     };
-    if (minDate) {
-        const minimumDate = flatpickr?.parseDate(minDate, format);
-        maskOptions = {
-            ...maskOptions,
-            // formatteren naar verwacht formaat voor cleave.js
-            dateMin: minimumDate ? flatpickr?.formatDate(minimumDate, 'Y-M-D') : undefined,
-        };
-    }
-    if (maxDate) {
-        const maximumDate = flatpickr?.parseDate(maxDate, format);
-        maskOptions = {
-            ...maskOptions,
-            // formatteren naar verwacht formaat voor cleave.js
-            dateMax: maximumDate ? flatpickr?.formatDate(maximumDate, 'Y-M-D') : undefined,
-        };
-    }
     return maskOptions;
 };
 

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -88,7 +88,7 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
     },
     minDate: {
         name: 'min-date',
-        description: "Minimum datum conform het ingestelde formaat (bv. '01-01-2019') of 'today' voor vandaag.",
+        description: "Minimum datum conform het ingestelde formaat (bv. '01.01.2019') of 'today' voor vandaag.",
         control: { type: CONTROLS.DATE },
         table: {
             type: { summary: TYPES.STRING },
@@ -98,7 +98,7 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
     },
     maxDate: {
         name: 'max-date',
-        description: "Maximum datum conform het ingestelde format (bv. '31-12-2019') of 'today' voor vandaag.",
+        description: "Maximum datum conform het ingestelde formaat (bv. '31.12.2019') of 'today' voor vandaag.",
         control: { type: CONTROLS.DATE },
         table: {
             type: { summary: TYPES.STRING },

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -75,6 +75,45 @@ De uitgelezen waarde volgt eveneens het [ISO-formaat](https://en.wikipedia.org/w
 ```
 
 
+## Varianten
+
+### Static
+
+<Canvas of={VlDatepickerStories.DatepickerStatic} />
+
+### Range
+
+<Canvas of={VlDatepickerStories.DatepickerRange} />
+
+### Time
+
+<Canvas of={VlDatepickerStories.DatepickerTime} />
+
+### Min-date en Max-date
+
+Je kan de selecteerbare datumrange beperken via de `min-date` en `max-date` attributen.
+De waarde moet conform het ingestelde `format` zijn (standaard `d.m.Y`), of de speciale waarde `'today'` voor de huidige datum.
+
+> Met `format="d.m.Y"` (standaard): `min-date="01.01.2019"` en `max-date="31.12.2019"`
+```html
+<vl-datepicker min-date="01.01.2019" max-date="31.12.2019"></vl-datepicker>
+```
+
+> Gebruik `'today'` om de huidige datum als grens in te stellen:
+```html
+<vl-datepicker min-date="today"></vl-datepicker>
+```
+
+<Canvas of={VlDatepickerStories.DatepickerMinDateAndMaxDate} />
+
+- Dagen buiten de opgegeven range worden uitgeschakeld in de kalender.
+- Ingetypte datums buiten de range worden gevalideerd via respectievelijk de `rangeUnderflow` en `rangeOverflow` ValidityState keys.
+
+### Date-time
+
+<Canvas of={VlDatepickerStories.DatepickerDateTime} />
+
+
 ## Validatie
 > Meer info over validatie binnen onze form componenten vind je hier: [Form - Validatie](/docs/patronen-formulier-validatie--documentatie)
 

--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -1043,6 +1043,36 @@ describe('vl-datepicker - form integration', () => {
         cy.checkA11y('vl-datepicker');
     });
 
+    it('should disable dates outside min/max in calendar', () => {
+        const format = 'd.m.Y';
+        const [minDate, maxDate] = createDateRange(new Date('2024-04-10'), 2, format);
+        mountDatepickerInForm({ ...datepickerDefaults, minDate, maxDate, format, type: 'date', value: '2024-04-10' });
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        cy.wait(100);
+
+        // dagen voor min-date zijn uitgeschakeld
+        cy.get('vl-datepicker')
+            .shadow()
+            .find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)')
+            .contains('7')
+            .should('have.class', 'flatpickr-disabled');
+
+        // dagen na max-date zijn uitgeschakeld
+        cy.get('vl-datepicker')
+            .shadow()
+            .find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)')
+            .contains('13')
+            .should('have.class', 'flatpickr-disabled');
+
+        // dag binnen range is selecteerbaar
+        cy.get('vl-datepicker')
+            .shadow()
+            .find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)')
+            .contains('10')
+            .should('not.have.class', 'flatpickr-disabled');
+    });
+
     it('should validate min/max with type "time"', () => {
         mountDatepickerInForm({ ...datepickerDefaults, minTime: '10:00', maxTime: '12:00', type: 'time' });
         cy.injectAxe();
@@ -1121,6 +1151,68 @@ describe('vl-datepicker - form integration', () => {
         cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
         cy.get('vl-form-message[state="rangeUnderflow"]').should('have.attr', 'show');
         cy.checkA11y('vl-datepicker');
+    });
+
+    it('should validate min/max with min-date="today" and max-date="today"', () => {
+        const today = new Date();
+        const yesterday = new Date(today);
+        yesterday.setDate(today.getDate() - 1);
+        const tomorrow = new Date(today);
+        tomorrow.setDate(today.getDate() + 1);
+
+        mountDatepickerInForm({ ...datepickerDefaults, minDate: 'today', maxDate: 'today', format: 'd.m.Y', type: 'date' });
+        cy.get('form').then((form$) => {
+            form$.on('submit', (e) => {
+                e.preventDefault();
+            });
+        });
+
+        // vandaag wordt geaccepteerd
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').type(createDateString({ date: today }));
+        cy.get('button[type="submit"]').click({ force: true });
+        cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
+        cy.get('vl-form-message[state="rangeUnderflow"]').shadow().find('p').should('have.attr', 'hidden');
+
+        cy.get('button[type="reset"]').click();
+
+        // gisteren triggert rangeUnderflow
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').type(createDateString({ date: yesterday }));
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="rangeUnderflow"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
+
+        cy.get('button[type="reset"]').click();
+
+        // morgen triggert rangeOverflow
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').type(createDateString({ date: tomorrow }));
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="rangeOverflow"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="rangeUnderflow"]').shadow().find('p').should('have.attr', 'hidden');
+    });
+
+    it('should disable dates outside today in calendar with min-date="today" and max-date="today"', () => {
+        const today = new Date();
+        const todayDay = today.getDate();
+
+        cy.mount(html`<vl-datepicker min-date="today" max-date="today" label="date"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        cy.wait(100);
+
+        // vandaag is selecteerbaar
+        cy.get('vl-datepicker')
+            .shadow()
+            .find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)')
+            .contains(new RegExp(`^${todayDay}$`))
+            .should('not.have.class', 'flatpickr-disabled');
+
+        // alle andere dagen zijn uitgeschakeld
+        cy.get('vl-datepicker')
+            .shadow()
+            .find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay):not(.today)')
+            .each(($day) => {
+                cy.wrap($day).should('have.class', 'flatpickr-disabled');
+            });
     });
 });
 

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -619,7 +619,7 @@ export class VlDatepickerComponent extends FormControl {
         let maskOptions: MaskOptions | null = null;
         switch (type) {
             case 'date':
-                maskOptions = createDateMask(format, this.minDate, this.maxDate);
+                maskOptions = createDateMask(format);
                 break;
             case 'time':
                 maskOptions = createTimeMask(format);


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-589
https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC299 ⚙️ 

- masks.ts: 'Y-M-D' verbeterd naar 'Y-m-d' zodat Cleave.js dateMin/dateMax correct worden opgebouwd (M & D staat bij flatpickr respectievelijk voor tekstuele weergave van maand en dag ipv numeriek (verwacht))
- helpers.ts: 'today' waarde wordt nucorrect verwerkt in getDatepickerBoundary voor rangeUnderflow/rangeOverflow validatie
- stories-arg.ts: voorbeeldformaat gecorrigeerd naar standaard d.m.Y notatie
- vl-datepicker.component.cy.ts: regressietest toegevoegd voor min-date/max-date met 'today' waarde