### PR TITLE
feat: FLUX-176 - vl-checkbox-group - nieuwe component voor multi-select checkboxes

### DIFF
--- a/libs/components/src/form/checkbox-group/index.ts
+++ b/libs/components/src/form/checkbox-group/index.ts
@@ -1,0 +1,1 @@
+export { VlCheckboxGroupComponent } from './vl-checkbox-group.component';

--- a/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories-arg.ts
+++ b/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories-arg.ts
@@ -1,0 +1,64 @@
+import { CATEGORIES, TYPES } from '@resources/utils-storybook';
+import { ArgTypes } from '@storybook/web-components-vite';
+import { action } from 'storybook/actions';
+import { formControlArgs, formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
+import { checkboxGroupDefaults } from '../vl-checkbox-group.defaults';
+
+type CheckboxGroupArgs = typeof formControlArgs &
+    typeof checkboxGroupDefaults & { onVlChange: () => void; onVlInput: () => void; onVlValid: () => void };
+
+export const checkboxGroupArgs: CheckboxGroupArgs = {
+    ...formControlArgs,
+    ...checkboxGroupDefaults,
+    onVlChange: action('vl-change'),
+    onVlInput: action('vl-input'),
+    onVlValid: action('vl-valid'),
+};
+
+export const checkboxGroupArgTypes: ArgTypes<CheckboxGroupArgs> = {
+    ...formControlArgTypes,
+    readonly: {
+        name: 'readonly',
+        description: 'Duidt aan dat de groep enkel leesbaar is.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(checkboxGroupArgs.readonly) },
+        },
+    },
+    block: {
+        name: 'block',
+        description: 'Duidt aan dat de checkboxes de volledige breedte van hun parent innemen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(checkboxGroupArgs.block) },
+        },
+    },
+    onVlChange: {
+        name: 'vl-change',
+        description:
+            'Event dat afgevuurd wordt als een checkbox aangevinkt of uitgevinkt wordt.<br>Het detail object bevat de checked state en de waarde van de checkbox.',
+        table: {
+            type: { summary: '{ checked: boolean, value?: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlInput: {
+        name: 'vl-input',
+        description:
+            'Event dat alleen afgevuurd wordt als een gebruiker een checkbox aanvinkt of uitvinkt.<br>Het detail object bevat de checked state en de waarde van de checkbox.',
+        table: {
+            type: { summary: '{ checked: boolean, value?: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlValid: {
+        name: 'vl-valid',
+        description: 'Event dat afgevuurd wordt als de groep geldig is.',
+        table: {
+            type: { summary: '{ checked: boolean, value?: string }' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+};

--- a/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories-doc.mdx
+++ b/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories-doc.mdx
@@ -1,0 +1,61 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlCheckboxGroupStories from './vl-checkbox-group.stories';
+import FormControlPublicMethods from '../../form-control/stories/form-control.public-methods-doc.mdx'
+
+# Checkbox Group
+
+<FluxComponentMetaData id="components-form-checkbox-group" />
+
+
+## Doel
+
+Gebruik de `checkbox-group` component om de gebruiker de mogelijkheid te geven meerdere keuzes tegelijk te selecteren uit een lijst.
+De `vl-checkbox` componenten zijn de child-elementen van de groep.
+Zie het [form demo](/docs/patronen-formulier-demo--documentatie) voorbeeld voor gebruik binnen een formulier.
+
+
+## Voorbeeld
+
+```js
+import { VlCheckboxComponent, VlCheckboxGroupComponent } from '@domg-wc/components/form';
+```
+
+```html
+<vl-checkbox-group name="vervoer" label="Vervoersmiddel">
+    <vl-checkbox value="fiets">Fiets</vl-checkbox>
+    <vl-checkbox value="auto">Auto</vl-checkbox>
+    <vl-checkbox value="bus">Bus</vl-checkbox>
+</vl-checkbox-group>
+```
+
+<Canvas of={VlCheckboxGroupStories.CheckboxGroupDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlCheckboxGroupStories.CheckboxGroupDefault} />
+
+
+## Publieke methodes
+
+<FormControlPublicMethods />
+
+
+## Geselecteerde waarden uitlezen
+
+De geselecteerde waarden zijn beschikbaar via de `values`-property (JS-only):
+
+```js
+const group = document.querySelector('vl-checkbox-group');
+console.log(group.values); // bijv. ['fiets', 'bus']
+```
+
+Bij een form-submit worden alle aangevinkte waarden onder dezelfde `name` ingediend, compatibel met `FormData.getAll(name)`.
+
+
+## Validatie
+> Meer info over validatie binnen onze form componenten vind je hier: [Form - Validatie](/docs/patronen-formulier-validatie--documentatie)
+
+### Required
+
+De `checkbox-group` component kan ingesteld worden als `required`. Dit betekent dat minstens 1 `vl-checkbox` aangevinkt moet zijn.

--- a/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories.ts
+++ b/libs/components/src/form/checkbox-group/stories/vl-checkbox-group.stories.ts
@@ -1,0 +1,54 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { story } from '@resources/utils-storybook';
+import { Meta } from '@storybook/web-components-vite';
+import { html } from 'lit';
+import { VlCheckboxComponent } from '../../checkbox/vl-checkbox.component';
+import { VlCheckboxGroupComponent } from '../vl-checkbox-group.component';
+import { checkboxGroupArgs, checkboxGroupArgTypes } from './vl-checkbox-group.stories-arg';
+import checkboxGroupDoc from './vl-checkbox-group.stories-doc.mdx';
+
+registerWebComponents([VlCheckboxComponent, VlCheckboxGroupComponent]);
+
+export default {
+    id: 'components-form-checkbox-group',
+    title: 'Components - Form/checkbox-group',
+    tags: ['autodocs'],
+    args: checkboxGroupArgs,
+    argTypes: checkboxGroupArgTypes,
+    parameters: {
+        docs: {
+            page: checkboxGroupDoc,
+        },
+    },
+} as Meta<typeof checkboxGroupArgs>;
+
+export const CheckboxGroupDefault = story(
+    checkboxGroupArgs,
+    ({ id, required, readonly, disabled, error, success, label, name, onVlChange, onVlInput, onVlReset, onVlValid }) =>
+        html`
+            <vl-checkbox-group
+                id=${id}
+                name=${name}
+                label=${label}
+                ?required=${required}
+                ?readonly=${readonly}
+                ?disabled=${disabled}
+                ?error=${error}
+                ?success=${success}
+                @vl-change=${onVlChange}
+                @vl-input=${onVlInput}
+                @vl-reset=${onVlReset}
+                @vl-valid=${onVlValid}
+            >
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `
+);
+CheckboxGroupDefault.storyName = 'vl-checkbox-group - default';
+CheckboxGroupDefault.args = {
+    id: 'vervoer',
+    name: 'vervoer',
+    label: 'Vervoersmiddel',
+};

--- a/libs/components/src/form/checkbox-group/vl-checkbox-group.component.css.ts
+++ b/libs/components/src/form/checkbox-group/vl-checkbox-group.component.css.ts
@@ -1,0 +1,16 @@
+import { css, CSSResult } from 'lit';
+
+export const vlCheckboxGroupComponentStyles: CSSResult = css`
+    .vl-u-visually-hidden {
+        position: absolute !important;
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        clip: rect(1px, 1px, 1px, 1px);
+        margin: -1px;
+        padding: 0;
+        border: 0;
+        left: 0;
+        top: 0;
+    }
+`;

--- a/libs/components/src/form/checkbox-group/vl-checkbox-group.component.cy.ts
+++ b/libs/components/src/form/checkbox-group/vl-checkbox-group.component.cy.ts
@@ -1,0 +1,332 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlCheckboxComponent } from '../checkbox/vl-checkbox.component';
+import { VlCheckboxGroupComponent } from './vl-checkbox-group.component';
+
+registerWebComponents([VlCheckboxComponent, VlCheckboxGroupComponent]);
+
+const clickCheckboxWithValue = (value: string) => {
+    cy.get(`vl-checkbox[value="${value}"]`).shadow().find('input').click({ force: true });
+};
+
+describe('vl-checkbox-group - properties & states', () => {
+    beforeEach(() => {
+        cy.viewport(1200, 800);
+    });
+
+    it('should mount', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').shadow();
+    });
+
+    it('should be accessible', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-checkbox-group');
+    });
+
+    it('should have checked children when checked attribute is set on child', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets" checked>Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus" checked>Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="auto"]').should('not.have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="bus"]').should('have.attr', 'checked');
+    });
+
+    it('should reflect initial values in the values property', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets" checked>Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus" checked>Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').runTest((group) => {
+            expect((group as VlCheckboxGroupComponent).values).to.deep.equal(['fiets', 'bus']);
+        });
+    });
+
+    it('should propagate disabled to all checkboxes', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-checkbox-group').invoke('attr', 'disabled', '');
+        cy.checkA11y('vl-checkbox-group');
+
+        cy.get('vl-checkbox').each(($cb) => {
+            cy.wrap($cb).should('have.attr', 'disabled');
+        });
+    });
+
+    it('should propagate error to all checkboxes', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').invoke('attr', 'error', '');
+
+        cy.get('vl-checkbox').each(($cb) => {
+            cy.wrap($cb).should('have.attr', 'error');
+        });
+    });
+
+    it('should propagate success to all checkboxes', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-checkbox-group').invoke('attr', 'success', '');
+        cy.checkA11y('vl-checkbox-group');
+
+        cy.get('vl-checkbox').each(($cb) => {
+            cy.wrap($cb).should('have.attr', 'success');
+        });
+    });
+
+    it('should propagate block to all checkboxes', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').invoke('attr', 'block', '');
+
+        cy.get('vl-checkbox').each(($cb) => {
+            cy.wrap($cb).shadow().find('.vl-checkbox').should('have.class', 'vl-checkbox--block');
+        });
+    });
+
+    it('should prevent checking when readonly', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel" readonly>
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').shadow().find('input').click({ force: true });
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('not.have.attr', 'checked');
+        cy.checkA11y('vl-checkbox-group');
+    });
+});
+
+describe('vl-checkbox-group - multi-select interaction', () => {
+    it('should allow checking multiple checkboxes', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        clickCheckboxWithValue('fiets');
+        clickCheckboxWithValue('bus');
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="auto"]').should('not.have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="bus"]').should('have.attr', 'checked');
+    });
+
+    it('should update values property when checkboxes are toggled', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+                <vl-checkbox value="bus">Bus</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        clickCheckboxWithValue('fiets');
+        clickCheckboxWithValue('auto');
+
+        cy.get('vl-checkbox-group').runTest((group) => {
+            expect((group as VlCheckboxGroupComponent).values).to.include('fiets');
+            expect((group as VlCheckboxGroupComponent).values).to.include('auto');
+            expect((group as VlCheckboxGroupComponent).values).not.to.include('bus');
+        });
+
+        clickCheckboxWithValue('fiets');
+
+        cy.get('vl-checkbox-group').runTest((group) => {
+            expect((group as VlCheckboxGroupComponent).values).not.to.include('fiets');
+            expect((group as VlCheckboxGroupComponent).values).to.include('auto');
+        });
+    });
+
+    it('should allow unchecking a checked checkbox', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets" checked>Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('have.attr', 'checked');
+
+        clickCheckboxWithValue('fiets');
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('not.have.attr', 'checked');
+    });
+});
+
+describe('vl-checkbox-group - events', () => {
+    it('should dispatch vl-change event when a checkbox is toggled', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.createStubForEvent('vl-checkbox-group', 'vl-change');
+
+        clickCheckboxWithValue('fiets');
+
+        cy.get('@vl-change').should('have.been.calledOnce');
+        cy.get('@vl-change')
+            .its('firstCall.args.0.detail')
+            .should('deep.include', { checked: true, value: 'fiets' });
+    });
+
+    it('should dispatch vl-input event when a user clicks a checkbox', () => {
+        cy.mount(html`
+            <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                <vl-checkbox value="auto">Auto</vl-checkbox>
+            </vl-checkbox-group>
+        `);
+
+        cy.createStubForEvent('vl-checkbox-group', 'vl-input');
+
+        clickCheckboxWithValue('auto');
+
+        cy.get('@vl-input').should('have.been.calledOnce');
+    });
+});
+
+describe('vl-checkbox-group - in form', () => {
+    it('should work inside a form', () => {
+        cy.mount(html`
+            <form>
+                <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                    <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                    <vl-checkbox value="auto">Auto</vl-checkbox>
+                    <vl-checkbox value="bus">Bus</vl-checkbox>
+                </vl-checkbox-group>
+            </form>
+        `);
+
+        clickCheckboxWithValue('fiets');
+        clickCheckboxWithValue('bus');
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="auto"]').should('not.have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="bus"]').should('have.attr', 'checked');
+    });
+
+    it('should reset to initial checked state when the form is reset', () => {
+        cy.mount(html`
+            <form>
+                <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel">
+                    <vl-checkbox value="fiets" checked>Fiets</vl-checkbox>
+                    <vl-checkbox value="auto">Auto</vl-checkbox>
+                    <vl-checkbox value="bus">Bus</vl-checkbox>
+                </vl-checkbox-group>
+                <button class="vl-button" type="reset">Reset</button>
+            </form>
+        `);
+
+        clickCheckboxWithValue('auto');
+        clickCheckboxWithValue('fiets');
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="auto"]').should('have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('not.have.attr', 'checked');
+
+        cy.get('button[type="reset"]').click();
+
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="fiets"]').should('have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="auto"]').should('not.have.attr', 'checked');
+        cy.get('vl-checkbox-group').find('vl-checkbox[value="bus"]').should('not.have.attr', 'checked');
+    });
+
+    it('should fail required validation when no checkbox is checked', () => {
+        cy.mount(html`
+            <form>
+                <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel" required>
+                    <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                    <vl-checkbox value="auto">Auto</vl-checkbox>
+                </vl-checkbox-group>
+                <vl-form-message for="vervoer" state="valueMissing">Selecteer minstens één optie.</vl-form-message>
+                <button class="vl-button" type="submit">Verstuur</button>
+            </form>
+        `);
+        cy.injectAxe();
+
+        cy.get('button[type="submit"]').click();
+
+        cy.get('vl-checkbox-group').runTest((group) => {
+            expect((group as VlCheckboxGroupComponent).validity.valid).to.be.false;
+        });
+        cy.checkA11y('vl-checkbox-group');
+    });
+
+    it('should pass required validation when at least one checkbox is checked', () => {
+        cy.mount(html`
+            <form>
+                <vl-checkbox-group id="vervoer" name="vervoer" label="Vervoersmiddel" required>
+                    <vl-checkbox value="fiets">Fiets</vl-checkbox>
+                    <vl-checkbox value="auto">Auto</vl-checkbox>
+                </vl-checkbox-group>
+                <button class="vl-button" type="submit">Verstuur</button>
+            </form>
+        `);
+
+        clickCheckboxWithValue('fiets');
+
+        cy.get('vl-checkbox-group').runTest((group) => {
+            expect((group as VlCheckboxGroupComponent).validity.valid).to.be.true;
+        });
+    });
+});

