### PR TITLE
FLUX-612: vl-search-result - vl-search-result-title height met lange resultaten

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/search-result/vl-search-result.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/search-result/vl-search-result.stories.cy.ts
@@ -2,6 +2,8 @@ const searchResultDefaultUrl =
     'http://localhost:8080/iframe.html?id=components-block-search-result--search-result-default&viewMode=story';
 const searchResultGroupUrl =
     'http://localhost:8080/iframe.html?id=components-block-search-result--search-result-group&viewMode=story';
+const searchResultMultilineTitleUrl =
+    'http://localhost:8080/iframe.html?id=components-block-search-result--search-result-multiline-title&viewMode=story';
 
 describe('cypress-e2e - block components - vl-search-result - default story', () => {
     it('should render', () => {
@@ -16,5 +18,13 @@ describe('cypress-e2e - block components - vl-search-result - group story', () =
         cy.visit(searchResultGroupUrl);
 
         cy.get('vl-search-result').eq(1).shadow().find('vl-search-result-title');
+    });
+});
+
+describe('cypress-e2e - block components - vl-search-result - multiline title story', () => {
+    it('should render', () => {
+        cy.visit(searchResultMultilineTitleUrl);
+
+        cy.get('vl-search-result').shadow().find('vl-search-result-title');
     });
 });

--- a/libs/components/src/block/search-result/stories/vl-search-result.stories.ts
+++ b/libs/components/src/block/search-result/stories/vl-search-result.stories.ts
@@ -73,3 +73,19 @@ export const SearchResultGroup = () => html`
     </div>
 `;
 SearchResultGroup.storyName = 'vl-search-result - group';
+
+export const SearchResultMultilineTitle = () => html`
+    <vl-search-result>
+        <vl-search-result-title>
+            <a href="#">Een zeer lange zoekresultaat-titel die over meerdere regels loopt en de onderliggende inhoud niet mag overlappen</a>
+        </vl-search-result-title>
+        <vl-search-result-text>
+            <time>Maandag 22 oktober 2018</time>
+        </vl-search-result-text>
+        <vl-search-result-properties>
+            <label>Vlaanderenkiest.be</label>
+            <data>Verkiezingsresultaten op Vlaanderenkiest.be...</data>
+        </vl-search-result-properties>
+    </vl-search-result>
+`;
+SearchResultMultilineTitle.storyName = 'vl-search-result - multiline title';

--- a/libs/components/src/block/search-result/vl-search-result.component.cy.ts
+++ b/libs/components/src/block/search-result/vl-search-result.component.cy.ts
@@ -70,3 +70,48 @@ describe('cypress-component - block components - vl-search-result', () => {
             .should('contain.text', 'Vlaanderenkiest.be');
     });
 });
+
+describe('cypress-component - block components - vl-search-result - multiline title', () => {
+    it('should not overlap content below when title wraps to multiple lines', () => {
+        cy.viewport(400, 600);
+        cy.then(() => GlobalStyles.getInstance().register());
+        cy.mount(html`
+            <div class="snapshot-wrapper" style="width: 380px; padding: 20px; background: white;">
+                <vl-search-result>
+                    <vl-search-result-title>
+                        <a href="#">Een zeer lange zoekresultaat-titel die over meerdere regels loopt en de onderliggende inhoud niet mag overlappen</a>
+                    </vl-search-result-title>
+                    <vl-search-result-text>
+                        <time>Maandag 22 oktober 2018</time>
+                    </vl-search-result-text>
+                    <vl-search-result-properties>
+                        <label>Vlaanderenkiest.be</label>
+                        <data>Verkiezingsresultaten op Vlaanderenkiest.be...</data>
+                    </vl-search-result-properties>
+                </vl-search-result>
+            </div>
+        `);
+
+        cy.wait(100);
+        cy.get('.snapshot-wrapper').matchImageSnapshot('search-result-multiline-title');
+
+        // title must grow: its height should exceed one line-height (43.2px ≈ 2.7rem at 16px base)
+        cy.get('vl-search-result').shadow().find('vl-search-result-title').then(($title) => {
+            expect($title[0].getBoundingClientRect().height).to.be.greaterThan(44);
+        });
+
+        // text below must start after the title — no overlap
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-title')
+            .then(($title) => {
+                const titleBottom = $title[0].getBoundingClientRect().bottom;
+                cy.get('vl-search-result')
+                    .shadow()
+                    .find('vl-search-result-text')
+                    .then(($text) => {
+                        expect($text[0].getBoundingClientRect().top).to.be.gte(titleBottom);
+                    });
+            });
+    });
+});

--- a/libs/components/src/block/search-result/vl-search-result.css.ts
+++ b/libs/components/src/block/search-result/vl-search-result.css.ts
@@ -18,7 +18,8 @@ export const vlSearchResultStyles: CSSResult = css`
     vl-search-result-title {
         font-weight: 500;
         font-size: 2rem;
-        height: 2.7rem;
+        /* min-height matches line-height to keep the 1-line visual band; allows wrap for longer titles */
+        min-height: 2.7rem;
         line-height: 2.7rem;
 
         @media screen and (max-width: ${vlMediaScreenSmall}px) {


### PR DESCRIPTION
## Samenvatting

Vaste `height: 2.7rem` op `vl-search-result-title` vervangen door `min-height: 2.7rem` zodat titels die over meerdere regels lopen meegroeien en geen onderliggende content meer overlappen. Single-line titels blijven visueel identiek (`line-height: 2.7rem` ongewijzigd).

**Gekozen aanpak:** Voorstel 1 uit het refinement — `min-height` behoudt de expliciete visuele band van 2.7rem voor één-regel titels en is defensief tegenover slot-gebruik met kleine inline elementen.

## Wijzigingen

- `libs/components/src/block/search-result/vl-search-result.css.ts` — `height` → `min-height` (+ comment)
- `libs/components/src/block/search-result/stories/vl-search-result.stories.ts` — nieuwe story `SearchResultMultilineTitle`
- `libs/components/src/block/search-result/vl-search-result.component.cy.ts` — Cypress component test met visuele snapshot én bounding-box-assertions
- `apps/storybook-e2e/src/e2e/components/block/search-result/vl-search-result.stories.cy.ts` — E2E smoke-test voor de nieuwe story

## Succescriteria

- [x] `vl-search-result-title` groeit mee bij multi-line content
- [x] Geen overlap met `vl-search-result-text` / `vl-search-result-properties` / `vl-button` onder de titel
- [x] Single-line titels visueel identiek (`line-height` + `min-height` = 2.7rem)
- [x] Responsief gedrag onder `vlMediaScreenSmall` (1.6rem font-size) blijft correct
- [x] Visuele regression-test via `matchImageSnapshot('search-result-multiline-title')`

## Breaking changes

Geen — puur additieve layout-ruimte bij wrap.

## Jira

[FLUX-612](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-612)