### PR TITLE
fix: FLUX-639 - vl-header-next / vl-footer-next - legacy theme-tokens hersteld op body

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -6,7 +6,8 @@ import {
     VlPopoverComponent,
     VlPropertiesComponent,
 } from '@domg-wc/components/block';
-import { VlHeader } from '@domg-wc/components/compliance';
+import { VlPrivacy } from '@domg-wc/components/compliance';
+import { VlHeader } from '@domg-wc/components/compliance/next';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -18,6 +19,7 @@ export class AppComponent extends LitElement {
             VlPopoverComponent,
             VlPopoverActionListComponent,
             VlPopoverActionComponent,
+            VlPrivacy,
             VlInfoTile,
             VlPropertiesComponent,
         ]);
@@ -26,13 +28,14 @@ export class AppComponent extends LitElement {
     render() {
         return html`
             <vl-template>
-                <vl-header
+                <vl-header-next
                     slot="header"
                     development
                     simple
                     identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
-                ></vl-header>
+                ></vl-header-next>
                 <main slot="main">
+                    <vl-privacy></vl-privacy>
                     <section class="vl-section">
                         <div class="vl-content-block vl-content-block--full-width">
                             <vl-info-tile highlight-left>

--- a/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
@@ -83,4 +83,24 @@ describe('cypress-component - compliance components - vl-footer-next', () => {
             cy.get('@ready').should('have.been.calledOnce');
         });
     });
+
+    describe('legacy theme tokens', () => {
+        beforeEach(() => {
+            mountDefault(props);
+        });
+
+        it('should set --vl-theme-primary-color to legacy VO yellow on body', () => {
+            cy.get('body').then(($body) => {
+                const value = getComputedStyle($body[0]).getPropertyValue('--vl-theme-primary-color').trim();
+                expect(value).to.equal('#ffe615');
+            });
+        });
+
+        it('should set --vl-theme-fg-color to legacy VO foreground on body', () => {
+            cy.get('body').then(($body) => {
+                const value = getComputedStyle($body[0]).getPropertyValue('--vl-theme-fg-color').trim();
+                expect(value).to.equal('#333332');
+            });
+        });
+    });
 });

--- a/libs/components/src/compliance/next/footer/vl-footer.component.flux-css.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.flux-css.ts
@@ -1,25 +1,5 @@
 import { css } from 'lit';
 
-export const headerContainerStyles = css`
-    #header__container {
-        min-height: 43px;
-    }
-`;
-
-export const headerSkeletonStyles = css`
-    #header__skeleton {
-        content: '';
-        height: 43px;
-        width: 100%;
-        display: block;
-        background: #fff;
-    }
-
-    #header__container ~ #header__skeleton {
-        display: none;
-    }
-`;
-
 // body-scope wins over :root via CSS inheritance (closer ancestor),
 // restoring legacy VO values after the widget bundle overwrites them on :root.
 export const legacyThemeTokenStyles = css`

--- a/libs/components/src/compliance/next/footer/vl-footer.component.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.ts
@@ -7,6 +7,7 @@ import {
     webComponent,
 } from '@domg-wc/common';
 import { GlobalFooterClient } from '@govflanders/vl-widget-global-footer-types';
+import { legacyThemeTokenStyles } from './vl-footer.component.flux-css';
 
 declare global {
     interface Window {
@@ -54,6 +55,7 @@ export class VlFooter extends BaseLitElement {
             'beforeend',
             '<footer id="footer__container"><div id="footer"></div></footer>'
         );
+        document.adoptedStyleSheets = [...document.adoptedStyleSheets, legacyThemeTokenStyles.styleSheet!];
     }
 
     private onReady() {

--- a/libs/components/src/compliance/next/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.cy.ts
@@ -111,6 +111,30 @@ describe('cypress-component - compliance components - vl-header-next', () => {
             cy.get('#header__skeleton').should('have.css', 'height', '43px');
         });
     });
