### PR TITLE
feat: FLUX-635 - vl-doormat - title-only rendering zonder witruimte

### DIFF
--- a/libs/components/src/block/doormat/stories/vl-doormat.stories.ts
+++ b/libs/components/src/block/doormat/stories/vl-doormat.stories.ts
@@ -134,3 +134,20 @@ DoormatFullHeight.storyName = 'vl-doormat - full height';
 DoormatFullHeight.args = {
     fullHeight: true,
 };
+
+const DoormatTitleOnlyTemplate = story(
+    doormatArgs,
+    ({ href }) => html`
+        <div class="story--fixed-width">
+            <vl-doormat href=${href}>
+                <span slot="title">Bouwen, wonen en energie</span>
+            </vl-doormat>
+        </div>
+    `
+);
+
+export const DoormatTitleOnly = DoormatTitleOnlyTemplate.bind({});
+DoormatTitleOnly.storyName = 'vl-doormat - title only';
+DoormatTitleOnly.args = {
+    href: 'https://www.vlaanderen.be/bouwen-wonen-en-energie',
+};

--- a/libs/components/src/block/doormat/vl-doormat.component.cy.ts
+++ b/libs/components/src/block/doormat/vl-doormat.component.cy.ts
@@ -247,6 +247,48 @@ describe('cypress-component - block components - vl-doormat', () => {
             });
     });
 
