### PR TITLE
fix: FLUX-631 - vl-textarea-rich - vl-input event dispatchen bij gebruikersinvoer

### DIFF
--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
@@ -140,3 +140,38 @@ describe('vl-textarea-rich - properties & states', () => {
     });
 });
 
+describe('vl-textarea-rich - events', () => {
+    it('should dispatch vl-input and vl-change on TinyMCE input event', () => {
+        cy.mount(html`<vl-textarea-rich></vl-textarea-rich>`);
+        cy.wait(500);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
+
+        cy.get('vl-textarea-rich').then(($el) => {
+            const el = $el.get(0) as Element & { id: string };
+            cy.window().then((win: Window & { tinymce?: { get: (id: string) => { setContent: (c: string) => void; fire: (e: string) => void } | null } }) => {
+                const editor = win.tinymce?.get(el.id);
+                editor?.setContent('<p>test</p>');
+                editor?.fire('input');
+            });
+        });
+
+        cy.get('@vl-input').its('callCount').should('eq', 1);
+        cy.get('@vl-input').its('lastCall.args.0.detail.value').should('include', 'test');
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+    });
+
+    it('should not dispatch vl-input on programmatic value change', () => {
+        cy.mount(html`<vl-textarea-rich></vl-textarea-rich>`);
+        cy.wait(500);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
+
+        cy.get('vl-textarea-rich').invoke('attr', 'value', '<p>programmatic test</p>');
+
+        cy.get('@vl-change').its('callCount').should('eq', 1);
+        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: '<p>programmatic test</p>' });
+        cy.get('@vl-input').its('callCount').should('eq', 0);
+    });
+});
+

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
@@ -137,6 +137,7 @@ export class VlTextareaRichComponent extends VlTextareaComponent {
         this.editor = tinymce.get(this.id) as Editor | null;
 
         this.editor?.on('input change redo undo', () => {
+            this.dispatchInput = true;
             this.value = this.editor?.getContent() || '';
         });
 


### PR DESCRIPTION
## Review van de draft - Kris S.

- in Storybook geverifieerd, de fix werkt.
- de Bamboo build was initieel niet ok, maar dat is een header test die faalt, daar is geen impact op, flackyness, build opnieuw gestart : https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC308

**Ready for review**

## Samenvatting

`vl-textarea-rich` documenteerde (via de geërfde args van `vl-textarea`) een
`vl-input` event dat bij gebruikers-input afgevuurd zou worden. In de praktijk
kwam dit event nooit door — noch bij consumers, noch op de Storybook
docs-pagina. Oorzaak: de TinyMCE-listener zette wel `this.value`, maar niet
`this.dispatchInput = true`, waardoor het dispatch-mechanisme in
`VlTextareaComponent.updated()` de `vl-input` oversloeg.

### Wat verandert

- **`vl-textarea-rich.component.ts`**: één regel toegevoegd
  (`this.dispatchInput = true`) in de TinyMCE `input change redo undo`
  listener, vóór de `value`-toewijzing. Voorstel 1 uit het refinement-rapport.
- **`vl-textarea-rich.component.cy.ts`**: nieuw `events` describe-blok met
  twee Cypress component-tests.

## Succescriteria-checklist

- [x] Bij elke gebruikers-wijziging in TinyMCE (typen, plakken, undo, redo)
      wordt één `vl-input` event afgevuurd op de `vl-textarea-rich` host.
- [x] De `detail` payload bevat `{ value: string }` met de actuele HTML,
      consistent met `vl-textarea`.
- [x] Programmatisch wijzigen van `value` (attribuut/property) dispatcht
      geen `vl-input` — enkel `vl-change`.
- [x] `vl-change` blijft werken en `vl-input` begint óók te triggeren op de
      Storybook docs-pagina van `vl-textarea-rich`.
- [x] Component-test dekt het event af (zowel user-input als
      programmatische-update).

## Trade-offs

Gekozen voor Voorstel 1 (flag zetten) boven Voorstel 2 (direct dispatchen):
geen duplicatie van het event-contract, parent garandeert event-volgorde
(`vl-change` → `vl-input`) in één `updated()`-cyclus, en consistent met het
patroon in `vl-textarea` zelf.

## Risico's

- `editor.setContent()` in `updated()` triggert standaard geen TinyMCE
  `input`/`change` — dit is impliciet TinyMCE-gedrag, expliciet afgedekt
  door de tweede test (`should not dispatch vl-input on programmatic value
  change`).
- Geen breaking changes: consumers die al op `vl-change` leunen blijven
  werken; `vl-input` begint nu enkel ook te vuren zoals de docs al
  beloofden.

## Jira

 https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-631