### PR TITLE
fix: FLUX-612 - vl-search-result-title - height naar min-height voor multiline wrapping

### DIFF
--- a/libs/components/src/block/search-result/vl-search-result.component.cy.ts
+++ b/libs/components/src/block/search-result/vl-search-result.component.cy.ts
@@ -59,6 +59,35 @@ describe('cypress-component - block components - vl-search-result', () => {
         });
     });
 
+    it('should not overlap sibling when title wraps over multiple lines', () => {
+        cy.mount(html`
+            <vl-search-result>
+                <vl-search-result-title>
+                    <a href="#">
+                        Dit is een heel lange zoekresultaattitel die zeker over meerdere regels wrapt in een normale viewport breedte zodat we overlap met de volgende sibling kunnen detecteren
+                    </a>
+                </vl-search-result-title>
+                <vl-search-result-text>
+                    <time>Maandag 22 oktober 2018</time>
+                </vl-search-result-text>
+            </vl-search-result>
+        `);
+
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-title')
+            .then(($title) => {
+                const titleBottom = $title[0].getBoundingClientRect().bottom;
+                cy.get('vl-search-result')
+                    .shadow()
+                    .find('vl-search-result-text')
+                    .then(($text) => {
+                        const textTop = $text[0].getBoundingClientRect().top;
+                        expect(textTop).to.be.gte(titleBottom);
+                    });
+            });
+    });
+
     it('should have properties', () => {
         // enkel een test dat de properties component correct werkt, de properties component zelf doet voldoende testen
         cy.get('vl-search-result')

--- a/libs/components/src/block/search-result/vl-search-result.css.ts
+++ b/libs/components/src/block/search-result/vl-search-result.css.ts
@@ -18,7 +18,7 @@ export const vlSearchResultStyles: CSSResult = css`
     vl-search-result-title {
         font-weight: 500;
         font-size: 2rem;
-        height: 2.7rem;
+        min-height: 2.7rem;
         line-height: 2.7rem;
 
         @media screen and (max-width: ${vlMediaScreenSmall}px) {


### PR DESCRIPTION
## Review van de draft - Kris S.

- in Storybook geverifieerd, de fix werkt.
- de Bamboo build is ok: https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC306

**Ready for review**

## Samenvatting

Eén-woord CSS-fix op `vl-search-result-title`: `height: 2.7rem` vervangen door `min-height: 2.7rem`. Daardoor wrapt een lange titel correct over meerdere regels en duwt hij sibling-elementen (bv. `vl-search-result-text`, een `vl-button`) mee naar beneden in plaats van erachter te overflown.

- `libs/components/src/block/search-result/vl-search-result.css.ts` — `height` → `min-height`
- `libs/components/src/block/search-result/vl-search-result.component.cy.ts` — bijkomende test met wrappende titel

Gevolgd voorstel: **Voorstel 1** uit het refinement (aanbeveling van agent 1). Voorstel 2 (`height` verwijderen + `line-height` normaliseren) bewust niet gekozen om breaking-change-risico bij consumers te vermijden.

## Succescriteria

- [x] `vl-search-result-title` met lange inhoud wrapt en duwt siblings mee naar beneden (geen overlap).
- [x] Korte, éénregelige titel behoudt dezelfde visuele baseline/hoogte (geen regressie) — `min-height` + onveranderde `line-height: 2.7rem` geven byte-identieke single-line rendering.
- [x] Styling blijft encapsuleerd in `vl-search-result.css.ts`; geen wijziging aan de publieke API.
- [x] Bestaande Cypress-assert op `font-size: 20px` blijft slagen; bijkomende test met lange titel toegevoegd.

## Review-notities

Reviewer merkte op dat de nieuwe Cypress-assert (`textTop >= titleBottom`) in block-layout met `overflow: visible` ook zou passeren met de oude bug — de assertie heeft dus vooral smoke-waarde en kan in een follow-up versterkt worden (bv. `titleRect.height > singleLine` of `anchorBottom <= titleBottom`). Fix zelf is correct en minimaal; niet-blokkerend.

## Jira

 https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-612
