### PR TITLE
feat: FLUX-638 - vl-datepicker - native ondersteuning geschrapt

### DIFF
--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -144,16 +144,6 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
             defaultValue: { summary: String(datepickerArgs.disableMaskValidation) },
         },
     },
-    disableMobileNativeInput: {
-        name: 'disable-mobile-native-input',
-        description:
-            'Rendert de native datepicker op mobiele toestellen in plaats van flatpickr calendar. [Meer Info](https://flatpickr.js.org/mobile-support/)',
-        table: {
-            type: { summary: TYPES.BOOLEAN },
-            category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: String(datepickerArgs.disableMobileNativeInput) },
-        },
-    },
     pattern: {
         name: 'pattern',
         description:

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -129,10 +129,6 @@ De waarde moet conform het ingestelde `format` zijn (standaard `d.m.Y`), of de s
 - Als de mask validatie is uitgeschakeld, kan je met het `pattern` attribuut een regex patroon instellen. Je kan ook de `regex` property gebruiken voor complexere validatie.
 - De `patternMismatch` ValidityState key wordt gebruikt voor de pattern validatie error.
 
-## Mobile ondersteuning
-
-Standaard wordt de datepicker weergegeven als een kalender. Voor mobiele toestellen is het mogelijk de datepicker weer te geven als een input veld met een datepicker door het `enable-mobile-native-input` attribuut toe te voegen.
-
 ## Gekende Beperkingen
 
 - De datepicker is gedeeltelijk toegankelijk voor gebruikers die enkel met het toetsenbord navigeren. Ze kunnen wel manueel een datum invullen.

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
@@ -51,7 +51,6 @@ const DatepickerTemplate = story(
         error,
         readonly,
         required,
-        disableMobileNativeInput,
         disableMaskValidation,
         value,
         placeholder,
@@ -86,7 +85,6 @@ const DatepickerTemplate = story(
                             ?readonly=${readonly}
                             ?disabled=${disabled}
                             ?block=${block}
-                            ?disable-mobile-native-input=${disableMobileNativeInput}
                             ?disable-mask-validation=${disableMaskValidation}
                             type=${type}
                             format=${format}

--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -1668,35 +1668,69 @@ describe('vl-datepicker - interaction', () => {
     });
 });
 
+describe('vl-datepicker - mobile UA rendering', () => {
+    let originalUserAgent: string;
+
+    before(() => {
+        cy.window().then((win) => {
+            originalUserAgent = win.navigator.userAgent;
+        });
+    });
+
+    afterEach(() => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => originalUserAgent,
+                configurable: true,
+            });
+        });
+    });
+
+    it('should render the styled input + calendar button on mobile UA', () => {
+        cy.window().then((win) => {
+            Object.defineProperty(win.navigator, 'userAgent', {
+                get: () => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+                configurable: true,
+            });
+        });
+
+        cy.mount(html`<vl-datepicker label="date"></vl-datepicker>`);
+
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('exist').and('be.visible');
+        cy.get('vl-datepicker').shadow().find('button#toggle-calendar').should('exist').and('be.visible');
+        cy.get('vl-datepicker').shadow().find('input[type="date"]').should('not.exist');
+    });
+});
+
 describe('vl-datepicker - mobile', () => {
     beforeEach(() => {
         cy.viewport(320, 480);
     });
 
-    it('should mount with native input disabled', () => {
-        cy.mount(html`<vl-datepicker disable-mobile-native-input label="date"></vl-datepicker>`);
+    it('should mount', () => {
+        cy.mount(html`<vl-datepicker label="date"></vl-datepicker>`);
         cy.injectAxe();
 
         cy.get('vl-datepicker').shadow().find('input');
         cy.checkA11y('vl-datepicker');
     });
 
-    it('should be accessible with native input disabled', () => {
-        cy.mount(html` <vl-datepicker disable-mobile-native-input id="date" name="date" label="date"></vl-datepicker> `);
+    it('should be accessible', () => {
+        cy.mount(html` <vl-datepicker id="date" name="date" label="date"></vl-datepicker> `);
         cy.injectAxe();
 
         cy.checkA11y('vl-datepicker');
     });
 
-    it('should open the datepicker on button click with native input disabled', () => {
-        cy.mount(html`<vl-datepicker disable-mobile-native-input label="date"></vl-datepicker>`);
+    it('should open the datepicker on button click', () => {
+        cy.mount(html`<vl-datepicker label="date"></vl-datepicker>`);
 
         shouldOpenCalendar();
     });
 
-    it('should set initial date with native input disabled', () => {
+    it('should set initial date', () => {
         const date = '2021-11-01';
-        cy.mount(html`<vl-datepicker disable-mobile-native-input value=${date} label="date"></vl-datepicker>`);
+        cy.mount(html`<vl-datepicker value=${date} label="date"></vl-datepicker>`);
         cy.injectAxe();
 
         cy.get('vl-datepicker').shadow().find('input.vl-input-field').should('have.value', '01.11.2021');

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -45,7 +45,6 @@ export class VlDatepickerComponent extends FormControl {
     private amPm = datepickerDefaults.amPm;
     private disableMaskValidation = datepickerDefaults.disableMaskValidation; // Wordt enkel gebruikt in de mask validator
     private pattern = datepickerDefaults.pattern; // Wordt enkel gebruikt in de mask validator
-    private disableMobileNativeInput = datepickerDefaults.disableMobileNativeInput;
     private position = datepickerDefaults.position;
     private isStatic = datepickerDefaults.isStatic;
     // Variables
@@ -84,7 +83,6 @@ export class VlDatepickerComponent extends FormControl {
             maxTime: { type: String, attribute: 'max-time' },
             pattern: { type: String },
             disableMaskValidation: { type: Boolean, attribute: 'disable-mask-validation' },
-            disableMobileNativeInput: { type: Boolean, attribute: 'disable-mobile-native-input' },
             rawValue: { type: Boolean, attribute: 'raw-value' },
             inputValue: { type: String, state: true }, // Houdt de waarde van het getoonde inputveld bij
             isOpen: { type: Boolean, state: true },
@@ -153,15 +151,9 @@ export class VlDatepickerComponent extends FormControl {
 
         const options = this.getDynamicOptions();
         const dynamicAttributes = ['disabled', 'readonly', 'minDate', 'maxDate', 'minTime', 'maxTime', 'position'];
-        const nativeInputAttributes = ['disabled', 'readonly', 'placeholder', 'required', 'block', 'error', 'success'];
 
         if (dynamicAttributes.some((prop) => changedProperties.has(prop))) {
             this.updateOptionsForInstance(options);
-        }
-
-        const changedNativeAttributes = nativeInputAttributes.filter((prop) => changedProperties.has(prop));
-        if (changedNativeAttributes.length) {
-            this.updateOptionsForNativeInput(changedNativeAttributes, nativeInputAttributes);
         }
 
         if (changedProperties.has('value')) {
@@ -207,16 +199,6 @@ export class VlDatepickerComponent extends FormControl {
                 this.getFlatpickrWrapper()?.classList.remove('flatpickr-wrapper--block');
             }
         }
-
-        if (this.flatpickrInstance?.isMobile && !this.disableMobileNativeInput) {
-            this.getNativeDateInput()?.classList.add(
-                'js-vl-datepicker-input',
-                'vl-input-field',
-                'flatpickr-input',
-                'flatpickr-mobile'
-            );
-            this.getNativeDateInput()?.classList.remove('vl-input-group');
-        }
     }
 
     disconnectedCallback() {
@@ -246,47 +228,41 @@ export class VlDatepickerComponent extends FormControl {
 
         return html`
             <div class="vl-group vl-group--input-group" id="datepicker-wrapper">
-                ${!(this.flatpickrInstance?.isMobile && !this.disableMobileNativeInput)
-                    ? html`
-                          <input
-                              id=${this.id || nothing}
-                              name=${this.name || nothing}
-                              class=${classMap(inputClasses)}
-                              type="text"
-                              aria-label=${this.label || nothing}
-                              aria-invalid=${this.isInvalid || nothing}
-                              ?required=${this.required}
-                              ?disabled=${this.disabled}
-                              ?error=${this.error}
-                              ?readonly=${this.readonly}
-                              .value=${live(this.inputValue)}
-                              placeholder=${this.placeholder || nothing}
-                              autocomplete=${this.autocomplete || nothing}
-                              pattern=${this.pattern || nothing}
-                              inputmode=${this.cleaveInstance ? 'numeric' : nothing}
-                              @focus="${this.onInputFocus}"
-                              @blur="${this.onInputBlur}"
-                              @input=${!this.cleaveInstance ? this.onInput : nothing}
-                          />
-                          <button
-                              id="toggle-calendar"
-                              type="button"
-                              class=${classMap(buttonClasses)}
-                              ?disabled=${this.disabled || this.readonly}
-                              aria-label="datumkiezer${this.label ? ` ${this.label}` : ''}"
-                              aria-expanded=${this.isOpen}
-                              aria-controls=${this.id || nothing}
-                              @click=${this.toggleCalendar}
-                          >
-                              <span
-                                  class="vl-icon vl-icon--small vl-vi vl-vi-${this.type === 'time'
-                                      ? 'clock'
-                                      : 'calendar'}"
-                                  aria-hidden="true"
-                              ></span>
-                          </button>
-                      `
-                    : nothing}
+                <input
+                    id=${this.id || nothing}
+                    name=${this.name || nothing}
+                    class=${classMap(inputClasses)}
+                    type="text"
+                    aria-label=${this.label || nothing}
+                    aria-invalid=${this.isInvalid || nothing}
+                    ?required=${this.required}
+                    ?disabled=${this.disabled}
+                    ?error=${this.error}
+                    ?readonly=${this.readonly}
+                    .value=${live(this.inputValue)}
+                    placeholder=${this.placeholder || nothing}
+                    autocomplete=${this.autocomplete || nothing}
+                    pattern=${this.pattern || nothing}
+                    inputmode=${this.cleaveInstance ? 'numeric' : nothing}
+                    @focus="${this.onInputFocus}"
+                    @blur="${this.onInputBlur}"
+                    @input=${!this.cleaveInstance ? this.onInput : nothing}
+                />
+                <button
+                    id="toggle-calendar"
+                    type="button"
+                    class=${classMap(buttonClasses)}
+                    ?disabled=${this.disabled || this.readonly}
+                    aria-label="datumkiezer${this.label ? ` ${this.label}` : ''}"
+                    aria-expanded=${this.isOpen}
+                    aria-controls=${this.id || nothing}
+                    @click=${this.toggleCalendar}
+                >
+                    <span
+                        class="vl-icon vl-icon--small vl-vi vl-vi-${this.type === 'time' ? 'clock' : 'calendar'}"
+                        aria-hidden="true"
+                    ></span>
+                </button>
             </div>
             <div id="datepicker-calendar-placeholder"></div>
         `;
@@ -409,7 +385,7 @@ export class VlDatepickerComponent extends FormControl {
             noCalendar: this.type === 'time',
             time_24hr: !this.amPm,
             mode: this.type !== 'range' ? 'single' : 'range',
-            disableMobile: this.disableMobileNativeInput,
+            disableMobile: true,
         };
 
         const options = {
@@ -431,10 +407,6 @@ export class VlDatepickerComponent extends FormControl {
         return this.shadowRoot?.querySelector<HTMLDivElement>('.flatpickr-wrapper');
     }
 
-    private getNativeDateInput(): HTMLInputElement | undefined | null {
-        return this.renderRoot?.querySelector<HTMLInputElement>('input[type="date"]');
-    }
-
     private getCalendarPlaceholder(): HTMLDivElement {
         return this.shadowRoot?.querySelector('#datepicker-calendar-placeholder') as HTMLDivElement;
     }
@@ -447,24 +419,6 @@ export class VlDatepickerComponent extends FormControl {
             });
     }
 
-    private updateOptionsForNativeInput(changedNativeAttributes: string[], nativeInputAttributes: string[]) {
-        nativeInputAttributes.forEach((attribute) => {
-            if (changedNativeAttributes.includes(attribute) && this.getNativeDateInput()) {
-                this.updateInputForAttribute(attribute, this.getNativeDateInput()!);
-            }
-        });
-    }
-
-    private updateInputForAttribute(attribute: string, inputElement: HTMLInputElement) {
-        const attributeKey = attribute as unknown as keyof VlDatepickerComponent;
-        if (this[attributeKey]) {
-            inputElement.setAttribute(attribute, typeof this[attributeKey] === 'boolean' ? '' : this[attributeKey]);
-            inputElement.classList.add(`vl-input-field--${attributeKey}`);
-        } else {
-            inputElement.removeAttribute(attribute);
-            inputElement.classList.remove(`vl-input-field--${attributeKey}`);
-        }
-    }
 
     private initializeComponent() {
         if (this.getDatePicker() && !this.flatpickrInstance) {

--- a/libs/components/src/form/datepicker/vl-datepicker.defaults.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.defaults.ts
@@ -16,7 +16,6 @@ export const datepickerDefaults = {
     minTime: '' as string,
     maxTime: '' as string,
     disableMaskValidation: false as boolean,
-    disableMobileNativeInput: false as boolean,
     pattern: '' as string,
     regex: null as RegExp | null,
     position: 'auto' as (typeof DATEPICKER_POSITIONS)[number],


### PR DESCRIPTION
Dit vervangt de PR https://github.com/milieuinfo/flux-web-components/pull/768

Jira: https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-638 - zie https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-638?focusedId=1262899&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1262899
Bamboo: http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC327