### PR TITLE
feat: FLUX-616 - vl-select-rich / vl-textarea-rich - vl-input event bij gebruikersinteractie

### DIFF
--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -506,6 +506,103 @@ describe('cypress-component - form components - vl-select-rich - single', () => 
         cy.get('@vl-input').should('to.not.have.been.called.at.all');
     });
 
+    it('should dispatch vl-input when user selects after async options load', () => {
+        cy.mount(html`<vl-select-rich label="geboorteplaats"></vl-select-rich>`);
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).options = [
+                { label: 'Hasselt', value: 'hasselt' },
+                { label: 'Turnhout', value: 'turnhout' },
+            ];
+        });
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click({ force: true });
+        cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+    });
+
+    it('should NOT dispatch vl-input when options are loaded programmatically with pre-selected values', () => {
+        cy.mount(html`<vl-select-rich label="geboorteplaats"></vl-select-rich>`);
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).options = [
+                { label: 'Hasselt', value: 'hasselt', selected: true },
+                { label: 'Turnhout', value: 'turnhout' },
+            ];
+        });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+    });
+
+    it('should dispatch vl-input when user selects after options are loaded asynchronously', () => {
+        cy.mount(html`<vl-select-rich label="geboorteplaats"></vl-select-rich>`);
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.get('vl-select-rich').then(
+            (el) =>
+                new Cypress.Promise<void>((resolve) => {
+                    setTimeout(() => {
+                        (el[0] as VlSelectRichComponent).options = [
+                            { label: 'Hasselt', value: 'hasselt' },
+                            { label: 'Turnhout', value: 'turnhout' },
+                        ];
+                        resolve();
+                    }, 250);
+                })
+        );
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click({ force: true });
+        cy.get('vl-select-rich').shadow().find('.vl-select__list').find('.vl-select__item').contains('Hasselt').click();
+        cy.get('@vl-input')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+    });
+
+    it('should dispatch vl-change but NOT vl-input on selectByValue / removeSelectionByValue / removeAllSelections', () => {
+        cy.mount(html`<vl-select-rich label="geboorteplaats" .options=${options}></vl-select-rich>`);
+        cy.createStubForEvent('vl-select-rich', 'vl-change');
+        cy.createStubForEvent('vl-select-rich', 'vl-input');
+        cy.injectAxe();
+        cy.checkA11y('vl-select-rich');
+
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).selectByValue('hasselt');
+        });
+        cy.get('@vl-change')
+            .should('have.been.calledTwice')
+            .its('secondCall.args.0.detail')
+            .should('deep.equal', { value: 'hasselt' });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).removeSelectionByValue('hasselt');
+        });
+        cy.get('@vl-change')
+            .should('have.been.calledThrice')
+            .its('thirdCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).selectByValue('turnhout');
+        });
+        cy.get('@vl-change')
+            .should('have.callCount', 4)
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { value: 'turnhout' });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+
+        cy.get('vl-select-rich').then((el) => {
+            (el[0] as VlSelectRichComponent).removeAllSelections();
+        });
+        cy.get('@vl-change')
+            .should('have.callCount', 5)
+            .its('lastCall.args.0.detail')
+            .should('deep.equal', { value: null });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+    });
+
     it('should dispatch vl-select-search event on input search value', () => {
         cy.mount(
             html`<vl-select-rich

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -153,6 +153,8 @@ export class VlSelectRichComponent extends FormControl {
                 this.choices.setChoices(this.options, 'value', 'label', true);
                 this.updateSelectedOptions(this.options);
             }
+            // Guard: programmatische options-update mag geen vl-input triggeren
+            this.dispatchInput = false;
             if (VlSelectRichComponent.compareValue(this.value, changedProperties.has('value'))) {
                 this.value = this.collectFormData();
             }
@@ -162,6 +164,10 @@ export class VlSelectRichComponent extends FormControl {
             const detail = { value: this.getSelected() };
             this.setValue(this.value);
             this.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true, detail }));
+            if (this.dispatchInput) {
+                this.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail }));
+                this.dispatchInput = false;
+            }
             if (this.validity.valid) {
                 this.dispatchEventIfValid(detail);
             }
@@ -220,7 +226,6 @@ export class VlSelectRichComponent extends FormControl {
                 ?disabled=${this.disabled}
                 ?error=${this.error}
                 ?multiple=${this.multiple}
-                @change=${this.onInput}
                 @addItem=${this.onChange}
                 @removeItem=${this.onChange}
             ></select>
@@ -240,6 +245,7 @@ export class VlSelectRichComponent extends FormControl {
         this.choices?.clearStore();
         this.choices?.setChoices(this.options, 'value', 'label', true);
         this.updateSelectedOptions(this.initialOptions);
+        this.dispatchInput = false;
         this.value = this.collectFormData();
     }
 
@@ -304,6 +310,7 @@ export class VlSelectRichComponent extends FormControl {
             return;
         }
         this.choices.setChoiceByValue(value);
+        this.dispatchInput = false;
         this.setValue(this.collectFormData());
     }
 
@@ -321,6 +328,7 @@ export class VlSelectRichComponent extends FormControl {
         } else {
             this.choices.removeActiveItemsByValue(value);
         }
+        this.dispatchInput = false;
         this.setValue(this.collectFormData());
     }
 
@@ -333,6 +341,7 @@ export class VlSelectRichComponent extends FormControl {
         }
 
         this.choices.removeActiveItems();
+        this.dispatchInput = false;
         this.setValue(this.collectFormData());
     }
 
@@ -504,23 +513,13 @@ export class VlSelectRichComponent extends FormControl {
     }
 
     /**
-     * Event handler voor de change event van de select. Deze wordt aangeroepen wanneer de waarde van de
-     * select verandert, ongeacht de bron (bijv. door de gebruiker of door code).
+     * Event handler voor addItem/removeItem events van Choices.js — vuurt alleen bij echte
+     * gebruikersinteractie (selecteren of verwijderen via UI).
      * @private
      */
     private onChange() {
+        this.dispatchInput = true;
         this.value = this.collectFormData();
-    }
-
-    /**
-     * Event handler voor de input event van de select. Deze wordt aangeroepen wanneer de gebruiker
-     * de waarde van de select wijzigt.
-     * @private
-     */
-    private onInput() {
-        this.dispatchEvent(
-            new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: this.getSelected() } })
-        );
     }
 
     private onClickChoices = () => {

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
@@ -4,6 +4,52 @@ import { VlTextareaRichComponent } from './vl-textarea-rich.component';
 
 registerWebComponents([VlTextareaRichComponent]);
 
+describe('vl-textarea-rich - vl-input event', () => {
+    beforeEach(() => {
+        cy.viewport(1280, 720);
+    });
+
+    it('should dispatch vl-input when user types in editor', () => {
+        cy.mount(html`<vl-textarea-rich label="test"></vl-textarea-rich>`);
+        cy.wait(1000);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.get('vl-textarea-rich').then(($el) => {
+            const editor = ($el[0] as any).editor;
+            if (editor) {
+                // Stel body HTML rechtstreeks in (vermijdt TinyMCE 'change'-event dat via setContent vuurt)
+                // zodat fire('input') de value wél als gewijzigd beschouwt en vl-input dispatcht.
+                editor.getBody().innerHTML = '<p>Hello</p>';
+                editor.fire('input');
+            }
+        });
+        cy.get('@vl-input').should('have.been.calledOnce');
+    });
+
+    it('should dispatch vl-change when user types in editor', () => {
+        cy.mount(html`<vl-textarea-rich label="test"></vl-textarea-rich>`);
+        cy.wait(1000);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
+        cy.get('vl-textarea-rich').then(($el) => {
+            const editor = ($el[0] as any).editor;
+            if (editor) {
+                editor.getBody().innerHTML = '<p>Hello</p>';
+                editor.fire('input');
+            }
+        });
+        cy.get('@vl-change').should('have.been.calledOnce');
+    });
+
+    it('should NOT dispatch vl-input when value is set programmatically', () => {
+        cy.mount(html`<vl-textarea-rich label="test"></vl-textarea-rich>`);
+        cy.wait(1000);
+        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
+        cy.get('vl-textarea-rich').then(($el) => {
+            ($el[0] as any).value = '<p>programmatic content</p>';
+        });
+        cy.get('@vl-input').should('to.not.have.been.called.at.all');
+    });
+});
+
 describe('vl-textarea-rich - properties & states', () => {
     beforeEach(() => {
         cy.viewport(1280, 720);
@@ -139,39 +185,3 @@ describe('vl-textarea-rich - properties & states', () => {
         cy.get('.snapshot-wrapper').matchImageSnapshot('textarea-rich-height-large');
     });
 });
-
-describe('vl-textarea-rich - events', () => {
-    it('should dispatch vl-input and vl-change on TinyMCE input event', () => {
-        cy.mount(html`<vl-textarea-rich></vl-textarea-rich>`);
-        cy.wait(500);
-        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
-        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
-
-        cy.get('vl-textarea-rich').then(($el) => {
-            const el = $el.get(0) as Element & { id: string };
-            cy.window().then((win: Window & { tinymce?: { get: (id: string) => { setContent: (c: string) => void; fire: (e: string) => void } | null } }) => {
-                const editor = win.tinymce?.get(el.id);
-                editor?.setContent('<p>test</p>');
-                editor?.fire('input');
-            });
-        });
-
-        cy.get('@vl-input').its('callCount').should('eq', 1);
-        cy.get('@vl-input').its('lastCall.args.0.detail.value').should('include', 'test');
-        cy.get('@vl-change').its('callCount').should('eq', 1);
-    });
-
-    it('should not dispatch vl-input on programmatic value change', () => {
-        cy.mount(html`<vl-textarea-rich></vl-textarea-rich>`);
-        cy.wait(500);
-        cy.createStubForEvent('vl-textarea-rich', 'vl-input');
-        cy.createStubForEvent('vl-textarea-rich', 'vl-change');
-
-        cy.get('vl-textarea-rich').invoke('attr', 'value', '<p>programmatic test</p>');
-
-        cy.get('@vl-change').its('callCount').should('eq', 1);
-        cy.get('@vl-change').its('lastCall.args.0.detail').should('deep.equal', { value: '<p>programmatic test</p>' });
-        cy.get('@vl-input').its('callCount').should('eq', 0);
-    });
-});
-

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.ts
@@ -136,8 +136,11 @@ export class VlTextareaRichComponent extends VlTextareaComponent {
 
         this.editor = tinymce.get(this.id) as Editor | null;
 
-        this.editor?.on('input change redo undo', () => {
+        this.editor?.on('input', () => {
             this.dispatchInput = true;
+            this.value = this.editor?.getContent() || '';
+        });
+        this.editor?.on('change redo undo', () => {
             this.value = this.editor?.getContent() || '';
         });
 


### PR DESCRIPTION
## Review van de draft - Kris S.

- de Bamboo build was niet ok door een falende flacky test - niet gerelateerd: https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC311
- geverifieerd in Storybook
- de 2 test issues:
   laad `options` asynchroon en selecteer pas daarna — `vl-input` moet afgaan
   roep `selectByValue` / `removeSelectionByValue` / `removeAllSelections` / `resetFormControl` aan — geen `vl-input`
 -> voor beide is een extra Cypress test geschreven

**Ready for review**

## Jira

[FLUX-616](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-616)

## Samenvatting

Spiegelt het `dispatchInput`-patroon uit `VlTextareaComponent` in `vl-textarea-rich` en `vl-select-rich` zodat `vl-input` strikt alleen bij user-interactie vuurt en nooit bij programmatische mutaties, init of async options-load. `vl-change` gedrag blijft identiek; additieve, non-breaking fix.

### vl-textarea-rich

- TinyMCE listener gesplitst: `input` zet `dispatchInput = true`; `change redo undo` updaten enkel de waarde zonder flag.
- Parent `VlTextareaComponent.updated()` dispatcht `vl-input` op basis van de flag.

### vl-select-rich

- Fragiele `onInput()` op native `<select>` `@change` verwijderd (inclusief template-binding).
- `dispatchInput` wordt nu alleen in `onChange()` (addItem/removeItem van Choices.js) gezet — exclusief user-interactie.
- Expliciete `dispatchInput = false`-guards in `resetFormControl`, `selectByValue`, `removeSelectionByValue`, `removeAllSelections` én in de `options`-tak van `updated()`.

## Succescriteria

- [x] `vl-textarea-rich` dispatcht `vl-input` bij user-typen / plakken / formatteren.
- [x] `vl-textarea-rich` dispatcht geen `vl-input` bij programmatische `value`-wijzigingen of init.
- [x] `vl-select-rich` dispatcht `vl-input` bij user-selectie, ook na async options-load.
- [x] `vl-select-rich` dispatcht geen `vl-input` bij programmatische mutatie van `options` of `value` (incl. pre-selected opties in async load).
- [x] `vl-change` blijft werken zoals vandaag in beide componenten.

## Test plan

- [x] `vl-textarea-rich`: typ in de editor, bevestig dat `vl-input` afgaat; zet `value` programmatisch, bevestig dat `vl-input` niet afgaat.
- [x] `vl-select-rich`: selecteer een optie via de dropdown, bevestig `vl-input`; laad `options` asynchroon en selecteer pas daarna — `vl-input` moet afgaan.
- [x] `vl-select-rich`: laad `options` programmatisch met `selected: true` — geen `vl-input`.
- [x] `vl-select-rich`: roep `selectByValue` / `removeSelectionByValue` / `removeAllSelections` / `resetFormControl` aan — geen `vl-input`.
- [ ] Geen regressies in bestaande `vl-change`-consumers.