### PR TITLE
feat: FLUX-672 - vl-input-field-masked - ontbrekende Cleave numeral-opties toegevoegd aan MaskOptions

### DIFF
--- a/libs/components/src/form/models/cleave.model.ts
+++ b/libs/components/src/form/models/cleave.model.ts
@@ -7,11 +7,17 @@ export interface MaskOptions {
     delimiter?: string;
     delimiters?: string[];
     prefix?: string;
+    signBeforePrefix?: boolean;
+    tailPrefix?: boolean;
+    noImmediatePrefix?: boolean;
     numericOnly?: boolean;
     numeral?: boolean;
     numeralPositiveOnly?: boolean;
     rawValueTrimPrefix?: boolean;
     numeralDecimalMark?: string;
+    numeralDecimalScale?: number;
+    numeralIntegerScale?: number;
+    numeralThousandsGroupStyle?: 'thousand' | 'lakh' | 'wan' | 'none';
     date?: boolean;
     datePattern?: string[];
     dateMin?: string;


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-672

## Samenvatting
Consumers van `VlInputFieldMaskedComponent.setMasks()` kunnen voortaan Cleave's numeral- en prefix-opties (waaronder `numeralDecimalScale`) gebruiken zonder `as MaskOptions` type-cast. De `MaskOptions` interface dekt nu de meest gevraagde Cleave-opties die voordien ontbraken.

## Wijzigingen
- `numeralDecimalScale`, `numeralIntegerScale` en `numeralThousandsGroupStyle` toegevoegd aan `MaskOptions` zodat numeral-masks zonder type-cast registreerbaar zijn.
- `signBeforePrefix`, `tailPrefix` en `noImmediatePrefix` toegevoegd zodat prefix-gerelateerde Cleave-configuratie ook via de officiële interface beschikbaar is.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `MaskOptions` bevat `numeralDecimalScale?: number` — toegevoegd in `cleave.model.ts`, MJV kan de cast verwijderen.
- [x] TypeScript-compilatie van een mask-registratie met `numeralDecimalScale: 0` slaagt zonder cast — pure optionele property.
- [x] Bestaande consumers blijven zonder wijziging werken — uitsluitend additieve, optionele properties.
- [x] `numeralIntegerScale` en `numeralThousandsGroupStyle` meegenomen — voorkomt een vrijwel identiek vervolgticket.