### PR TITLE
fix: FLUX-136 - vl-datepicker - corrigeer flatpickr-tokens voor Cleave dateMin/dateMax

### DIFF
--- a/libs/components/src/form/datepicker/masks.ts
+++ b/libs/components/src/form/datepicker/masks.ts
@@ -25,16 +25,16 @@ export const createDateMask = (format: string, minDate?: string, maxDate?: strin
         const minimumDate = flatpickr?.parseDate(minDate, format);
         maskOptions = {
             ...maskOptions,
-            // formatteren naar verwacht formaat voor cleave.js
-            dateMin: minimumDate ? flatpickr?.formatDate(minimumDate, 'Y-M-D') : undefined,
+            // formatteren naar verwacht formaat voor cleave.js (yyyy-mm-dd)
+            dateMin: minimumDate ? flatpickr?.formatDate(minimumDate, 'Y-m-d') : undefined,
         };
     }
     if (maxDate) {
         const maximumDate = flatpickr?.parseDate(maxDate, format);
         maskOptions = {
             ...maskOptions,
-            // formatteren naar verwacht formaat voor cleave.js
-            dateMax: maximumDate ? flatpickr?.formatDate(maximumDate, 'Y-M-D') : undefined,
+            // formatteren naar verwacht formaat voor cleave.js (yyyy-mm-dd)
+            dateMax: maximumDate ? flatpickr?.formatDate(maximumDate, 'Y-m-d') : undefined,
         };
     }
     return maskOptions;

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-util.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-util.ts
@@ -1,12 +1,15 @@
 import flatpickr from 'flatpickr';
 
 export const formatEpoch = (epoch: number | string | symbol, format: string | symbol): string | symbol => {
-    if (epoch && (typeof epoch === 'string' || typeof epoch === 'number')) {
+    // Storybook's DATE-control geeft een Unix-timestamp (ms) terug; story-args bevatten doorgaans
+    // al een geformatteerde datum string. Enkel echte timestamps mogen geherformatteerd worden,
+    // anders wordt b.v. "05.05.2026" via Number(...) NaN en krijgen we "aN.aN.0NaN".
+    const isTimestamp = typeof epoch === 'number' || (typeof epoch === 'string' && /^\d+$/.test(epoch));
+    if (isTimestamp) {
         const dateFormat = format && typeof format !== 'symbol' ? format : 'd.m.Y';
         return flatpickr.formatDate(new Date(Number(epoch)), dateFormat);
-    } else {
-        return epoch as symbol;
     }
+    return epoch as symbol;
 };
 
 export const createDateRange = (

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
@@ -8,7 +8,7 @@ import { VlFormMessageComponent } from '../../form-message';
 import { VlDatepickerComponent } from '../vl-datepicker.component';
 import { datepickerArgs, datepickerArgTypes } from './vl-datepicker.stories-arg';
 import datepickerDocs from './vl-datepicker.stories-doc.mdx';
-import { createDateRange } from './vl-datepicker.stories-util';
+import { createDateRange, formatEpoch } from './vl-datepicker.stories-util';
 
 registerWebComponents([VlDatepickerComponent, VlFormMessageComponent, VlFormLabelComponent, VlButtonComponent]);
 
@@ -90,8 +90,8 @@ const DatepickerTemplate = story(
                             ?disable-mask-validation=${disableMaskValidation}
                             type=${type}
                             format=${format}
-                            min-date=${minDate}
-                            max-date=${maxDate}
+                            min-date=${formatEpoch(minDate, format)}
+                            max-date=${formatEpoch(maxDate, format)}
                             min-time=${minTime}
                             max-time=${maxTime}
                             am-pm=${amPm}

--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -500,6 +500,18 @@ describe('vl-datepicker - constraints', () => {
         cy.checkA11y('vl-datepicker');
     });
 
+    it('should clamp to min-date without corrupting the input value', () => {
+        cy.mount(html`<vl-datepicker min-date="01.06.2026" label="date"></vl-datepicker>`);
+        cy.injectAxe();
+
+        // Typ een datum vóór de min-date (15 april 2025)
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').type('15042025');
+
+        // Na de fix: Cleave klampt correct naar dateMin (01.06.2026), geen corrupte output
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('have.value', '01.06.2026');
+        cy.checkA11y('vl-datepicker');
+    });
+
     it('should set max time', () => {
         const maxTime = '16:45';
         cy.mount(html`<vl-datepicker type="time" max-time=${maxTime} label="time"></vl-datepicker>`);
@@ -1005,6 +1017,7 @@ describe('vl-datepicker - form integration', () => {
     it('should validate min/max with type "date"', () => {
         const format = 'd.m.Y';
         const [minDate, maxDate] = createDateRange(new Date('2024-04-10'), 2, format);
+        // minDate = '08.04.2024', maxDate = '12.04.2024'
         mountDatepickerInForm({ ...datepickerDefaults, minDate, maxDate, format, type: 'date' });
         cy.injectAxe();
         cy.get('form').then((form$) => {
@@ -1015,6 +1028,7 @@ describe('vl-datepicker - form integration', () => {
 
         cy.get('vl-datepicker').shadow().find('input').should('not.have.class', 'vl-input-field--error');
 
+        // In-range invoer wordt onveranderd doorgegeven
         cy.get('vl-datepicker').shadow().find('input.vl-input-field').type('10.04.2024');
         cy.get('vl-datepicker').should('have.value', '2024-04-10');
 
@@ -1025,21 +1039,24 @@ describe('vl-datepicker - form integration', () => {
 
         cy.get('button[type="reset"]').click();
 
+        // Boven max-date: Cleave klampt naar 12.04.2024 (FLUX-136 - Voorstel 1)
+        // Manuele invoer kan rangeOverflow niet meer triggeren - de waarde is steeds geldig.
         cy.get('vl-datepicker').shadow().find('input.vl-input-field').type('13.04.2024');
-        cy.get('vl-datepicker').should('have.value', '2024-04-13');
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('have.value', '12.04.2024');
+        cy.get('vl-datepicker').should('have.value', '2024-04-12');
         cy.get('button[type="submit"]').click();
-        cy.get('vl-form-message[state="rangeOverflow"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
         cy.get('vl-form-message[state="rangeUnderflow"]').shadow().find('p').should('have.attr', 'hidden');
 
         cy.get('button[type="reset"]').click();
-        cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
-        cy.get('vl-form-message[state="rangeUnderflow"]').shadow().find('p').should('have.attr', 'hidden');
 
+        // Onder min-date: Cleave klampt naar 08.04.2024 - rangeUnderflow blijft hidden.
         cy.get('vl-datepicker').shadow().find('input.vl-input-field').type('07.04.2024');
-        cy.get('vl-datepicker').should('have.value', '2024-04-07');
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('have.value', '08.04.2024');
+        cy.get('vl-datepicker').should('have.value', '2024-04-08');
         cy.get('button[type="submit"]').click();
         cy.get('vl-form-message[state="rangeOverflow"]').shadow().find('p').should('have.attr', 'hidden');
-        cy.get('vl-form-message[state="rangeUnderflow"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="rangeUnderflow"]').shadow().find('p').should('have.attr', 'hidden');
         cy.checkA11y('vl-datepicker');
     });
 


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-136

## Samenvatting
- `flatpickr.formatDate(date, 'Y-M-D')` gaf strings als `"2026-Jun-Wed"` door aan Cleave's `dateMin`/`dateMax`, waardoor Cleave die niet kon parsen en manuele invoer realtime corrupt herschreef (bv. `2025` → `20.26`).
- Beide tokens vervangen door `'Y-m-d'` in `libs/components/src/form/datepicker/masks.ts` zodat Cleave correct `yyyy-mm-dd` ontvangt en zijn numerieke min/max-clamping weer werkt.
- Cypress-regressietest toegevoegd in `vl-datepicker.component.cy.ts` (suite `vl-datepicker - constraints`).

## Succescriteria
- [x] Manueel typen van een datum onder `min-date` herschrijft het inputveld niet meer met onleesbare waarden.
- [x] Bestaande Cleave-mask-functionaliteit (numerieke afdwinging, separators, lengte-validatie) blijft werken voor datums binnen de range.
- [x] Cypress-test toegevoegd voor het regressiescenario uit het ticket.
- [x] Out-of-range waarde leesbaar laten staan voor de validator — bewust **niet** geadresseerd: na de fix klampt Cleave actief naar `dateMin` (gedocumenteerde trade-off van Voorstel 1 in het refinement-rapport). Indien deze UX ongewenst blijkt → follow-up langs Voorstel 2.

## Trade-off
Cleave clamped na deze fix correct naar `dateMin`/`dateMax` (numerieke clamping op datumniveau) i.p.v. de invoer corrupt te laten. Dat is het beoogde gedrag van de library zoals beschreven in het ticket.

## Test plan
- [ ] `npx nx run components:test --testFile=vl-datepicker.component.cy.ts` — bestaande constraint-tests blijven groen, nieuwe test `should clamp to min-date without corrupting the input value` slaagt.
- [x] Manuele check in Storybook: `vl-datepicker` met `min-date` in de toekomst, jaartal in het verleden typen — input mag niet "verspringen" naar onzin.