### PR TITLE
fix: FLUX-640 - vl-side-navigation-item - externe links navigeren correct

### DIFF
--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -1184,3 +1184,47 @@ describe('child-spacing attribuut', () => {
             .should('have.css', 'margin-top', '13px'); // 1.3rem * 10px root font = 13px
     });
 });
+
+describe('cypress-component - block components - vl-side-navigation-next - externe links in custom TOC', () => {
+    beforeEach(() => {
+        cy.viewport(1440, 900);
+    });
+
+    it('should not intercept external links in custom TOC (design choice: only a[href^="#"] are handled)', () => {
+        // setupCustomTocLinkHandlers selects only a[href^="#"] — external links pass through unmodified.
+        cy.mount(html`
+            <div class="vl-grid">
+                <vl-side-navigation-next class="${NAVIGATION_COLUMN_CLASSES}">
+                    <ul>
+                        <li>
+                            <a id="hash-link" href="#custom-section">Interne sectie</a>
+                        </li>
+                        <li>
+                            <a id="external-link" href="https://www.vlaanderen.be">Externe link</a>
+                        </li>
+                    </ul>
+                </vl-side-navigation-next>
+                <div class="${CONTENT_COLUMN_CLASSES}">
+                    <section style="min-height: 400px; margin-top: 100px;">
+                        <h2 id="custom-section">Sectie</h2>
+                    </section>
+                </div>
+            </div>
+        `);
+
+        // Capture defaultPrevented after any component handlers run (bubble phase)
+        let defaultPrevented: boolean;
+        cy.get('#external-link').then(($a) => {
+            $a[0].addEventListener('click', (e) => {
+                defaultPrevented = e.defaultPrevented;
+                e.preventDefault(); // prevent actual navigation in test
+            });
+        });
+
+        cy.get('#external-link').click();
+
+        cy.then(() => {
+            expect(defaultPrevented, 'vl-side-navigation-next must not prevent default for external links').to.be.false;
+        });
+    });
+});

--- a/libs/components/src/block/side-navigation/vl-side-navigation-item.component.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation-item.component.ts
@@ -49,13 +49,16 @@ export class VlSideNavigationItemComponent extends BaseLitElement {
         }
 
         a.addEventListener('click', (e) => {
-            e.preventDefault();
-
             const href = a.getAttribute('href');
             if (!href) {
                 console.warn('vl-side-navigation-item vereist een geldige href op het anchor element.');
                 return;
             }
+
+            // Non-hash hrefs (external URLs, relative paths) are handled by the browser.
+            if (!href.startsWith('#')) return;
+
+            e.preventDefault();
 
             const element = findDeepestElementThroughShadowRoot(this.getRootNode(), href);
             if (!element) {

--- a/libs/components/src/block/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.component.cy.ts
@@ -510,3 +510,57 @@ describe('cypress-component - block components - vl-side-navigation - scrollspy 
             .should('not.have.class', 'js-vl-scrollspy__toggle--fixed');
     });
 });
+
+describe('cypress-component - block components - vl-side-navigation - externe links', () => {
+    beforeEach(() => {
+        cy.viewport(960, 1440);
+
+        cy.mount(html`
+            <vl-side-navigation aria-label="navigatie">
+                <vl-side-navigation-h5>Navigatie</vl-side-navigation-h5>
+                <vl-side-navigation-content>
+                    <vl-side-navigation-group>
+                        <vl-side-navigation-item>
+                            <a id="external-link" href="https://www.vlaanderen.be">Externe link</a>
+                        </vl-side-navigation-item>
+                        <vl-side-navigation-item>
+                            <a id="hash-link" href="#sectie-1">Hash link</a>
+                        </vl-side-navigation-item>
+                    </vl-side-navigation-group>
+                </vl-side-navigation-content>
+            </vl-side-navigation>
+            <section id="sectie-1" style="margin-top: 2000px;">
+                <h2>Sectie 1</h2>
+            </section>
+        `);
+    });
+
+    it('should not call console.warn and not prevent default when clicking an external link', () => {
+        cy.window().then((win) => {
+            cy.stub(win.console, 'warn').as('consoleWarn');
+        });
+
+        // Capture defaultPrevented state after the component's bubble-phase handler runs
+        let defaultPrevented: boolean;
+        cy.get('#external-link').then(($a) => {
+            $a[0].addEventListener('click', (e) => {
+                defaultPrevented = e.defaultPrevented;
+                e.preventDefault(); // prevent actual navigation in test
+            });
+        });
+
+        cy.get('#external-link').click();
+
+        cy.get('@consoleWarn').should('not.have.been.called');
+        cy.then(() => {
+            expect(defaultPrevented, 'component must not call preventDefault for external links').to.be.false;
+        });
+    });
+
+    it('should still prevent default and scroll for hash links', () => {
+        cy.get('#hash-link').click();
+
+        // After clicking a hash link, the page should attempt to scroll (no navigation away)
+        cy.location('pathname').should('not.contain', 'vlaanderen.be');
+    });
+});


### PR DESCRIPTION
## Draf -> Ready - Kris S.

Uitgetest in Storybook: de fix werkt voor vl-side-navigation.
In vl-side-navigation-next is er geen probleem.

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-640
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC316 - build is ok

## Samenvatting

Fix waarbij `vl-side-navigation-item` externe `<a>`-hrefs niet langer onderschept met een unconditional `e.preventDefault()`. De click-handler retourneert vroeg voor hrefs die niet met `#` beginnen, waardoor de browser navigatie zelf afhandelt (inclusief `target="_blank"`, `rel`, cmd-/middle-click). Hash-anchors blijven werken zoals vandaag (smooth-scroll + optionele `history.pushState` bij `hash-sync`).

Voor `vl-side-navigation-next` is geen codewijziging nodig: `setupCustomTocLinkHandlers` filtert al op `a[href^="#"]`. Een dedicated cypress-test legt deze design-keuze vast.

## Succescriteria

- [x] Externe `<a href="https://...">` navigeert correct (browser-default, inclusief `target="_blank"` en `rel`).
- [x] Hash-href (`#content-1`) blijft werken: smooth-scroll met `scrollOffset` en optionele `history.pushState` bij `hash-sync`.
- [x] Geen console-warning meer voor geldige externe URL's.
- [x] Bestaande consumers met enkel `#`-anchors merken geen gedragsverschil (codepath byte-voor-byte gelijk).
- [x] Vaststelling-van-design-keuze voor `vl-side-navigation-next` met cypress-test als bewijs.

## Wijzigingen

- `libs/components/src/block/side-navigation/vl-side-navigation-item.component.ts` — vroege return voor niet-hash hrefs vóór `e.preventDefault()`.
- `libs/components/src/block/side-navigation/vl-side-navigation.component.cy.ts` — cypress-test voor externe link (geen `console.warn`, geen `preventDefault`) + behoud-test voor hash-link.
- `libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts` — cypress-test die bevestigt dat `vl-side-navigation-next` externe links in custom TOC ongewijzigd doorlaat.

## Backwards compatibility

Geen breaking change. Hash-codepad is ongewijzigd. Edge case: relatieve hrefs zonder `#` (bv. `./foo.html`) worden nu door de browser afgehandeld i.p.v. genegeerd na een mislukte selector-lookup — gedrag dat overeenkomt met de Storybook-documentatie.