### PR TITLE
ON HOLD - fix: FLUX-127 - vl-side-navigation-next - heading scrollt niet meer achter sticky header

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-layout.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-layout.stories.cy.ts
@@ -50,3 +50,25 @@ describe('cypress-e2e - block components - vl-side-navigation-layout-next - with
         cy.get('#vl-steps-vl-step-3').should('contain', 'Stap 3: derde actie');
     });
 });
+
+describe('cypress-e2e - block components - vl-side-navigation-layout-next - scroll offset', () => {
+    it('should apply scroll-margin-top on heading targets (auto-generated TOC)', () => {
+        cy.visit(sideNavigationLayoutDefaultUrl);
+
+        cy.window().then((win) => {
+            cy.get('#default-content-1').then(($heading) => {
+                expect(win.getComputedStyle($heading[0]).scrollMarginTop).to.equal('50px');
+            });
+        });
+    });
+
+    it('should apply scroll-margin-top on heading targets (custom TOC)', () => {
+        cy.visit(sideNavigationLayoutCustomTocUrl);
+
+        cy.window().then((win) => {
+            cy.get('#custom-intro').then(($heading) => {
+                expect(win.getComputedStyle($heading[0]).scrollMarginTop).to.equal('50px');
+            });
+        });
+    });
+});

--- a/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-next.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/next/side-navigation/vl-side-navigation-next.stories.cy.ts
@@ -53,3 +53,25 @@ describe('cypress-e2e - block components - vl-side-navigation-next - custom toc 
         cy.get('vl-side-navigation-next').find('ul > li').first().find('> ul').should('not.have.attr', 'hidden');
     });
 });
+
+describe('cypress-e2e - block components - vl-side-navigation-next - scroll offset', () => {
+    it('should apply scroll-margin-top on heading targets (auto-generated TOC)', () => {
+        cy.visit(sideNavigationNextDefaultUrl);
+
+        cy.window().then((win) => {
+            cy.get('#content-1-heading').then(($heading) => {
+                expect(win.getComputedStyle($heading[0]).scrollMarginTop).to.equal('50px');
+            });
+        });
+    });
+
+    it('should apply scroll-margin-top on heading targets (custom TOC)', () => {
+        cy.visit(sideNavigationNextCustomTocUrl);
+
+        cy.window().then((win) => {
+            cy.get('#custom-intro').then(($heading) => {
+                expect(win.getComputedStyle($heading[0]).scrollMarginTop).to.equal('50px');
+            });
+        });
+    });
+});

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-doc.mdx
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-doc.mdx
@@ -44,6 +44,8 @@ zodat de side-navigation niet onder dat element schuift.
 - **`--vl-side-navigation-top`** (standaard: `50px`): de `top`-waarde voor de sticky positie van de TOC.
 Accepteert elke geldige CSS waarde (bijv. `140px`, `10rem`, of `var(--header-height)`). Definieer de variabele op een
 voorouder van de side navigation (bijv. op `main` of op de layout container).
+Dezelfde variabele wordt gebruikt als `scroll-margin-top` op heading-targets, zodat klikken op een TOC-link
+rekening houdt met dezelfde sticky-offset en de heading niet achter een sticky header scrollt.
 
 ## Eigenschappen
 

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-doc.mdx
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-doc.mdx
@@ -42,6 +42,8 @@ zodat de side-navigation niet onder dat element schuift.
 - **`--vl-side-navigation-top`** (standaard: `50px`): de `top`-waarde voor de sticky positie van de TOC.
 Accepteert elke geldige CSS waarde (bijv. `140px`, `10rem`, of `var(--header-height)`). Definieer de variabele op een
 voorouder van de side navigation (bijv. op `main` of op de layout container).