--- a/libs/components/src/form/checkbox-group/vl-checkbox-group.component.ts
+++ b/libs/components/src/form/checkbox-group/vl-checkbox-group.component.ts
@@ -1,0 +1,195 @@
+import { webComponent } from '@domg-wc/common';
+import { vlResetStyles } from '@domg-wc/styles';
+import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
+import { Validator } from '@open-wc/form-control';
+import { FormControl } from '../form-control/form-control';
+import { VlCheckboxComponent } from '../checkbox/vl-checkbox.component';
+import { vlCheckboxGroupComponentStyles } from './vl-checkbox-group.component.css';
+import { checkboxGroupDefaults } from './vl-checkbox-group.defaults';
+
+/** Valide wanneer required niet gezet is, of wanneer minstens één checkbox aangevinkt is. */
+const atLeastOneCheckedValidator: Validator = {
+    attribute: 'required',
+    key: 'valueMissing',
+    message: 'Selecteer minstens één optie.',
+    isValid(instance: HTMLElement): boolean {
+        const group = instance as VlCheckboxGroupComponent;
+        if (!group.hasAttribute('required')) return true;
+        return group.values.length > 0;
+    },
+};
+
+@webComponent('vl-checkbox-group')
+export class VlCheckboxGroupComponent extends FormControl {
+    /** De geselecteerde waarden van de groep. Enkel via JS-property instelbaar; gebruik `checked` op de child `<vl-checkbox>` voor de initiële staat. */
+    values: string[] = [];
+
+    private readonly = checkboxGroupDefaults.readonly;
+    private block = checkboxGroupDefaults.block;
+    private initialValues: string[] = [];
+
+    // vl-checkbox gebruikt @click (niet @change), dus preventDefault() op de outer click werkt niet.
+    // We herstellen de state in onChildChange via een WeakSet-guard om dubbele verwerking te voorkomen.
+    private pendingRestores = new WeakSet<VlCheckboxComponent>();
+
+    static get styles(): CSSResult[] {
+        return [vlResetStyles, vlCheckboxGroupComponentStyles];
+    }
+
+    static get properties(): PropertyDeclarations {
+        return {
+            values: { type: Array },
+            readonly: { type: Boolean },
+            block: { type: Boolean },
+        };
+    }
+
+    static formControlValidators = [...FormControl.formControlValidators, atLeastOneCheckedValidator];
+
+    get validationTarget(): HTMLInputElement | undefined | null {
+        const firstCheckbox = this.getCheckboxes()[0];
+        return firstCheckbox ? firstCheckbox.validationTarget : null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('vl-change', this.onChildChange);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this.removeEventListener('vl-change', this.onChildChange);
+    }
+
+    protected firstUpdated(_changedProperties: PropertyValues) {
+        super.firstUpdated(_changedProperties);
+
+        const checked = this.getCheckboxes()
+            .filter((cb) => cb.hasAttribute('checked'))
+            .map((cb) => cb.getAttribute('value') ?? 'on');
+
+        this.values = checked;
+        this.initialValues = [...checked];
+        this.setFormValue(this.values);
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+
+        if (changedProperties.has('name')) {
+            this.updateCheckboxesForAttribute('name');
+        }
+        if (changedProperties.has('block')) {
+            this.updateCheckboxesForAttribute('block');
+        }
+        if (changedProperties.has('readonly')) {
+            this.updateCheckboxesForAttribute('readonly');
+        }
+        if (changedProperties.has('disabled')) {
+            this.updateCheckboxesForAttribute('disabled');
+        }
+        if (changedProperties.has('error')) {
+            this.updateCheckboxesForAttribute('error');
+        }
+        if (changedProperties.has('isInvalid')) {
+            this.getCheckboxes().forEach((cb) => {
+                if (this.isInvalid) {
+                    cb.setAttribute('error', '');
+                    cb.validationTarget?.setAttribute('aria-invalid', 'true');
+                } else {
+                    cb.removeAttribute('error');
+                    cb.validationTarget?.removeAttribute('aria-invalid');
+                }
+            });
+        }
+        if (changedProperties.has('success')) {
+            this.updateCheckboxesForAttribute('success');
+        }
+        if (changedProperties.has('values')) {
+            this.setFormValue(this.values);
+        }
+    }
+
+    render(): TemplateResult {
+        return html`
+            <fieldset>
+                <legend class="vl-u-visually-hidden">${this.label}</legend>
+                <slot></slot>
+            </fieldset>
+        `;
+    }
+
+    resetFormControl() {
+        super.resetFormControl();
+
+        this.values = [...this.initialValues];
+        this.syncCheckedStateToChildren(this.initialValues);
+        this.setFormValue(this.values);
+    }
+
+    private setFormValue(values: string[]) {
+        const fd = new FormData();
+        values.forEach((v) => fd.append(this.name, v));
+        this.setValue(fd);
+    }
+
+    private onChildChange = (event: Event) => {
+        const detail = (event as CustomEvent).detail as { checked: boolean; value?: string | null };
+        const value = detail.value ?? 'on';
+        const targetCheckbox = event.target as VlCheckboxComponent;
+
+        if (this.pendingRestores.has(targetCheckbox)) {
+            this.pendingRestores.delete(targetCheckbox);
+            return;
+        }
+
+        if (this.readonly) {
+            this.pendingRestores.add(targetCheckbox);
+            if (this.values.includes(value)) {
+                targetCheckbox.setAttribute('checked', '');
+            } else {
+                targetCheckbox.removeAttribute('checked');
+            }
+            targetCheckbox.validationTarget?.focus();
+            return;
+        }
+
+        if (detail.checked) {
+            if (!this.values.includes(value)) {
+                this.values = [...this.values, value];
+            }
+        } else {
+            this.values = this.values.filter((v) => v !== value);
+        }
+
+        this.setFormValue(this.values);
+    };
+
+    private syncCheckedStateToChildren(values: string[]) {
+        this.getCheckboxes().forEach((cb) => {
+            const value = cb.getAttribute('value') ?? 'on';
+            if (values.includes(value)) {
+                cb.setAttribute('checked', '');
+            } else {
+                cb.removeAttribute('checked');
+            }
+        });
+    }
+
+    private updateCheckboxesForAttribute(attribute: string) {
+        const key = attribute as keyof VlCheckboxGroupComponent;
+        this.getCheckboxes().forEach((cb) =>
+            this[key] ? cb.setAttribute(attribute, '') : cb.removeAttribute(attribute)
+        );
+    }
+
+    private getCheckboxes(): VlCheckboxComponent[] {
+        return Array.from(this.querySelectorAll<VlCheckboxComponent>('vl-checkbox'));
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-checkbox-group': VlCheckboxGroupComponent;
+    }
+}