+    it('should add vl-doormat--no-text class when no text slot is provided', () => {
+        cy.mount(html`
+            <vl-doormat href="https://www.vlaanderen.be/bouwen-wonen-en-energie">
+                <span slot="title">Bouwen, wonen en energie</span>
+            </vl-doormat>
+        `);
+
+        cy.get('vl-doormat').shadow().find('a.vl-doormat').should('have.class', 'vl-doormat--no-text');
+    });
+
+    it('should not add vl-doormat--no-text class when text slot is provided', () => {
+        cy.mount(html`
+            <vl-doormat href="https://www.vlaanderen.be/bouwen-wonen-en-energie">
+                <span slot="title">Bouwen, wonen en energie</span>
+                <span slot="text">Tekst over bouwen.</span>
+            </vl-doormat>
+        `);
+
+        cy.get('vl-doormat').shadow().find('a.vl-doormat').should('not.have.class', 'vl-doormat--no-text');
+    });
+
+    it('should hide the text wrapper when no text slot is provided', () => {
+        cy.mount(html`
+            <vl-doormat href="https://www.vlaanderen.be/bouwen-wonen-en-energie">
+                <span slot="title">Bouwen, wonen en energie</span>
+            </vl-doormat>
+        `);
+
+        cy.get('vl-doormat').shadow().find('.vl-doormat__text').should('have.css', 'display', 'none');
+    });
+
+    it('should show the text wrapper when a text slot is provided', () => {
+        cy.mount(html`
+            <vl-doormat href="https://www.vlaanderen.be/bouwen-wonen-en-energie">
+                <span slot="title">Bouwen, wonen en energie</span>
+                <span slot="text">Tekst over bouwen.</span>
+            </vl-doormat>
+        `);
+
+        cy.get('vl-doormat').shadow().find('.vl-doormat__text').should('not.have.css', 'display', 'none');
+    });
+
     it('should set graphic', () => {
         cy.mount(html`
             <vl-doormat

--- a/libs/components/src/block/doormat/vl-doormat.component.ts
+++ b/libs/components/src/block/doormat/vl-doormat.component.ts
@@ -1,6 +1,7 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common';
 import { doormatDefaults } from './vl-doormat.defaults';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
+import { state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { vlLinkStyles } from '../../atom/link-style/vl-link-style.css';
@@ -18,6 +19,7 @@ export class VlDoormatComponent extends BaseLitElement {
     private imageHeight = doormatDefaults.imageHeight;
     private graphic = doormatDefaults.graphic;
     private fullHeight = doormatDefaults.fullHeight;
+    @state() private hasText = false;
 
     static get styles(): CSSResult[] {
         return [vlIconStyles, vlLinkStyles(), doormatStyle];
@@ -44,6 +46,7 @@ export class VlDoormatComponent extends BaseLitElement {
             'vl-doormat--alt': this.alt,
             'vl-doormat--graphic': this.graphic,
             'vl-doormat--full-height': this.fullHeight,
+            'vl-doormat--no-text': !this.hasText,
         };
         const target = this.external ? '_blank' : nothing;
         const rel = this.external ? 'noopener noreferrer nofollow' : nothing;
@@ -63,11 +66,16 @@ export class VlDoormatComponent extends BaseLitElement {
                         ${this.external ? this.renderExternalIcon() : nothing}
                     </h2>
                     <div class="vl-doormat__text">
-                        <slot name="text"></slot>
+                        <slot name="text" @slotchange=${this.onTextSlotChange}></slot>
                     </div>
                 </div>
             </a>
         `;
+    }
+
+    private onTextSlotChange(e: Event): void {
+        const slot = e.target as HTMLSlotElement;
+        this.hasText = slot.assignedNodes({ flatten: true }).length > 0;
     }
 
     private renderExternalIcon(): TemplateResult {

--- a/libs/components/src/block/doormat/vl-doormat.css.ts
+++ b/libs/components/src/block/doormat/vl-doormat.css.ts
@@ -95,6 +95,16 @@ const styles: CSSResult = css`
         &.vl-doormat--full-height {
             height: 100%;
         }
+
+        &.vl-doormat--no-text {
+            .vl-doormat__title {
+                margin-bottom: 0;
+            }
+
+            .vl-doormat__text {
+                display: none;
+            }
+        }
     }
 `;
 export default styles;


### PR DESCRIPTION
## Review Kris S. - draft -> ready

build is ok: http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC322

De oplossing met `@state() private hasText` leek me relatief complex, maar een oplossing puur met een css selector lukt niet.

Die poging gaf volgende feedback: De CSS-only refactor lukt niet betrouwbaar. Ik heb :host:not(:has([slot='text'])), :host(:not(:has(...))) en de positieve omgekeerde variant :host:has([slot='text']) geprobeerd - alle drie matchen niet in de Chrome-versie die Cypress draait. :has()
De :host lijkt daar niet door de light-DOM kinderen te scannen voor slot-attributen. Tegelijk gebruikt vl-tab.flux-css.ts wel :host:has(a) succesvol, dus het is geen complete blokkade - vermoedelijk een edge case met het [slot='text'] attribuut of de combinatie met :not().
  
Conclusie: voor deze specifieke case is de @state hasText + slotchange aanpak inderdaad de simpelste werkende oplossing. Theoretisch eleganter met CSS, maar niet betrouwbaar gekregen binnen een redelijke tijd.

## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-635

## Samenvatting
Een `vl-doormat` zonder text-slot rendert nu compact, zonder de overbodige witruimte onder de titel. Doormats mét tekst behouden hun bestaande spacing en de publieke API blijft ongewijzigd.

## Wijzigingen
- Nieuwe modifier `vl-doormat--no-text` wordt automatisch toegepast wanneer er geen `slot="text"` aangeleverd is.
- In die modus wordt de margin onder de titel weggehaald en de lege text-wrapper verborgen.
- Detectie via slotchange-listener — werkt ook bij dynamisch toevoegen of verwijderen van tekst.
- Storybook-story `vl-doormat - title only` toont het nieuwe scenario.
- Drie Cypress-tests dekken het title-only gedrag af (class wel/niet aanwezig + verborgen text-wrapper).

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Een `<vl-doormat>` zonder `<… slot="text">` rendert zonder overbodige witruimte onder de titel — opgelost via de `vl-doormat--no-text` modifier.
- [x] Bestaande doormats mét tekst behouden hun huidige spacing — slotchange zet `hasText = true`, modifier verdwijnt.
- [x] Geen wijzigingen nodig aan de publieke API voor consumers die al een tekstslot meegeven — interne `@state()` only.
- [x] Een Storybook-story + Cypress-test dekt expliciet het "alleen titel"-scenario af — `DoormatTitleOnly` story + 3 component-tests.
- [x] Ook de `graphic`- en `image`-varianten blijven correct uitlijnen wanneer er geen tekst is — modifier raakt enkel titel en text-wrapper.