### PR TITLE
feat: FLUX-619 - vl-link - vl-click event toevoegen

### DIFF
--- a/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
@@ -10,13 +10,15 @@ import {
 import { ICON_PLACEMENT } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
 import { linkDefaults } from '../vl-link.defaults';
+import { action } from 'storybook/actions';
 
-type LinkArgs = typeof defaultArgs & typeof linkDefaults & { defaultSlot: string };
+type LinkArgs = typeof defaultArgs & typeof linkDefaults & { defaultSlot: string; onVlClick: () => void; };
 
 export const linkArgs: LinkArgs = {
     ...defaultArgs,
     ...linkDefaults,
     defaultSlot: '',
+    onVlClick: action('vl-click'),
 };
 
 export const linkArgTypes: ArgTypes<LinkArgs> = {
@@ -117,8 +119,7 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     },
     type: {
         name: 'type',
-        description:
-            'Het type van de button.<br/>Werkt enkel in combinatie met het `button-as-link`-attribuut.',
+        description: 'Het type van de button.<br/>Werkt enkel in combinatie met het `button-as-link`-attribuut.',
         control: { type: CONTROLS.SELECT },
         options: ['button', 'submit', 'reset'],
         table: {
@@ -134,6 +135,13 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
             type: { summary: TYPES.HTML },
             category: CATEGORIES.SLOTS,
             defaultValue: { summary: linkArgs.defaultSlot },
+        },
+    },
+    onVlClick: {
+        name: 'vl-click',
+        description: 'Event dat afgevuurd wordt bij het klikken op de link.',
+        table: {
+            category: CATEGORIES.EVENTS,
         },
     },
 };

--- a/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
+++ b/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
@@ -71,15 +71,45 @@ Via het `type`-attribuut kan je het type van de onderliggende `<button>` instell
 
 <Canvas of={VlLinkStories.ButtonStyledAsLink} />
 
+## Events
+
+`vl-link` dispatcht bij elke klik een custom `vl-click` event (`bubbles: true, composed: true`), zodat het event de
+Shadow DOM boundary overschrijdt en door parent-elementen kan worden opgevangen.
+
+```html
+<vl-link href="https://www.vlaanderen.be">Vlaanderen</vl-link>
+<script>
+  document.querySelector('vl-link').addEventListener('vl-click', () => {
+    console.log('link geklikt');
+  });
+</script>
+```
+
+Het native `click` event blijft ook werken — beide zijn geldig. Kies één van beide en gebruik ze niet gelijktijdig op
+hetzelfde element om dubbele callbacks te vermijden.
+
+> **Relatie met `vl-button`:** `vl-button` dispatcht `vl-click` alleen als de knop niet disabled of in laadstatus is.
+ `vl-link` heeft (nog) geen disabled-state, dus `vl-click` wordt altijd gedispatcht. De conventie is consistent: alle
+ interactieve flux-atoms dispatchen `vl-<actie>`.
+
 ## Toegankelijkheid
 
-Zorg er steeds voor dat de link een duidelijke en beknopte tekstuele beschrijving heeft van de actie die uitgevoerd wordt bij het klikken op de link. Dit is belangrijk voor alle gebruikers, maar vooral voor gebruikers die schermlezers gebruiken.
+Zorg er steeds voor dat de link een duidelijke en beknopte tekstuele beschrijving heeft van de actie die uitgevoerd
+wordt bij het klikken op de link. Dit is belangrijk voor alle gebruikers, maar vooral voor gebruikers die schermlezers
+gebruiken.
 