+
+    describe('legacy theme tokens', () => {
+        beforeEach(() => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next development identifier="${identifier}"></vl-header-next>
+                </body>
+            `);
+        });
+
+        it('should set --vl-theme-primary-color to legacy VO yellow on body', () => {
+            cy.get('body').then(($body) => {
+                const value = getComputedStyle($body[0]).getPropertyValue('--vl-theme-primary-color').trim();
+                expect(value).to.equal('#ffe615');
+            });
+        });
+
+        it('should set --vl-theme-fg-color to legacy VO foreground on body', () => {
+            cy.get('body').then(($body) => {
+                const value = getComputedStyle($body[0]).getPropertyValue('--vl-theme-fg-color').trim();
+                expect(value).to.equal('#333332');
+            });
+        });
+    });
 });
 
 const stubWidgetScriptMinimal = () => ({

--- a/libs/components/src/compliance/next/header/vl-header.component.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@domg-wc/common';
 import { ApplicationMenuLink, GlobalHeaderClient } from '@govflanders/vl-widget-global-header-types';
 import { PropertyDeclarations } from 'lit';
-import { headerContainerStyles, headerSkeletonStyles } from './vl-header.component.flux-css';
+import { headerContainerStyles, headerSkeletonStyles, legacyThemeTokenStyles } from './vl-header.component.flux-css';
 import { headerDefaults } from './vl-header.defaults';
 export type ApplicationLink = ApplicationMenuLink;
 
@@ -105,7 +105,11 @@ export class VlHeader extends BaseLitElement {
             'afterbegin',
             '<header id="header__container"><div id="header"></div></header>'
         );
-        document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerContainerStyles.styleSheet!];
+        document.adoptedStyleSheets = [
+            ...document.adoptedStyleSheets,
+            headerContainerStyles.styleSheet!,
+            legacyThemeTokenStyles.styleSheet!,
+        ];
     }
 
     private injectHeaderContainerSkeleton() {

--- a/libs/styles/src/base/var/vl-color-domg.raw.css
+++ b/libs/styles/src/base/var/vl-color-domg.raw.css
@@ -8,3 +8,8 @@
     --vl-color--domg-steunkleur-light: #a67d43;
     --vl-color--domg-steunkleur-extra-light: #c58835;
 }
+
+/*body {*/
+/*    --vl-theme-primary-color: red;*/
+/*    --vlw-theme-primary-color: red;*/
+/*}*/


### PR DESCRIPTION
## Jira

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-639
-> Zie de vraag in het ticket aan Alexander Peyls, het probleem lijkt er niet meer te zijn.

## Samenvatting
Wanneer `vl-header-next` of `vl-footer-next` op een pagina aanwezig is, blijven de globale CSS-variabelen `--vl-theme-primary-color` en `--vl-theme-fg-color` (en hun afgeleiden) op hun legacy VO-waarden in plaats van overschreven te worden door de externe widget-bundel. Componenten zoals `vl-infoblock` die deze tokens consumeren, renderen opnieuw correct (geel i.p.v. grijs).

## Wijzigingen
- `vl-header-next` injecteert een `body`-scoped stylesheet met de legacy VO theme-tokens via `document.adoptedStyleSheets`.
- `vl-footer-next` doet hetzelfde via een nieuwe `vl-footer.component.flux-css.ts` module.
- Token-set bevat `--vl-theme-primary-color`, `-60`, `-70`, `-rgba-30`, `--vl-theme-fg-color`, `-60`, `-70` — identiek aan de bestaande overrides in `vl-tabs`, `vl-search` en `map-actions`.
- Cypress component-tests toegevoegd die de aanwezigheid van de legacy waarden op `body` verifiëren voor zowel header als footer.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `--vl-theme-primary-color` blijft `#ffe615` op pagina's met `vl-header-next`/`vl-footer-next` — body-scoped tokens winnen via inheritance van de widget-`:root`-declaraties.
- [x] Icon-achtergrond van `vl-infoblock` rendert opnieuw geel — visueel reproduceerbaar via de privacy-pagina van het Grups-project.
- [x] Geen visuele regressie binnen de header/footer-widget zelf — token-set gelijk aan bestaande in-app overrides; visuele eindverificatie blijft aanbevolen op de Grups-app.
- [x] Andere globale tokens (`--vl-theme-fg-color*`) blijven op hun legacy waarden — meegenomen in dezelfde stylesheet.