### PR TITLE
feat: FLUX-632 - vl-properties - rij-uitlijning tussen kolommen

### DIFF
--- a/libs/components/src/block/properties/stories/vl-properties.stories.ts
+++ b/libs/components/src/block/properties/stories/vl-properties.stories.ts
@@ -95,11 +95,27 @@ export const PropertiesColumns = story(
                 <label>Postcode</label>
                 <data>1000</data>
             </div>
+            <div class="column">
+                <label>Woonplaats</label>
+                <data>Antwerpen</data>
+            </div>
+            <div class="column">
+                <label>Postcode langer</label>
+                <data>1000</data>
+            </div>
+            <div class="column">
+                <label>Woonplaats</label>
+                <data>Gent</data>
+            </div>
+            <div class="column">
+                <label>Postcode</label>
+                <data>1000</data>
+            </div>
             <div class="column column--full-width">
                 <label>Gewest</label>
-                <data>Brussel</data>
+                <data>Hier komt het gewest waar je woont, dit kan best lang zijn.</data>
             </div>
         </vl-properties>
-    `
+    `,
 );
 PropertiesColumns.storyName = 'vl-properties - columns';

--- a/libs/components/src/block/properties/vl-properties.component.cy.ts
+++ b/libs/components/src/block/properties/vl-properties.component.cy.ts
@@ -43,6 +43,29 @@ const propertiesColumnsTemplate = html`
     </vl-properties>
 `;
 
+// Column 1 has a 2-line label (via block spans) to force a taller row than column 2.
+// Used to verify that CSS Grid cross-column row alignment holds even when label heights differ.
+const propertiesColumnsAlignmentTemplate = html`
+    <vl-properties>
+        <div class="column">
+            <label><span style="display:block">Eerste regel</span><span style="display:block">Tweede regel</span></label>
+            <data>Waarde 1</data>
+            <label>Kort label</label>
+            <data>Waarde 2</data>
+        </div>
+        <div class="column">
+            <label>Kort</label>
+            <data>Waarde A</data>
+            <label>Kort</label>
+            <data>Waarde B</data>
+        </div>
+        <div class="column column--full-width">
+            <label>Volledig</label>
+            <data>Waarde X</data>
+        </div>
+    </vl-properties>
+`;
+
 const propertiesWithPropsTemplate = ({ props }: PropertiesDefaultTypes = {}) => html`
     <vl-properties .props=${props}>
         <label>Woonplaats</label>
@@ -199,6 +222,48 @@ describe('cypress-component - block components - vl-properties', () => {
                                 cy.get('dd').eq(1).should('contain.text', 'Perenstraat');
                             });
                     });
+            });
+    });
+
+    it('should align items at the same vertical position across columns', () => {
+        cy.mount(propertiesColumnsAlignmentTemplate);
+
+        cy.get('vl-properties')
+            .shadow()
+            .find('dl')
+            .then(($dl) => {
+                const dl = $dl[0];
+                const col1Items = dl.querySelectorAll<HTMLElement>('.column:nth-child(1) .item');
+                const col2Items = dl.querySelectorAll<HTMLElement>('.column:nth-child(2) .item');
+
+                expect(col1Items.length).to.equal(2);
+                expect(col2Items.length).to.equal(2);
+
+                [...col1Items].forEach((item1, i) => {
+                    const top1 = item1.getBoundingClientRect().top;
+                    const top2 = col2Items[i].getBoundingClientRect().top;
+                    expect(top1, `items at index ${i} should start at the same vertical position`).to.equal(top2);
+                });
+            });
+    });
+
+    it('should place the full-width column below both regular columns', () => {
+        cy.mount(propertiesColumnsAlignmentTemplate);
+
+        cy.get('vl-properties')
+            .shadow()
+            .find('dl')
+            .then(($dl) => {
+                const dl = $dl[0];
+                const col1Items = dl.querySelectorAll<HTMLElement>('.column:nth-child(1) .item');
+                const fullWidthItems = dl.querySelectorAll<HTMLElement>('.column--full-width .item');
+
+                expect(fullWidthItems.length).to.be.greaterThan(0);
+
+                const lastCol1Bottom = col1Items[col1Items.length - 1].getBoundingClientRect().bottom;
+                const fullWidthTop = fullWidthItems[0].getBoundingClientRect().top;
+
+                expect(fullWidthTop).to.be.gte(lastCol1Bottom);
             });
     });
 

--- a/libs/components/src/block/properties/vl-properties.css.ts
+++ b/libs/components/src/block/properties/vl-properties.css.ts
@@ -1,12 +1,6 @@
 import { vlMediaScreenSmall } from '@domg-wc/styles';
 import { css, CSSResult } from 'lit';
 
-const columnWidth = (widthPercentage: number): CSSResult => {
-    return css`
-        width: calc(${widthPercentage}% - 1rem);
-    `;
-};
-
 const collapsedDt = (): CSSResult => {
     return css`
         font-size: 1.6rem;
