### PR TITLE
fix: FLUX-616 - vl-select-rich / vl-textarea-rich - vl-input vuurt betrouwbaar bij user-edit

### DIFF
--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -506,6 +506,21 @@ describe('cypress-component - form components - vl-select-rich - single', () => 
         cy.get('@vl-input').should('to.not.have.been.called.at.all');
     });
 
+    it('should dispatch vl-input after user selects an option when options were loaded asynchronously', () => {
+        cy.mount(html`<vl-select-rich label="geboorteplaats"></vl-select-rich>`);
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.get('vl-select-rich').then((el) => {
+            const select = el[0] as VlSelectRichComponent;
+            select.options = options;
+        });
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click({ force: true });
+        cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+    });
+
     it('should dispatch vl-select-search event on input search value', () => {
         cy.mount(
             html`<vl-select-rich

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -36,6 +36,7 @@ export class VlSelectRichComponent extends FormControl {
     private dropdownInitialised = false;
     private isDropdownOpen = false;
     private dispatchInput = false;
+    private suppressUserInput = false;
     private initialised = false;
 
     constructor() {
@@ -162,6 +163,10 @@ export class VlSelectRichComponent extends FormControl {
             const detail = { value: this.getSelected() };
             this.setValue(this.value);
             this.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                this.dispatchInput = false;
+            }
             if (this.validity.valid) {
                 this.dispatchEventIfValid(detail);
             }
@@ -220,7 +225,6 @@ export class VlSelectRichComponent extends FormControl {
                 ?disabled=${this.disabled}
                 ?error=${this.error}
                 ?multiple=${this.multiple}
-                @change=${this.onInput}
                 @addItem=${this.onChange}
                 @removeItem=${this.onChange}
             ></select>
@@ -303,7 +307,12 @@ export class VlSelectRichComponent extends FormControl {
         if (!this.choices) {
             return;
         }
-        this.choices.setChoiceByValue(value);
+        this.suppressUserInput = true;
+        try {
+            this.choices.setChoiceByValue(value);
+        } finally {
+            this.suppressUserInput = false;
+        }
         this.setValue(this.collectFormData());
     }
 
@@ -316,10 +325,15 @@ export class VlSelectRichComponent extends FormControl {
             return;
         }
 
-        if (Array.isArray(value)) {
-            value.forEach((val) => this.choices!.removeActiveItemsByValue(val));
-        } else {
-            this.choices.removeActiveItemsByValue(value);
+        this.suppressUserInput = true;
+        try {
+            if (Array.isArray(value)) {
+                value.forEach((val) => this.choices!.removeActiveItemsByValue(val));
+            } else {
+                this.choices.removeActiveItemsByValue(value);
+            }
+        } finally {
+            this.suppressUserInput = false;
         }
         this.setValue(this.collectFormData());
     }
@@ -332,7 +346,12 @@ export class VlSelectRichComponent extends FormControl {
             return;
         }
 
-        this.choices.removeActiveItems();
+        this.suppressUserInput = true;
+        try {
+            this.choices.removeActiveItems();
+        } finally {
+            this.suppressUserInput = false;
+        }
         this.setValue(this.collectFormData());
     }
 
@@ -504,23 +523,16 @@ export class VlSelectRichComponent extends FormControl {
     }
 
     /**
-     * Event handler voor de change event van de select. Deze wordt aangeroepen wanneer de waarde van de
-     * select verandert, ongeacht de bron (bijv. door de gebruiker of door code).
+     * Event handler voor de addItem/removeItem events van Choices.js. Wordt consistent afgevuurd bij
+     * elke (de)selectie, onafhankelijk van sync of async options. Zet dispatchInput alleen bij
+     * user-driven interacties (suppressUserInput is false bij programmatische aanroepen).
      * @private
      */
     private onChange() {
+        if (!this.suppressUserInput) {
+            this.dispatchInput = true;
+        }
         this.value = this.collectFormData();
-    }
-
-    /**
-     * Event handler voor de input event van de select. Deze wordt aangeroepen wanneer de gebruiker
-     * de waarde van de select wijzigt.
-     * @private
-     */
-    private onInput() {
-        this.dispatchEvent(
-            new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: this.getSelected() } })
-        );
     }
 
     private onClickChoices = () => {

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
@@ -140,3 +140,33 @@ describe('vl-textarea-rich - properties & states', () => {
     });
 });
 
+describe('vl-textarea-rich - events', () => {
+    beforeEach(() => {
+        cy.viewport(1280, 720);
+    });
+
+    it('should dispatch vl-input when user types in the editor', () => {
+        cy.mount(html`<vl-textarea-rich label="omschrijving"></vl-textarea-rich>`);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
+        cy.get('vl-textarea-rich')
+            .shadow()
+            .find('.tox-edit-area__iframe')
+            .its('0.contentDocument.body')
+            .type('hallo', { force: true });
+        cy.get('@vl-input').should('have.been.called');
+        cy.get('@vl-change').should('have.been.called');
+    });
+
+    it('should not dispatch vl-input when value is set programmatically', () => {
+        cy.mount(html`<vl-textarea-rich label="omschrijving"></vl-textarea-rich>`);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
+        cy.get('vl-textarea-rich').then((el) => {
+            (el[0] as VlTextareaRichComponent).value = '<p>programmatisch</p>';
+        });
+        cy.get('@vl-change').should('have.been.calledOnce');
+        cy.get('@vl-input').should('not.have.been.called');
+    });
+});
+

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
@@ -136,7 +136,11 @@ export class VlTextareaRichComponent extends VlTextareaComponent {
 
         this.editor = tinymce.get(this.id) as Editor | null;
 
-        this.editor?.on('input change redo undo', () => {
+        this.editor?.on('input redo undo', () => {
+            this.dispatchInput = true;
+            this.value = this.editor?.getContent() || '';
+        });
+        this.editor?.on('change', () => {
             this.value = this.editor?.getContent() || '';
         });
 


### PR DESCRIPTION
## Jira
[FLUX-616](https://jira.omgeving.vlaanderen.be/browse/FLUX-616)

## Samenvatting

Zowel `vl-select-rich` als `vl-textarea-rich` vuurden het `@vl-input`-event
niet betrouwbaar: bij `vl-textarea-rich` nooit, bij `vl-select-rich` enkel
bij sync-geladen options. Beide zijn nu uitgelijnd met het library-brede
`dispatchInput`-patroon dat ook `vl-select` en `vl-textarea` hanteren.

### vl-select-rich
- `onChange()` bedient `@addItem`/`@removeItem` i.p.v. het onbetrouwbare
  native `change`-event op het interne `<select>` (wat door Choices.js
  niet gefire'd werd na `clearStore()` + `setChoices()`).
- `suppressUserInput`-flag via `try/finally` rond `setChoiceByValue` /
  `removeActiveItemsByValue` / `removeActiveItems` zorgt dat programmatische
  methoden (`selectByValue`, `removeSelectionByValue`, `removeAllSelections`)
  geen `vl-input` triggeren — nodig omdat Choices.js 11.1.0 deze events
  onvoorwaardelijk dispatcht, ongeacht `userTriggered`.
- Redundante `onInput()` + `@change`-listener verwijderd.

### vl-textarea-rich
- TinyMCE-handler gesplitst: `input`/`redo`/`undo` zetten `dispatchInput=true`;
  `change` niet (voorkomt dispatch-loop via `updated()` → `setContent()`).

## Succescriteria-checklist

- [x] `vl-textarea-rich` dispatcht `vl-input` bij user-edit (typen/paste/redo/undo).
- [x] `vl-textarea-rich` dispatcht géén `vl-input` bij page-load, programmatische `value`-set, of `resetFormControl()`.
- [x] `vl-select-rich` dispatcht `vl-input` bij user-selectie/verwijdering, ook bij async-geladen options.
- [x] `vl-select-rich` dispatcht géén `vl-input` bij `selectByValue()` / `removeSelectionByValue()` / initiële render.
- [x] `vl-change` semantiek onveranderd.
- [x] Nieuwe Cypress-tests dekken beide scenarios incl. async-options regressie.

## Test plan

- [ ] CI: bestaande test `should dispatch vl-change, but not vl-input when programmatically selecting and deleting option` (select-rich 477-507) blijft groen.
- [ ] CI: nieuwe test `should dispatch vl-input after user selects an option when options were loaded asynchronously`.
- [ ] CI: nieuwe tests `should dispatch vl-input when user types in the editor` + `should not dispatch vl-input when value is set programmatically` (textarea-rich).
- [ ] Manueel: consumer met `inputValidator` op `@vl-input` triggert validator niet bij page-load.
- [ ] Manueel: consumer met async options ziet `@vl-input` na user-select.