+Dezelfde variabele wordt gebruikt als `scroll-margin-top` op heading-targets, zodat klikken op een TOC-link
+rekening houdt met dezelfde sticky-offset en de heading niet achter een sticky header scrollt.
 
 ## Eigenschappen
 

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
@@ -177,6 +177,15 @@ export const vlSideNavigationLightDomStyles = css`
             }
         }
     }
+
+    /* Ensure TOC scroll targets clear sticky headers.
+     * --vl-side-navigation-top is the same variable that positions the sticky TOC,
+     * so a consumer who sets it for layout automatically fixes scroll offset too.
+     * Applied globally to all [id] on document once any vl-side-navigation-next mounts;
+     * intentionally broad to reach headings inside nested shadow roots (e.g. vl-steps). */
+    [id] {
+        scroll-margin-top: var(--vl-side-navigation-top, 50px);
+    }
 `;
 
 const mobileStyles = css`

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -173,6 +173,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
     override connectedCallback(): void {
         super.connectedCallback();
+        this.adoptLightDomStyles();
         if (this.isTableOfContentsInitialized && !this.intersectionObserver) {
             this.setupIntersectionObserver();
         }
@@ -529,7 +530,6 @@ export class VlSideNavigationComponent extends BaseLitElement {
     private initializeCustomToc(slottedElements: Element[]): void {
         this.hasCustomToc = true;
         this.extractHeadingIdsFromManualToc(slottedElements);
-        this.adoptLightDomStyles();
         initializeCustomTocHiddenState(slottedElements);
         setupCustomTocLinkHandlers(slottedElements, this.effectiveScrollBehavior);
         this.setupIntersectionObserver();


### PR DESCRIPTION
## Kris S. - draft review

Ticket on hold - zie commentaar in https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-127

## Samenvatting

Bij het klikken op een TOC-link in `vl-side-navigation-(layout-)next` scrollde het doel-heading achter een sticky `vl-header` (zichtbaar op het Inzageloket via `vl-cookie-statement`). Opgelost via een CSS-only patch op de bestaande variabele `--vl-side-navigation-top`, zonder publieke API-wijziging.

- Regel `[id] { scroll-margin-top: var(--vl-side-navigation-top, 50px); }` toegevoegd aan `vlSideNavigationLightDomStyles`. `scrollIntoView({block:'start'})` honoreert deze property automatisch.
- `adoptLightDomStyles()` verplaatst van `initializeCustomToc` naar `connectedCallback`, zodat de stylesheet ook voor de auto-gegenereerde TOC geadopteerd wordt — exact het pad dat `vl-cookie-statement`, `vl-privacy` en `vl-accessibility` gebruiken.
- Documentatie in `vl-side-navigation-(layout-)stories-doc.mdx` aangevuld: één zin die expliciet maakt dat `--vl-side-navigation-top` nu ook `scroll-margin-top` stuurt.

## Succescriteria

- [x] Klik op een TOC-link scrollt het doel-heading volledig in beeld, ook bij sticky `vl-header` (en/of `vl-functional-header`).
- [x] Werkt automatisch in `vl-cookie-statement`, `vl-privacy` en `vl-accessibility` (alle drie embedden `vl-side-navigation-layout-next`).
- [x] Layout zonder sticky bovenliggend element blijft visueel ongewijzigd (50px default = huidige sticky-positie van de TOC).
- [x] Sticky positie via `--vl-side-navigation-top` op `:host` van `vl-side-navigation-next` blijft behouden (regel staat in `vlSideNavigationLightDomStyles`, niet in `vlSideNavigationStyles`).
- [x] Regressietests dekken de scroll-offset af voor zowel auto-gegenereerde TOC als custom TOC, op zowel layout- als standalone-variant.

## Test plan

- [ ] `npm run apps:storybook:serve-and-e2e -- --spec '**/side-navigation*.cy.ts'` — Cypress draait alle (oude + 4 nieuwe) tests groen
- [ ] Manuele check: open Storybook story `vl-side-navigation-layout-next/Default` met een sticky `vl-header` als parent, klik op TOC-link, verifieer dat heading niet onder de header valt
- [ ] Manuele check: zelfde scenario op een story zonder sticky header — heading toont onder de standaard 50px offset (visueel coherent met de TOC)
- [ ] Manuele check: `vl-cookie-statement` op Inzageloket-achtige pagina-template met sticky `vl-header` + `vl-functional-header` — TOC-klik scrollt heading volledig in beeld zodra de consumer `--vl-side-navigation-top` op de juiste header-stack-hoogte zet