### PR TITLE
fix: FLUX-218 - vl-datepicker - kalender opent automatisch naar links in smalle containers

### DIFF
--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -1704,3 +1704,46 @@ describe('vl-datepicker - mobile', () => {
         cy.checkA11y('vl-datepicker');
     });
 });
+
+describe('vl-datepicker - auto positioning', () => {
+    it('should open calendar right-aligned when close to the right viewport edge', () => {
+        cy.viewport(400, 600);
+        cy.mount(html`
+            <div style="display: flex; justify-content: flex-end; width: 100%;">
+                <vl-datepicker label="datum"></vl-datepicker>
+            </div>
+        `);
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker').shadow().find('.flatpickr-calendar').should('have.class', 'arrowRight');
+    });
+
+    it('should open calendar left-aligned when there is sufficient space to the right', () => {
+        cy.viewport(1200, 800);
+        cy.mount(html`<vl-datepicker label="datum"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker').shadow().find('.flatpickr-calendar').should('not.have.class', 'arrowRight');
+    });
+
+    it('should respect an explicit position attribute even when there is insufficient space to the right', () => {
+        cy.viewport(400, 600);
+        cy.mount(html`
+            <div style="display: flex; justify-content: flex-end; width: 100%;">
+                <vl-datepicker label="datum" position="auto"></vl-datepicker>
+            </div>
+        `);
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        // position="auto" falls through to the heuristic, so close to right edge → still arrowRight
+        cy.get('vl-datepicker').shadow().find('.flatpickr-calendar').should('have.class', 'arrowRight');
+    });
+
+    it('should use explicit position="auto right" in a wide viewport', () => {
+        cy.viewport(1200, 800);
+        cy.mount(html`<vl-datepicker label="datum" position="auto right"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').click();
+        cy.get('vl-datepicker').shadow().find('.flatpickr-calendar').should('have.class', 'arrowRight');
+    });
+});

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -357,8 +357,32 @@ export class VlDatepickerComponent extends FormControl {
             maxTime: this.maxTime,
             defaultHour: minimumDateTime?.getHours() ?? 12,
             defaultMinute: minimumDateTime?.getMinutes() ?? 0,
-            position: this.position || 'auto',
+            position: this.resolveAutoPosition(),
         };
+    }
+
+    /**
+     * Returns the flatpickr position string to use.
+     * When the consumer sets an explicit position (anything other than the default 'auto'),
+     * that value wins unchanged. For the default 'auto', we check whether the toggle button
+     * is close enough to the right viewport edge that the calendar would be clipped; if so
+     * we return 'auto right' so flatpickr right-aligns the calendar instead.
+     * Static mode is skipped because CSS controls positioning there.
+     */
+    private resolveAutoPosition(): string {
+        if (this.position && this.position !== 'auto') {
+            return this.position;
+        }
+        if (this.isStatic) {
+            return 'auto';
+        }
+        const button = this.shadowRoot?.querySelector<HTMLElement>('button#toggle-calendar');
+        if (!button) {
+            return 'auto';
+        }
+        const { right } = button.getBoundingClientRect();
+        // Calendar width from CSS is 307.875px; 320px provides a safe margin
+        return window.innerWidth - right < 320 ? 'auto right' : 'auto';
     }
 
     private addAccessibilityAttributes() {


### PR DESCRIPTION
## Jira

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-218

## Samenvatting

In een smalle container (side-sheet, drawer) kiest `vl-datepicker` met `position="auto"` nu automatisch voor rechts-uitlijning wanneer er rechts van de toggle-button onvoldoende ruimte is, zodat de kalender niet meer buiten beeld valt. Expliciete `position`-waarden blijven onveranderd.

## Succescriteria

- [x] `vl-datepicker` opent in een smalle container automatisch naar links zonder dat de consumer een attribuut hoeft te zetten
- [x] `position="auto"` (de default) detecteert correct de beschikbare horizontale ruimte t.o.v. de viewport-rand
- [x] Bestaande gevallen waar de kalender vandaag correct naar rechts opent blijven onveranderd (geen visuele regressie)
- [x] Geconfigureerde waarden van `position` (bv. expliciet `"auto right"`) behouden prioriteit boven auto-detectie
- [x] Dekkende Cypress-test in `vl-datepicker.component.cy.ts` met een input dicht tegen de rechterrand