### PR TITLE
feat: FLUX-609 - vl-properties - voorkom zichtbare Lit-markers in label/data

### DIFF
--- a/libs/components/src/block/properties/vl-properties.builder.spec.ts
+++ b/libs/components/src/block/properties/vl-properties.builder.spec.ts
@@ -25,12 +25,12 @@ describe('jest - components - vl-properties', () => {
             {
                 items: [
                     {
-                        labels: ['Woonplaats'],
-                        data: ['Brussel'],
+                        labels: [[document.createTextNode('Woonplaats')]],
+                        data: [[document.createTextNode('Brussel')]],
                     },
                     {
-                        labels: ['Postcode'],
-                        data: ['1000'],
+                        labels: [[document.createTextNode('Postcode')]],
+                        data: [[document.createTextNode('1000')]],
                     },
                 ],
             },
@@ -96,15 +96,42 @@ describe('jest - components - vl-properties', () => {
                 class: 'column',
                 items: [
                     {
-                        labels: ['Woonplaats'],
-                        data: ['Brussel'],
+                        labels: [[document.createTextNode('Woonplaats')]],
+                        data: [[document.createTextNode('Brussel')]],
                     },
                     {
-                        labels: ['Postcode'],
-                        data: ['1000'],
+                        labels: [[document.createTextNode('Postcode')]],
+                        data: [[document.createTextNode('1000')]],
                     },
                 ],
             },
         ]);
+    });
+
+    it('buildProperties should handle Lit-binding comment markers without serialising them as text', () => {
+        const labelElement = document.createElement('label');
+        labelElement.appendChild(document.createComment('?lit$34872438$0?'));
+        labelElement.appendChild(document.createTextNode('Dynamische waarde'));
+        labelElement.appendChild(document.createComment('?'));
+
+        const dataElement = document.createElement('data');
+        dataElement.appendChild(document.createComment('?lit$34872438$0?'));
+        dataElement.appendChild(document.createTextNode('42'));
+        dataElement.appendChild(document.createComment('?'));
+
+        const result = buildProperties([labelElement, dataElement], false);
+
+        expect(result).toHaveLength(1);
+        const item = result[0].items[0];
+        const labelNodes = item.labels[0] as Node[];
+        const dataNodes = item.data[0] as Node[];
+        expect(labelNodes).toHaveLength(3);
+        expect(labelNodes[0].nodeType).toBe(Node.COMMENT_NODE);
+        expect(labelNodes[1].nodeType).toBe(Node.TEXT_NODE);
+        expect((labelNodes[1] as Text).textContent).toBe('Dynamische waarde');
+        expect(labelNodes[2].nodeType).toBe(Node.COMMENT_NODE);
+        expect(dataNodes).toHaveLength(3);
+        expect(dataNodes[1].nodeType).toBe(Node.TEXT_NODE);
+        expect((dataNodes[1] as Text).textContent).toBe('42');
     });
 });

--- a/libs/components/src/block/properties/vl-properties.builder.ts
+++ b/libs/components/src/block/properties/vl-properties.builder.ts
@@ -5,8 +5,8 @@ const moveChildNodes = (childNodes: ChildNode[], clone: boolean): Node[] =>
 
 const buildItems = (elements: Element[], clone: boolean): Item[] => {
     const items: Item[] = [];
-    let labels: any[] = [],
-        data: any[] = [];
+    let labels: Node[][] = [],
+        data: Node[][] = [];
 
     elements.forEach((element: Element) => {
         switch (element.localName) {
@@ -18,15 +18,11 @@ const buildItems = (elements: Element[], clone: boolean): Item[] => {
                     labels = [];
                     data = [];
                 }
-                labels.push(
-                    element.children.length > 0 ? moveChildNodes([...element.childNodes], clone) : element.innerHTML,
-                );
+                labels.push(moveChildNodes([...element.childNodes], clone));
                 break;
             case 'data':
             case 'vl-property-data':
-                data.push(
-                    element.children.length > 0 ? moveChildNodes([...element.childNodes], clone) : element.innerHTML,
-                );
+                data.push(moveChildNodes([...element.childNodes], clone));
                 break;
         }
     });


### PR DESCRIPTION
## Review van de draft - Kris S.

- in Storybook geverifieerd, de stories zijn niet gewijzigd maar renderen nog zoals voordien
- de Bamboo build was initieel niet ok, maar die faalde om een onduidelijke rede op de finalise-release stap, de feitelijke build en testen waren ok: https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC309

**Ready for review**

## Context

Jira: [FLUX-609]( https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-609)

Consumers die `vl-properties` gebruiken met Lit-bindings in `<label>`/`<data>` (bv. `<data>${x}</data>`) zagen lit-marker comments (`<!--?lit$…?-->`) als letterlijke tekst verschijnen. Workaround was een extra `<span>` wrappen; dit ticket fixt het structureel.

## Root cause
In `vl-properties.builder.ts::buildItems` stond een ternary:
`element.children.length > 0 ? moveChildNodes(...) : element.innerHTML`.
Bij een Lit-binding zijn de childNodes `[Comment, Text, Comment]` — `element.children` (alleen Elements) telt er 0, dus de `innerHTML`-tak werd gekozen. `innerHTML` serialiseert de comment-markers mee als string, die Lit vervolgens als tekst rendert.

## Fix
Altijd `moveChildNodes([...element.childNodes], clone)` gebruiken. Comment-nodes blijven DOM-comments (onzichtbaar), Text-nodes renderen als tekst, Element-children renderen ongewijzigd. Eén pad, geen string-serialisatie.

## Succescriteria
- [x] `<vl-properties><label>${expr}</label><data>${expr}</data></vl-properties>` rendert zonder zichtbare lit-markers
- [x] Extra `<span>`-wrap is niet meer nodig
- [x] Bestaande patterns (plain text, HTML-rijke labels, columns via `<div>`) werken identiek
- [x] Reactieve Lit-bindings vloeien door (mutation observer flow onveranderd)
- [x] Unit-tests in `vl-properties.builder.spec.ts` dekken het Lit-marker scenario

## API-impact
Geen. Publieke `Item`-type (`string[] | Node[][]`) in `vl-properties.model.ts` is ongewijzigd. Slots/attributes/events/accessibility onveranderd.

## Test
- Jest components: 36/36 groen (incl. nieuwe marker-test)
- TypeScript `tsc --noEmit`: clean
- Cypress: niet lokaal gedraaid; gedragspad via bestaande component cy-tests ongewijzigd

## Test plan
- [ ] Integrator / consumer app checken: Lit-template met `<vl-properties><label>${label}</label><data>${value}</data></vl-properties>` rendert nu zonder marker-tekst
- [x] Bestaande stories in Storybook (plain-text, HTML-rijke labels, columns) visueel identiek
- [ ] Reactieve update op een gebonden `value` vloeit door naar de `<dd>`