### PR TITLE
fix: FLUX-605 - vl-popover-action-list - sluit popover automatisch na klik op actie

### DIFF
--- a/libs/components/src/block/block.web-types.json
+++ b/libs/components/src/block/block.web-types.json
@@ -1814,7 +1814,14 @@
                 },
                 {
                     "name": "vl-popover-action-list",
-                    "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-popover--documentatie"
+                    "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-popover--documentatie",
+                    "attributes": [
+                        {
+                            "name": "keep-open",
+                            "description": "Verhindert dat de bijhorende popover sluit na het klikken op een actie.",
+                            "default": "false"
+                        }
+                    ]
                 },
                 {
                     "name": "vl-progress-bar",

--- a/libs/components/src/block/popover/vl-popover-action-list.component.ts
+++ b/libs/components/src/block/popover/vl-popover-action-list.component.ts
@@ -1,14 +1,33 @@
 import { BaseLitElement } from '@domg-wc/common';
 import { vlLegacyStyles } from '@domg-wc/styles';
 import { resetStyle } from '@domg/govflanders-style/common';
-import { CSSResult, html, PropertyValues, TemplateResult } from 'lit';
+import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { vlPopoverActionListFluxStyles } from './vl-popover-action-list.flux-css';
 
 @customElement('vl-popover-action-list')
 export class VlPopoverActionListComponent extends BaseLitElement {
+    /** Verhindert dat de bijhorende popover sluit na het klikken op een actie. */
+    keepOpen = false;
+
     static get styles(): (CSSResult | CSSResult[])[] {
         return [resetStyle, vlLegacyStyles, vlPopoverActionListFluxStyles];
+    }
+
+    static get properties(): PropertyDeclarations {
+        return {
+            keepOpen: { type: Boolean, attribute: 'keep-open' },
+        };
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener('click', this.handleClick);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener('click', this.handleClick);
     }
 
     protected render(): TemplateResult {
@@ -19,6 +38,16 @@ export class VlPopoverActionListComponent extends BaseLitElement {
         super.firstUpdated(changedProperties);
         this.setAttribute('role', 'menu');
     }
+
+    private handleClick = (e: MouseEvent): void => {
+        if (this.keepOpen) return;
+        const isAction = e.composedPath().some(
+            (el) => el instanceof Element && el.tagName.toLowerCase() === 'vl-popover-action'
+        );
+        if (!isAction) return;
+        const popover = this.closest('vl-popover') as (HTMLElement & { hide: () => void }) | null;
+        popover?.hide();
+    };
 }
 
 declare global {

--- a/libs/components/src/block/popover/vl-popover.component.cy.ts
+++ b/libs/components/src/block/popover/vl-popover.component.cy.ts
@@ -14,6 +14,7 @@ const mountDefault = ({
     hideArrow,
     hideOnClick,
     distance,
+    keepOpen,
 }: {
     trigger?: string;
     contentPadding?: string;
@@ -22,6 +23,7 @@ const mountDefault = ({
     hideArrow?: boolean;
     hideOnClick?: boolean;
     distance?: number;
+    keepOpen?: boolean;
 }) => {
     return cy.mount(html`
         <vl-button ghost icon="nav-show-more-vertical" id="btn-acties" label="Acties"></vl-button>
@@ -36,7 +38,7 @@ const mountDefault = ({
             distance=${distance || nothing}
             content-padding=${contentPadding || nothing}
         >
-            <vl-popover-action-list aria-label="Acties">
+            <vl-popover-action-list aria-label="Acties" ?keep-open=${keepOpen}>
                 <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
                 <vl-popover-action icon="bell" .action=${'report'}>Rapportenoverzicht</vl-popover-action>
                 <vl-popover-action icon="pin" .action=${'locate'}>Vind locatie</vl-popover-action>
@@ -76,7 +78,20 @@ describe('cypress-component - block components - vl-popover - default', () => {
         cy.checkA11y('vl-popover');
     });
 
-    it('should close when clicking an action', () => {
+    it('should auto-close when clicking an action', () => {
+        mountDefault({});
+        cy.injectAxe();
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').should('have.attr', 'open');
+        cy.checkA11y('vl-popover');
+
+        cy.get('vl-popover').find('vl-popover-action').first().click();
+        cy.get('vl-popover').should('not.have.attr', 'open');
+        cy.checkA11y('vl-popover');
+    });
+
+    it('should close when clicking an action with hide-on-click', () => {
         mountDefault({ hideOnClick: true });
         cy.injectAxe();
 
@@ -89,8 +104,8 @@ describe('cypress-component - block components - vl-popover - default', () => {
         cy.checkA11y('vl-popover');
     });
 
-    it('should not close when clicking an action', () => {
-        mountDefault({});
+    it('should not close when clicking an action with keep-open on action-list', () => {
+        mountDefault({ keepOpen: true });
         cy.injectAxe();
 
         cy.get('#btn-acties').click();


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-605

## Samenvatting
`vl-popover` sluit nu consistent in alle browsers wanneer een gebruiker op een `vl-popover-action` klikt, zonder dat consumers `hide-on-click` manueel moeten zetten. Voor flows die de popover bewust open willen houden (bv. multi-select binnen de actie-lijst) is er een nieuw `keep-open` attribuut op `vl-popover-action-list`.

## Wijzigingen
- `vl-popover-action-list` sluit zijn omsluitende `vl-popover` automatisch na een klik op een `vl-popover-action` (zowel button- als link-acties).
- Nieuw `keep-open` attribuut op `vl-popover-action-list` als opt-out voor consumers die de popover open willen laten.
- `hide-on-click` op `vl-popover` blijft volledig werken voor popovers met vrije content.
- Cypress-tests gedekt: nieuwe auto-close-test, hernoemde `hide-on-click`-test, en nieuwe `keep-open`-test.
- Web-types JSON gedocumenteerd met het nieuwe `keep-open` attribuut.

## Backwards compatibility
Breaking change: een `vl-popover` met `vl-popover-action-list` sluit nu automatisch bij klik op een action — eerder bleef hij open zonder `hide-on-click`. Migratie: consumers die de popover open willen houden (bv. multi-select binnen de action-list) zetten `keep-open` op `vl-popover-action-list`.

## Succescriteria
- [x] Klik op een `vl-popover-action` (button of link) sluit de bijhorende `vl-popover` consistent in alle browsers, zonder dat consumers `hide-on-click` manueel moeten zetten — gedekt door de nieuwe click-listener in `vl-popover-action-list`.
- [x] Bestaand gebruik van `vl-popover` met arbitraire content (zonder `vl-popover-action-list`) blijft ongewijzigd open zodra erin geklikt wordt — listener zit op de action-list, niet op de popover.
- [x] `hide-on-click` attribute blijft werken voor consumers die ook bij niet-action content willen sluiten — niet aangeraakt.
- [x] Bestaande Cypress tests blijven groen; nieuwe test dekt sluiten-na-action-click af zonder `hide-on-click` — auto-close-test toegevoegd, oude pre-fix-test correct herschreven naar `keep-open`-test.
- [x] Storybook story `PopoverDefault` demonstreert dat clicken op een action de popover sluit (zonder dat de control op true gezet hoeft te worden) — komt automatisch tot uiting via de nieuwe default-flow.