### PR TITLE
fix: FLUX-244 - vl-loader - tekst wordt correct getoond onafhankelijk van de code formattering

### DIFF
--- a/libs/components/src/block/loader/vl-loader.component.cy.ts
+++ b/libs/components/src/block/loader/vl-loader.component.cy.ts
@@ -1,0 +1,66 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlLoaderComponent } from './vl-loader.component';
+
+registerWebComponents([VlLoaderComponent]);
+
+describe('cypress-component - block components - vl-loader', () => {
+    it('should be accessible', () => {
+        cy.mount(html`<vl-loader></vl-loader>`);
+        cy.injectAxe();
+        cy.checkA11y('vl-loader');
+    });
+
+    it('should show default text when no attribute or slot content is provided', () => {
+        cy.mount(html`<vl-loader></vl-loader>`);
+        cy.get('vl-loader').shadow().find('#text').should('contain.text', 'Pagina is aan het laden');
+    });
+
+    it('should show text attribute value', () => {
+        cy.mount(html`<vl-loader text="Gegevens laden"></vl-loader>`);
+        cy.get('vl-loader').shadow().find('#text').should('contain.text', 'Gegevens laden');
+    });
+
+    it('should show text attribute value with close tag on next line', () => {
+        cy.mount(
+            html`<vl-loader text="Gegevens laden">
+                 </vl-loader>`
+        );
+        cy.get('vl-loader').shadow().find('#text').should('contain.text', 'Gegevens laden');
+    });
+
+    it('should show text attribute value when whitespace-only content is between open and close tags', () => {
+        cy.mount(html`<vl-loader text="foobar"></vl-loader>`);
+        cy.get('vl-loader').then(($el) => {
+            $el[0].appendChild(document.createTextNode('\n'));
+        });
+        cy.get('vl-loader').shadow().find('#text').should('contain.text', 'foobar');
+    });
+
+    it('should show default text when whitespace-only content is between open and close tags without text attribute', () => {
+        cy.mount(html`<vl-loader></vl-loader>`);
+        cy.get('vl-loader').then(($el) => {
+            $el[0].appendChild(document.createTextNode('\n'));
+        });
+        cy.get('vl-loader').shadow().find('#text').should('contain.text', 'Pagina is aan het laden');
+    });
+
+    it('should show custom slot content', () => {
+        cy.mount(html`
+            <vl-loader>
+                <span>Aangepaste tekst</span>
+            </vl-loader>
+        `);
+        cy.get('vl-loader').contains('Aangepaste tekst');
+    });
+
+    it('should apply light styling', () => {
+        cy.mount(html`<vl-loader light></vl-loader>`);
+        cy.get('vl-loader').shadow().find('.vl-loader').should('have.class', 'vl-loader--light');
+    });
+
+    it('should visually hide text when single attribute is set', () => {
+        cy.mount(html`<vl-loader single></vl-loader>`);
+        cy.get('vl-loader').shadow().find('#text').should('have.class', 'vl-u-visually-hidden');
+    });
+});

--- a/libs/components/src/block/loader/vl-loader.component.ts
+++ b/libs/components/src/block/loader/vl-loader.component.ts
@@ -37,6 +37,16 @@ export class VlLoaderComponent extends BaseHTMLElement {
         super(html, styleSheets);
     }
 
+    connectedCallback(): void {
+        super.connectedCallback();
+        // opkuis van whitespace / lege tekst nodes
+        [...this.childNodes].forEach((node) => {
+            if (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()) {
+                node.remove();
+            }
+        });
+    }
+
     get _loader() {
         return this._shadow?.querySelector('.vl-loader');
     }
@@ -54,7 +64,7 @@ export class VlLoaderComponent extends BaseHTMLElement {
     }
 
     _textChangedCallback(oldValue: string, newValue: string) {
-        this._slot!.innerText = newValue;
+        this._slot!.textContent = newValue;
     }
 
     _singleChangedCallback(oldValue: string, newValue: string) {


### PR DESCRIPTION
## Jira & Bamboo

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-244
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC335

## Samenvatting
`vl-loader` toont het `text`-attribuut (of de default tekst) nu betrouwbaar, ook wanneer de open- en sluitingstag op verschillende regels staan. Vroeger werd in die situatie de whitespace tussen de tags als slot-content geprojecteerd, waardoor de loader leeg leek.