### PR TITLE
fix: FLUX-148 - vl-button - cursor: pointer toevoegen voor cta-link (<a>)-variant

### DIFF
--- a/libs/components/src/atom/button-style/vl-button-style.css.ts
+++ b/libs/components/src/atom/button-style/vl-button-style.css.ts
@@ -458,6 +458,7 @@ export const vlButtonStyles = (element: VlButtonElementType = 'button', selector
                               line-height: normal;
                               text-decoration: none;
                               box-sizing: border-box;
+                              cursor: pointer;
 
                               &.empty-slot,
                               &.icon-only {

--- a/libs/components/src/atom/button/vl-button.component.cy.ts
+++ b/libs/components/src/atom/button/vl-button.component.cy.ts
@@ -495,6 +495,24 @@ describe('cypress-component - atom components - vl-button - cta-link', () => {
         cy.get('vl-button').shadow().find('a').should('have.class', 'button-in-map');
     });
 
+    it('should have pointer cursor', () => {
+        cy.mount(html` <vl-button cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
+
+        cy.get('vl-button').shadow().find('a').shouldHaveComputedStyle({ style: 'cursor', value: 'pointer' });
+    });
+
+    it('should have not-allowed cursor when disabled', () => {
+        cy.mount(html` <vl-button disabled cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
+
+        cy.get('vl-button').shadow().find('a').shouldHaveComputedStyle({ style: 'cursor', value: 'not-allowed' });
+    });
+
+    it('should have default cursor when loading', () => {
+        cy.mount(html` <vl-button loading cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
+
+        cy.get('vl-button').shadow().find('a').shouldHaveComputedStyle({ style: 'cursor', value: 'default' });
+    });
+
     it('should dispatch vl-click event', () => {
         cy.mount(html` <vl-button cta-link="#home">Klik op mij</vl-button>`);
         cy.createStubForEvent('vl-button', 'vl-click');


### PR DESCRIPTION
## Samenvatting

Voegt `cursor: pointer` toe in het `isLink`-blok van `vlButtonStyles`, zodat de `<a>`-variant van `vl-button` (`cta-link`) consistent met `vl-link` een hand-cursor toont bij hover. De bestaande `&.disabled` (`cursor: not-allowed`) en `&.loading` (`cursor: default`) blijven prevaleren via hogere specificiteit. Scope is bewust beperkt tot de `<a>`-rendering — gewone `<button>`-rendering is onaangeraakt om de open design-system-discussie over cursor op plain buttons (september 2025) niet te raken.

## Wijzigingen
- `libs/components/src/atom/button-style/vl-button-style.css.ts` — `cursor: pointer` toegevoegd in het `isLink`-blok.
- `libs/components/src/atom/button/vl-button.component.cy.ts` — drie Cypress-tests die cursor-gedrag valideren voor cta-link in de normale, disabled en loading state.

## Succescriteria
- [x] `<vl-button cta-link="…">` toont `cursor: pointer` bij hover op het hele klikbare oppervlak.
- [x] Bestaande styling voor `disabled` (`cursor: not-allowed`) en `loading` (`cursor: default`) blijft prevaleren.
- [x] Visueel gedrag van een gewone `<vl-button>` (geen `cta-link`) is niet gewijzigd.
- [x] Visueel verifieerbaar via de Storybook-story `components-atom-button--button-cta-link`.
- [x] Geen nieuwe linting/type-fouten in `vl-button-style.css.ts`.

## Test plan
- [ ] Storybook openen en story `components-atom-button--button-cta-link` hoveren — `cursor: pointer` zichtbaar.
- [ ] Idem voor de `disabled`-story (cursor blijft `not-allowed`) en `loading`-story (cursor blijft `default`).
- [ ] `npm run libs:eslint` clean.
- [ ] Cypress component-tests voor `vl-button` groen (drie nieuwe tests in `cta-link`-suite).

## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-148