@@ -42,8 +36,15 @@ export const sizeQueryStyles = css`
             grid-template-columns: 100%;
         }
 
-        .column {
-            ${columnWidth(100)};
+        /* Collapse 2-column grid to single column on small screens */
+        dl:has(> .column) {
+            grid-template-columns: 1fr;
+        }
+
+        /* Reset column placement so all items stack in a single column */
+        .column:nth-child(1):not(.column--full-width) > .item,
+        .column:nth-child(2):not(.column--full-width) > .item {
+            grid-column: 1;
         }
 
         dd {
@@ -61,14 +62,9 @@ export const propertiesStyles: CSSResult = css`
         display: block;
     }
 
+    /* display:contents makes .column transparent to the dl grid while keeping DOM structure */
     .column {
-        ${columnWidth(50)};
-        float: left;
-    }
-
-    .column--full-width {
-        ${columnWidth(100)};
-        float: left;
+        display: contents;
     }
 
     dl {
@@ -81,9 +77,30 @@ export const propertiesStyles: CSSResult = css`
         margin-block: 0;
     }
 
+    /* Override to CSS Grid when columns are present; same specificity as dl:has(.item) so
+       source order (this rule comes after) makes display:grid win for the column case */
+    dl:has(> .column) {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+    }
+
     dl .item {
         display: grid;
         padding-bottom: 2rem;
+    }
+
+    /* Place items from the first and second column into their respective grid tracks.
+       Items from both columns share row tracks in the dl grid, achieving cross-column alignment. */
+    .column:nth-child(1):not(.column--full-width) > .item {
+        grid-column: 1;
+    }
+
+    .column:nth-child(2):not(.column--full-width) > .item {
+        grid-column: 2;
+    }
+
+    .column--full-width > .item {
+        grid-column: 1 / -1;
     }
 
     dt {


### PR DESCRIPTION
## Review van de draft - Kris S.

- de Bamboo build faalt - te bekijken: https://www.milieuinfo.be/bamboo/browse/FLUX-CFWC312
- de implementatie is ok, maar bij nakijken: ook de huidige implementatie geeft het verwachte resultaat, ik breide als  
test de story 'vl-properties - columns' uit (zie de extra commit), die werkt correct in deze branch, maar ook met de vorige versie

**Nagevraagd bij Maarten Aerts - eerst antwoord afwachten**

## Samenvatting

Items op dezelfde index in een 2-kolom `vl-properties` lijnen nu verticaal uit, ook wanneer een label over meerdere regels wrapt. De oude float-based layout behandelde elke kolom onafhankelijk, waardoor rijen schots en scheef liepen zodra labelhoogtes verschilden.

Implementatie: `<dl>` wordt een 2-kolom CSS Grid zodra er directe `.column`-kinderen zijn; `.column` krijgt `display: contents` zodat `.item`s direct deelnemen aan het `<dl>`-grid en rij-tracks delen. De `.column--full-width` rij krijgt `grid-column: 1 / -1` en valt via auto-placement onder beide reguliere kolommen. Shadow-DOM-only wijziging — geen publieke API-verandering.

## Succescriteria

- [x] Items uit verschillende kolommen lijnen op dezelfde y-coördinaat (gedeelde rij-tracks via CSS Grid).
- [x] Wrap van een lang label in één kolom duwt beide kolommen samen omlaag (`display: contents` maakt `.item`s directe grid-children).
- [x] Bestaand gedrag voor varianten zonder kolommen (`PropertiesDefault`, `PropertiesCollapsed`, `PropertiesHtmlEnriched`) blijft pixel-identiek (`dl:has(> .column)` matcht alleen bij directe `.column`-kinderen).
- [x] `.column--full-width` rij blijft onder beide kolommen (`grid-column: 1 / -1`).
- [x] Responsive collapse onder `vlMediaScreenSmall` blijft werken (1-kolom override + grid-column reset in `sizeQueryStyles`).

## Tests

- 2 nieuwe Cypress-tests in `vl-properties.component.cy.ts`:
  - Cross-column rij-uitlijning via `getBoundingClientRect().top`-vergelijking met een 2-regel label in kolom 1.
  - Full-width column staat verticaal onder de reguliere kolommen.
- Bestaande tests raken geen wijzigingen in DOM-structuur.

## Trade-off

Kolombreedte gaat van `calc(50% - 1rem)` (float) naar `1fr` (grid). Scheiding tussen kolommen loopt nu volledig via de bestaande `padding-right: 1rem` op `<dt>` in plaats van de float-margin. Visueel nalopen op de Storybook-preview is aanbevolen.

## Jira

https://omgeving.atlassian.net/browse/FLUX-632