--- a/libs/components/src/form/checkbox-group/vl-checkbox-group.defaults.ts
+++ b/libs/components/src/form/checkbox-group/vl-checkbox-group.defaults.ts
@@ -1,0 +1,7 @@
+import { formControlDefaults } from '../form-control/form-control.defaults';
+
+export const checkboxGroupDefaults = {
+    ...formControlDefaults,
+    readonly: false as boolean,
+    block: false as boolean,
+} as const;

--- a/libs/components/src/form/index.ts
+++ b/libs/components/src/form/index.ts
@@ -1,6 +1,7 @@
 export { VlFormLabelComponent, vlFormLabelComponentStyles } from './form-label'; // TODO: volgorde imports is hier belangrijk, invloed op registratie
 export { VlInputFieldComponent, inputFieldStyles } from './input-field'; // TODO: volgorde imports is hier belangrijk, invloed op registratie
 export { VlCheckboxComponent } from './checkbox';
+export { VlCheckboxGroupComponent } from './checkbox-group';
 export { VlDatepickerComponent } from './datepicker';
 export { VlFieldsetComponent } from './fieldset';
 export { VlFormMessageComponent } from './form-message';


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-176

## Samenvatting
Een nieuwe `<vl-checkbox-group>` component groepeert meerdere `<vl-checkbox>`-elementen tot één form-control, zodat een consumer de geselecteerde waarden als groep kan uitlezen, valideren en submitten.