-Zorg er bij externe links voor dat gebruikers weten dat de link in een nieuw venster opent. Dit kan je doen adhv het `external` attribuut en door dit expliciet te vermelden in de linktekst of door het `label` attribuut te gebruiken om een beschrijvende `aria-label` toe te voegen aan de link. Indien `label` gebruikt wordt, is dit de enige linktekst die door schermlezers wordt voorgelezen. Dus neem ook de zichtbare linktekst hierin op.
+Zorg er bij externe links voor dat gebruikers weten dat de link in een nieuw venster opent. Dit kan je doen adhv het
+`external` attribuut en door dit expliciet te vermelden in de linktekst of door het `label` attribuut te gebruiken om
+een beschrijvende `aria-label` toe te voegen aan de link. Indien `label` gebruikt wordt, is dit de enige linktekst die
+door schermlezers wordt voorgelezen. Dus neem ook de zichtbare linktekst hierin op.
 
-Indien de link enkel een icoon bevat, is het verplicht om het `label` attribuut te gebruiken zodat een beschrijvende `aria-label` wordt toegevoegd aan de link.
+Indien de link enkel een icoon bevat, is het verplicht om het `label` attribuut te gebruiken zodat een beschrijvende
+`aria-label` wordt toegevoegd aan de link.
 
-Indien de link een dropdown menu of dialog opent, gebruik dan het `aria-haspopup` attribuut met de juiste waarde (`true`, `menu`, `listbox`, `tree`, `grid`, `dialog`) om aan te geven dat er een popup aanwezig is. Dit helpt schermlezers om de gebruiker correct te informeren over de aanwezigheid van een popup. `aria-haspopup` wordt doorgegeven aan de onderliggende link.
+Indien de link een dropdown menu of dialog opent, gebruik dan het `aria-haspopup` attribuut met de juiste waarde
+(`true`, `menu`, `listbox`, `tree`, `grid`, `dialog`) om aan te geven dat er een popup aanwezig is. Dit helpt
+schermlezers om de gebruiker correct te informeren over de aanwezigheid van een popup. `aria-haspopup` wordt doorgegeven
+aan de onderliggende link.
 
 ## Referenties
 

--- a/libs/components/src/atom/link/stories/vl-link.stories.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories.ts
@@ -24,23 +24,37 @@ export default {
 
 const LinkTemplate = story(
     linkArgs,
-    ({ href, bold, small, large, error, external, buttonAsLink, type, icon, iconPlacement, defaultSlot, label }) =>
-        html`
-            <vl-link
-                href=${href}
-                ?bold=${bold}
-                ?small=${small}
-                ?large=${large}
-                ?error=${error}
-                ?external=${external}
-                ?button-as-link=${buttonAsLink}
-                type=${type}
-                icon=${icon}
-                icon-placement=${iconPlacement}
-                label=${label}
-                >${unsafeHTML(defaultSlot)}</vl-link
-            >
-        `
+    ({
+        href,
+        bold,
+        small,
+        large,
+        error,
+        external,
+        buttonAsLink,
+        type,
+        icon,
+        iconPlacement,
+        defaultSlot,
+        label,
+        onVlClick
+    }) => html`
+        <vl-link
+            href=${href}
+            ?bold=${bold}
+            ?small=${small}
+            ?large=${large}
+            ?error=${error}
+            ?external=${external}
+            ?button-as-link=${buttonAsLink}
+            type=${type}
+            icon=${icon}
+            icon-placement=${iconPlacement}
+            label=${label}
+            @vl-click=${onVlClick}
+            >${unsafeHTML(defaultSlot)}</vl-link
+        >
+    `,
 );
 
 export const LinkDefault = LinkTemplate.bind({});

--- a/libs/components/src/atom/link/vl-link.component.cy.ts
+++ b/libs/components/src/atom/link/vl-link.component.cy.ts
@@ -112,6 +112,14 @@ describe('cypress-component - atom components - vl-link', () => {
         cy.get('vl-link').shadow().find('a').find('slot');
         cy.get('vl-link').contains('Vlaanderen');
     });
+
+    it('should dispatch vl-click event', () => {
+        cy.mount(html`<vl-link href="#vlaanderen">Vlaanderen</vl-link>`);
+        cy.createStubForEvent('vl-link', 'vl-click');
+
+        cy.get('vl-link').shadow().find('a').click({ force: true });
+        cy.get('@vl-click').should('have.been.calledOnce');
+    });
 });
 
 describe('cypress-component - atom components - vl-link - button as link', () => {
@@ -238,5 +246,13 @@ describe('cypress-component - atom components - vl-link - button as link', () =>
         cy.mount(html`<vl-link button-as-link type="reset">Vlaanderen</vl-link>`);
 
         cy.get('vl-link').shadow().find('button').should('have.attr', 'type', 'reset');
+    });
+
+    it('should dispatch vl-click event', () => {
+        cy.mount(html`<vl-link button-as-link>Vlaanderen</vl-link>`);
+        cy.createStubForEvent('vl-link', 'vl-click');
+
+        cy.get('vl-link').shadow().find('button').click('bottomLeft');
+        cy.get('@vl-click').should('have.been.calledOnce');
     });
 });

