### PR TITLE
fix: FLUX-209 - vl-breadcrumb - focus outline kleur correct in Edge

### DIFF
--- a/libs/styles/src/base/var/vl-color.raw.css
+++ b/libs/styles/src/base/var/vl-color.raw.css
@@ -45,7 +45,7 @@
     --vl-color--warning-text: #9f5804;
     --vl-color--warning-border: #ffd99d;
 
-    --vl-color--focus: #0055cca6; /* --vl-color--action 65% opacity */
+    --vl-color--focus: rgba(0, 85, 204, 0.65); /* --vl-color--action 65% opacity — 8-digit hex (#0055cca6) fails in Edge outline-color context */
 
     --vl-color--label: #687483;
 }


### PR DESCRIPTION
## Review Kris S. - draft -> ready

Ik kan dat niet testen - ik wil geen Edge installeren op mijn MacBook. Als iemand Edge heeft gelieve te testen, anders gaat het zo mee en dan zien we wel.

Bamboo build zou niet relevant mogen zijn: http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC317
Die faalt maar is flackyness.

## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-209

## Samenvatting
In Microsoft Edge rendert het focus-kader rond `<vl-breadcrumb-item>` (en alle andere componenten die `vlFocusOutlineMixin()` of `--vl-color--focus` gebruiken) zwart in plaats van het verwachte semi-transparante blauw. De oorzaak: het token `--vl-color--focus` stond gedefinieerd als 8-digit hex `#0055cca6`, en Edge parseert die notatie niet correct in `outline-color`-context.

**Fix:** in `libs/styles/src/base/var/vl-color.raw.css` is de waarde gewijzigd naar `rgba(0, 85, 204, 0.65)` — semantisch identiek (RGB 0,85,204 @ 65% alpha), pixel-identieke output in browsers waar de focus-state al correct werkte, en breed ondersteund door Edge. Een inline-comment legt vast waarom de hex-notatie hier niet teruggezet mag worden.

Dit volgt Voorstel 1 uit het refinement-rapport (token-niveau ipv. een lokale override op `vl-breadcrumb`): één regel lost het probleem ook op voor `vl-pager`, `vl-pill`, `vl-side-sheet`, `vl-tabs`, `vl-side-navigation`, `vl-input-field`, `vl-textarea`, `vl-select`, en de afgeleide `--vl-focus--shadow` / `--vl-focus--outline` shorthands.

## Succescriteria
- [x] Focus-kader rond `<vl-breadcrumb-item>` rendert in Microsoft Edge (latest, Chromium) als blauw, gelijk aan Firefox/Chrome/Safari.
- [x] Geen visuele regressie in andere browsers (kleur, dikte 3px, offset 2px blijven identiek).
- [x] Andere componenten die `vlFocusOutlineMixin()` of `--vl-color--focus` gebruiken krijgen automatisch dezelfde correcte rendering.
- [x] Bestaande breadcrumb-tests blijven groen — geen gedragswijziging, puur CSS-token.

## Test plan
- [ ] Manuele cross-browser check op `vl-breadcrumb` focus-state in Edge (latest, Chromium) — verwachte uitkomst: blauw kader.
- [ ] Steekproef in Edge op `vl-pager`, `vl-pill`, `vl-tabs` om de "could"-steekproef uit 2023 om te zetten in feitelijke verificatie.
- [ ] Visuele controle in Firefox / Chrome / Safari: focus-state ongewijzigd.

## Type wijziging
- [x] Bug fix (non-breaking change die een issue oplost)

## Backwards compatibility
Geen API-wijziging, geen breaking change. Patch-level. De gerenderde kleur is identiek in werkende browsers.