## Wijzigingen
- Nieuwe component `<vl-checkbox-group>` analoog aan `<vl-radio-group>` (wrapper rond bestaande `<vl-checkbox>`).
- Geselecteerde waarden beschikbaar via JS-property `values: string[]`; initiële staat via `checked` op child-checkboxes.
- Bij form-submit worden alle aangevinkte waarden onder de groeps-`name` ingediend (compatibel met `FormData.getAll(name)` / `URLSearchParams.getAll(name)`).
- Propagatie van `name`, `disabled`, `error`, `success`, `block` en `readonly` naar de child-checkboxes.
- Custom `atLeastOneCheckedValidator` zorgt dat `required` faalt zolang geen enkele checkbox aangevinkt is (gekoppeld aan `vl-form-message[state="valueMissing"]`).
- Storybook-story met docs en Cypress component-tests (mount, a11y, propagatie, multi-select, events, form-reset, required-validatie).

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `<vl-checkbox-group>` bestaat onder `libs/components/src/form/checkbox-group/` en wordt geëxporteerd via `libs/components/src/form/checkbox-group/index.ts` en `libs/components/src/form/index.ts` — module is toegevoegd en publiek geëxporteerd.
- [x] Component groepeert child `<vl-checkbox>` via `<slot>` binnen `<fieldset>` + `<legend>` — zelfde a11y-patroon als `vl-radio-group`.
- [x] Gegroepeerde waarde leesbaar én programmatisch instelbaar — via `values`-property; initiële staat via `checked` op child-checkboxes.
- [x] Bij form-submit worden alle aangevinkte values onder de groeps-`name` meegestuurd — `FormData.append` per value, compatibel met `getAll(name)`.
- [x] Propagatie van `name`, `disabled`, `error`, `success`, `readonly` naar children — geïmplementeerd in `updated()` (incl. `block`).
- [x] Validatie via `FormControl`: `required` zorgt dat minstens één checkbox aangevinkt moet zijn — custom `atLeastOneCheckedValidator` met key `valueMissing`.
- [x] Storybook story + Cypress-tests aanwezig — analoog aan `radio-group/stories/` en `radio-group/vl-radio-group.component.cy.ts`.
- [x] Geen breaking changes voor bestaande `vl-checkbox`-consumers — geen wijzigingen aan `vl-checkbox.component.ts`.