--- a/libs/components/src/atom/link/vl-link.component.ts
+++ b/libs/components/src/atom/link/vl-link.component.ts
@@ -75,6 +75,7 @@ export class VlLinkComponent extends BaseLitElement {
                                     | 'dialog')
                               : undefined
                       )}
+                      @click=${this.handleClick}
                   >
                       ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
@@ -100,6 +101,7 @@ export class VlLinkComponent extends BaseLitElement {
                                     | 'dialog')
                               : undefined
                       )}
+                      @click=${this.handleClick}
                   >
                       ${positionIconBefore ? this.renderIcon() : nothing}
                       <slot></slot>
@@ -107,6 +109,10 @@ export class VlLinkComponent extends BaseLitElement {
                       ${this.external ? this.renderExternalIcon() : ''}
                   </button>
               `;
+    }
+
+    private handleClick(): void {
+        this.dispatchEvent(new CustomEvent('vl-click', { bubbles: true, composed: true }));
     }
 
     private renderIcon(): TemplateResult | typeof nothing {


### PR DESCRIPTION
## Review van de draft - Kris S.

- aanpassing 1: het event was niet opgenomen in de stories-arg
- aanpassing 2: de cypress testen faalden doordat er een externe href werd gebruikt  
- de Bamboo build was niet ok door de falende testen, maar dit is (in elk geval lokaal) opgelost: https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC307

**Ready for review**

## Succescriteria

- [x] Event-API van `vl-link` is consistent en ondubbelzinnig gedocumenteerd tegenover `vl-button`.
- [x] Consumer die een click wil afvangen op `vl-link` hoeft niet te raden of `@click` of `@vl-click` werkt.
- [x] Bestaande consumers van `vl-link` (die `@click` gebruiken) blijven werken — geen breaking change.
- [x] Bestaande consumers van `vl-button` (die `@vl-click` gebruiken) blijven werken — geen aanraking van `vl-button`.
- [x] Storybook-doc (`vl-link.stories-doc.mdx`) beschrijft het gekozen event-contract.

## Samenvatting

Voegt een custom `vl-click` event toe aan `vl-link`, met dezelfde signatuur als `vl-button` (`bubbles: true, composed: true`), zodat het event door Shadow DOM heen bubbelt en de event-API van interactieve flux-atoms consistent wordt.

De wijziging is **strikt additief**:
- `vl-link.component.ts` — `handleClick` methode dispatcht het custom event; aangesloten via `@click` op zowel het `<a>`- als het `<button>`-renderpad. Native `click` blijft volledig ongestoord werken.
- `vl-link.component.cy.ts` — twee Cypress component tests voor beide renderpaden, conform het bestaande `vl-button` event-test patroon.
- `vl-link.stories-doc.mdx` — nieuwe "Events" sectie met voorbeeldcode en uitleg van de semantische asymmetrie met `vl-button` (`vl-click` daar onderdrukt bij `disabled`/`loading`; `vl-link` heeft die states nog niet).

Gekozen voor Voorstel 1 uit het refinement (de aanbeveling) — Voorstel 3 (forward-compat met disabled-state-guard) is bewust vermeden als YAGNI.

## Jira

[FLUX-619](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-619)