### PR TITLE
fix: FLUX-638 - vl-datepicker - dubbele input op mobile verholpen

### DIFF
--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -1668,6 +1668,75 @@ describe('vl-datepicker - interaction', () => {
     });
 });
 
+describe('vl-datepicker - mobile rendering regression', () => {
+    let originalUserAgent: string;
+
+    before(() => {
+        cy.window().then((win) => {
+            originalUserAgent = win.navigator.userAgent;
+        });
+    });
+
+    afterEach(() => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => originalUserAgent,
+                configurable: true,
+            });
+        });
+    });
+
+    it('should render only native date input on mobile UA', () => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+                configurable: true,
+            });
+        });
+
+        cy.mount(html`<vl-datepicker label="date"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('not.exist');
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').should('not.exist');
+        cy.get('vl-datepicker').shadow().find('input[type="date"]').should('exist').and('be.visible');
+    });
+
+    it('should render consistently across multiple instances on mobile UA', () => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+                configurable: true,
+            });
+        });
+
+        cy.mount(html`
+            <div>
+                <vl-datepicker id="dp1" label="date1"></vl-datepicker>
+                <vl-datepicker id="dp2" label="date2"></vl-datepicker>
+            </div>
+        `);
+
+        cy.get('vl-datepicker#dp1').shadow().find('input.vl-input-field').should('not.exist');
+        cy.get('vl-datepicker#dp1').shadow().find('input[type="date"]').should('exist').and('be.visible');
+        cy.get('vl-datepicker#dp2').shadow().find('input.vl-input-field').should('not.exist');
+        cy.get('vl-datepicker#dp2').shadow().find('input[type="date"]').should('exist').and('be.visible');
+    });
+
+    it('should render styled input when disable-mobile-native-input is set on mobile UA', () => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+                configurable: true,
+            });
+        });
+
+        cy.mount(html`<vl-datepicker disable-mobile-native-input label="date"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('exist').and('be.visible');
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').should('exist');
+    });
+});
+
 describe('vl-datepicker - mobile', () => {
     beforeEach(() => {
         cy.viewport(320, 480);

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -20,6 +20,9 @@ import { datepickerDefaults } from './vl-datepicker.defaults';
 const dateRangeSeparator = ' tot en met ';
 const dateRangeSeparatorCharacter = '/';
 
+const isMobileUserAgent = () =>
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
 @webComponent('vl-datepicker')
 export class VlDatepickerComponent extends FormControl {
     static formControlValidators = [
@@ -52,6 +55,7 @@ export class VlDatepickerComponent extends FormControl {
     private initialValue = '';
     private inputHasFocus = false;
     private isOpen: boolean | undefined;
+    private isMobileBrowser = isMobileUserAgent();
     private flatpickrInstance: Instance | null = null;
     private maskOptions: MaskOptions | null = null; // Wordt enkel gebruikt in de mask validator
     private cleaveInstance: CleaveInstance | null = null;
@@ -88,6 +92,7 @@ export class VlDatepickerComponent extends FormControl {
             rawValue: { type: Boolean, attribute: 'raw-value' },
             inputValue: { type: String, state: true }, // Houdt de waarde van het getoonde inputveld bij
             isOpen: { type: Boolean, state: true },
+            isMobileBrowser: { state: true },
             position: { type: String },
             isStatic: { type: Boolean, attribute: 'static' },
         };
@@ -208,7 +213,7 @@ export class VlDatepickerComponent extends FormControl {
             }
         }
 
-        if (this.flatpickrInstance?.isMobile && !this.disableMobileNativeInput) {
+        if (this.isMobileBrowser && !this.disableMobileNativeInput) {
             this.getNativeDateInput()?.classList.add(
                 'js-vl-datepicker-input',
                 'vl-input-field',
@@ -246,7 +251,7 @@ export class VlDatepickerComponent extends FormControl {
 
         return html`
             <div class="vl-group vl-group--input-group" id="datepicker-wrapper">
-                ${!(this.flatpickrInstance?.isMobile && !this.disableMobileNativeInput)
+                ${!(this.isMobileBrowser && !this.disableMobileNativeInput)
                     ? html`
                           <input
                               id=${this.id || nothing}


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-638

## Samenvatting
`vl-datepicker` rendert op mobile UA nu betrouwbaar één inputveld in plaats van soms een dubbele (styled + native) of soms enkel de native variant. De render-conditie hangt niet langer af van het niet-reactieve `flatpickrInstance.isMobile`, maar van een Lit reactive state (`isMobileBrowser`) die in de constructor via dezelfde UA-test als flatpickr bepaald wordt — daarmee evalueert Lit de juiste tak al vóór flatpickr aan de DOM raakt.

## Succescriteria
- [x] `vl-datepicker` rendert in álle situaties exact één zichtbaar inputveld voor de gebruiker, ongeacht of `isMobile` `true` of `false` is.
- [x] Wanneer `isMobile === true` en `disable-mobile-native-input` niet gezet is: alleen de native `<input type="date">` is zichtbaar (huidig product-gedrag).
- [x] Wanneer `isMobile === false` of `disable-mobile-native-input === true`: alleen het VL-styled tekstveld + kalender-knop is zichtbaar.
- [x] Het gedrag is deterministisch: meerdere instances van `<vl-datepicker>` op dezelfde pagina gedragen zich identiek.
- [x] Bestaande Cypress-coverage in `vl-datepicker.component.cy.ts` blijft groen; een nieuwe regressietest dekt de mobile-rendering.

## Wijzigingen
- `libs/components/src/form/datepicker/vl-datepicker.component.ts` — `isMobileUserAgent()` helper, `isMobileBrowser` reactive state, render-conditie en `updated()` aangepast.
- `libs/components/src/form/datepicker/vl-datepicker.component.cy.ts` — drie regressietests met UA-mock voor mobile-rendering, multi-instance-determinisme en `disable-mobile-native-input`-override.

## Backwards compatibility
Geen API-wijziging — geen attribute, property of event toegevoegd of veranderd. `disable-mobile-native-input` gedraagt zich ongewijzigd.