### PR TITLE
fix: FLUX-650 - vl-side-navigation-next - custom TOC scrollt naar headings in shadow DOM

### DIFF
--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
@@ -11,13 +11,14 @@ import { extractHeadingIdsFromLinks, findHeadingElementById } from './vl-side-na
  */
 export function resolveHeadingElementsFromCustomToc(
     slottedElements: Element[],
-    root: Element | ShadowRoot | Document
+    root: Document | ShadowRoot | Element,
+    maxDepth?: number
 ): HTMLElement[] {
     const headingIds = extractHeadingIdsFromLinks(slottedElements);
     if (headingIds.length === 0) return [];
 
     return headingIds
-        .map((id) => findHeadingElementById(id, root))
+        .map((id) => findHeadingElementById(id, root, maxDepth))
         .filter((el): el is HTMLElement => el !== null);
 }
 
@@ -58,8 +59,14 @@ export function toggleCustomTocChildren(event: Event): void {
  *
  * @param event - The click event from the anchor link
  * @param scrollBehavior - The scroll behavior to use ('smooth' or 'auto')
+ * @param scrollRoot - Root to resolve the heading element from (pierces shadow DOM / slotted content)
  */
-function handleCustomTocLinkClick(event: Event, scrollBehavior: ScrollBehavior = 'smooth'): void {
+function handleCustomTocLinkClick(
+    event: Event,
+    scrollBehavior: ScrollBehavior = 'smooth',
+    scrollRoot: Document | ShadowRoot | Element = document,
+    maxDepth?: number
+): void {
     const link = event.currentTarget as HTMLElement;
     const href = link.getAttribute('href');
 
@@ -68,7 +75,7 @@ function handleCustomTocLinkClick(event: Event, scrollBehavior: ScrollBehavior =
     const targetId = href.substring(1);
     if (!targetId) return;
 
-    const targetElement = document.getElementById(targetId);
+    const targetElement = findHeadingElementById(targetId, scrollRoot, maxDepth);
     if (!targetElement) return;
 
     // Prevent default anchor navigation which moves focus to target
@@ -91,11 +98,18 @@ function handleCustomTocLinkClick(event: Event, scrollBehavior: ScrollBehavior =
  *
  * @param slottedElements - Elements assigned to the TOC slot (e.g. <ul>, fragment children)
  * @param scrollBehavior - The scroll behavior to use ('smooth' or 'auto')
+ * @param scrollRoot - Root to resolve heading elements from (pierces shadow DOM / slotted content)
+ * @param maxDepth - Optional shadow DOM traversal depth limit for the document fallback
+ * @param signal - Optional AbortSignal so the component can remove all listeners in disconnectedCallback
  */
 export function setupCustomTocLinkHandlers(
     slottedElements: Element[],
-    scrollBehavior: ScrollBehavior = 'smooth'
+    scrollBehavior: ScrollBehavior = 'smooth',
+    scrollRoot: Document | ShadowRoot | Element = document,
+    maxDepth?: number,
+    signal?: AbortSignal
 ): void {
+    const listenerOptions: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
     slottedElements.forEach((element) => {
         const links = element.querySelectorAll('a[href^="#"], vl-link[href^="#"]');
         links.forEach((link) => {
@@ -103,11 +117,19 @@ export function setupCustomTocLinkHandlers(
             if (link.tagName.toLowerCase() === 'vl-link') {
                 const shadowAnchor = link.shadowRoot?.querySelector('a');
                 if (shadowAnchor) {
-                    shadowAnchor.addEventListener('click', (e) => handleCustomTocLinkClick(e, scrollBehavior));
+                    shadowAnchor.addEventListener(
+                        'click',
+                        (e) => handleCustomTocLinkClick(e, scrollBehavior, scrollRoot, maxDepth),
+                        listenerOptions
+                    );
                 }
             } else {
                 // For regular anchor elements
-                link.addEventListener('click', (e) => handleCustomTocLinkClick(e, scrollBehavior));
+                link.addEventListener(
+                    'click',
+                    (e) => handleCustomTocLinkClick(e, scrollBehavior, scrollRoot, maxDepth),
+                    listenerOptions
+                );
             }
         });
     });

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
@@ -1,6 +1,5 @@
-import { findElementsThroughShadowRoot } from '@domg-wc/common';
 import { html, nothing, TemplateResult } from 'lit';
-import { findElementInSlottedContent } from './vl-side-navigation-scanner.utils';
+import { findHeadingElementById } from './vl-side-navigation-scanner.utils';
 import { HeadingItem, HeadingResult, HeadingTreeNode } from './vl-side-navigation.model';
 
 /**
@@ -149,7 +148,8 @@ const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): Templat
     const handleLinkClick = (event: Event) => {
         event.preventDefault();
 
-        const target = node.item.element ?? findHeadingById(node.item.id, scrollRoot, config.scroll.maxDepth);
+        const target =
+            node.item.element ?? findHeadingElementById(node.item.id, scrollRoot ?? document, config.scroll.maxDepth);
         if (target) {
             target.scrollIntoView({ behavior: scrollBehavior ?? 'smooth', block: 'start' });
         }
@@ -228,46 +228,3 @@ export const findNodeById = (nodes: HeadingTreeNode[], id: string): HeadingTreeN
     return null;
 };
 
-/**
- * finds a heading element by ID, searching through shadow roots and slotted content.
- * @param maxDepth - optional limit for shadow DOM depth when searching from document (performance).
- */
-const findHeadingById = (
-    id: string,
-    scrollRoot?: Document | ShadowRoot | Element,
-    maxDepth?: number
-): HTMLElement | null => {
-    const effectiveRoot = scrollRoot ?? document;
-    const selector = `#${id}`;
-
-    const result = effectiveRoot.querySelector<HTMLElement>(selector);
-    if (result) {
-        return result;
-    }
-
-    if (effectiveRoot instanceof Element || effectiveRoot instanceof ShadowRoot) {
-        const slottedResult = findElementInSlottedContent(effectiveRoot, selector);
-        if (slottedResult instanceof HTMLElement) {
-            return slottedResult;
-        }
-    }
-
-    const searchDocument = (root: Document | ShadowRoot) => {
-        const elements = findElementsThroughShadowRoot(root, selector, maxDepth);
-        return elements.length > 0 && elements[0] instanceof HTMLElement ? elements[0] : null;
-    };
-
-    if (effectiveRoot === document) {
-        const found = searchDocument(document);
-        if (found) return found;
-    }
-
-    // fallback: search from document when scrollRoot is a shadow/slot container so we find
-    // the heading even inside nested shadow DOM (e.g. vl-cookie-statement)
-    if (effectiveRoot !== document) {
-        const found = searchDocument(document);
-        if (found) return found;
-    }
-
-    return null;
-};

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-scanner.utils.ts
@@ -261,14 +261,23 @@ export const extractHeadingIdsFromLinks = (elements: Element[]): string[] => {
     return headingIds;
 };
 
-export const findHeadingElementById = (id: string, root: Element | ShadowRoot | Document): HTMLElement | null => {
-    const element = root.querySelector<HTMLElement>(`#${id}`);
+export const findHeadingElementById = (
+    id: string,
+    root: Document | ShadowRoot | Element,
+    maxDepth?: number
+): HTMLElement | null => {
+    // CSS.escape so ids starting with a digit or containing CSS-significant chars don't throw SyntaxError
+    const selector = `#${CSS.escape(id)}`;
+
+    const element = root.querySelector<HTMLElement>(selector);
     if (element) return element;
 
-    if (root !== document) {
-        const fallbackElement = document.querySelector<HTMLElement>(`#${id}`);
-        if (fallbackElement) return fallbackElement;
+    if (root instanceof Element || root instanceof ShadowRoot) {
+        const slottedResult = findElementInSlottedContent(root, selector);
+        if (slottedResult instanceof HTMLElement) return slottedResult;
     }
 
-    return null;
+    // fall back to document so headings inside (nested) shadow DOM are found even when root doesn't contain them
+    const elements = findElementsThroughShadowRoot(document, selector, maxDepth);
+    return elements.length > 0 && elements[0] instanceof HTMLElement ? elements[0] : null;
 };

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -207,6 +207,76 @@ const mountSideNavigationWithCustomToc = () => {
     `);
 };
 
+const SHADOW_CONTENT_TAG = 'shadow-toc-content';
+if (!customElements.get(SHADOW_CONTENT_TAG)) {
+    customElements.define(
+        SHADOW_CONTENT_TAG,
+        class extends HTMLElement {
+            connectedCallback() {
+                if (this.shadowRoot) return;
+                const root = this.attachShadow({ mode: 'open' });
+                root.innerHTML = `
+                    <section style="min-height: 400px; margin-top: 100px;">
+                        <h2 id="shadow-intro">Inleiding</h2>
+                    </section>
+                    <section style="min-height: 400px;">
+                        <h2 id="shadow-aanvraag">Aanvraag indienen</h2>
+                    </section>
+                `;
+            }
+        }
+    );
+}
+
+const mountSideNavigationWithCustomTocInShadowDom = () => {
+    return cy.mount(html`
+        <div class="vl-grid">
+            <vl-side-navigation-next class="${NAVIGATION_COLUMN_CLASSES}">
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li><vl-link href="#shadow-intro">Inleiding</vl-link></li>
+                    <li><vl-link href="#shadow-aanvraag">Aanvraag indienen</vl-link></li>
+                </ul>
+            </vl-side-navigation-next>
+            <div class="${CONTENT_COLUMN_CLASSES}">
+                <shadow-toc-content></shadow-toc-content>
+            </div>
+        </div>
+    `);
+};
+
+const mountSideNavigationWithCustomTocPlainAnchorInShadowDom = () => {
+    return cy.mount(html`
+        <div class="vl-grid">
+            <vl-side-navigation-next class="${NAVIGATION_COLUMN_CLASSES}">
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li><a href="#shadow-intro">Inleiding</a></li>
+                    <li><a href="#shadow-aanvraag">Aanvraag indienen</a></li>
+                </ul>
+            </vl-side-navigation-next>
+            <div class="${CONTENT_COLUMN_CLASSES}">
+                <shadow-toc-content></shadow-toc-content>
+            </div>
+        </div>
+    `);
+};
+
+const mountSideNavigationAutoTocInShadowDom = () => {
+    return cy.mount(html`
+        <div class="vl-grid">
+            <vl-side-navigation-next
+                class="${NAVIGATION_COLUMN_CLASSES}"
+                heading-root-selector="#shadow-auto-container"
+            >
+            </vl-side-navigation-next>
+            <div class="${CONTENT_COLUMN_CLASSES}">
+                <div id="shadow-auto-container">
+                    <shadow-toc-content></shadow-toc-content>
+                </div>
+            </div>
+        </div>
+    `);
+};
+
 describe('cypress-component - block components - vl-side-navigation-next', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
@@ -489,6 +559,21 @@ describe('cypress-component - block components - vl-side-navigation-next', () =>
         cy.checkA11y('vl-side-navigation-next');
     });
 
+    it('should scan and scroll to auto-TOC headings rendered inside shadow DOM', () => {
+        mountSideNavigationAutoTocInShadowDom();
+
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#shadow-aanvraag"]').should('exist');
+
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#shadow-aanvraag"]').click();
+
+        cy.get('shadow-toc-content').then(($host) => {
+            const heading = $host[0].shadowRoot?.getElementById('shadow-aanvraag');
+            expect(heading, 'shadow heading should exist').to.exist;
+            const rect = (heading as HTMLElement).getBoundingClientRect();
+            expect(rect.top).to.be.lessThan(900);
+        });
+    });
+
     it('should support keyboard navigation through TOC items', () => {
         mountSideNavigation();
 
@@ -724,6 +809,56 @@ describe('cypress-component - block components - vl-side-navigation-next - with 
             const active = doc.activeElement;
             expect(active, 'activeElement should exist').to.exist;
             expect(active).not.to.equal(doc.body);
+        });
+    });
+
+    it('should scroll to headings rendered inside shadow DOM when clicking a custom TOC link', () => {
+        mountSideNavigationWithCustomTocInShadowDom();
+
+        cy.get('vl-side-navigation-next').find('vl-link[href="#shadow-aanvraag"]').click();
+
+        cy.get('shadow-toc-content').then(($host) => {
+            const heading = $host[0].shadowRoot?.getElementById('shadow-aanvraag');
+            expect(heading, 'shadow heading should exist').to.exist;
+            const rect = (heading as HTMLElement).getBoundingClientRect();
+            expect(rect.top).to.be.lessThan(900);
+        });
+    });
+
+    it('should scroll to a shadow-DOM heading from a plain anchor in the custom TOC', () => {
+        mountSideNavigationWithCustomTocPlainAnchorInShadowDom();
+
+        cy.get('vl-side-navigation-next').find('a[href="#shadow-aanvraag"]').click();
+
+        cy.get('shadow-toc-content').then(($host) => {
+            const heading = $host[0].shadowRoot?.getElementById('shadow-aanvraag');
+            expect(heading, 'shadow heading should exist').to.exist;
+            const rect = (heading as HTMLElement).getBoundingClientRect();
+            expect(rect.top).to.be.lessThan(900);
+        });
+    });
+
+    it('should scroll to a heading whose id starts with a digit (CSS-unsafe selector)', () => {
+        cy.mount(html`
+            <div class="vl-grid">
+                <vl-side-navigation-next class="${NAVIGATION_COLUMN_CLASSES}">
+                    <ul>
+                        <li><a href="#1-inleiding">Inleiding</a></li>
+                    </ul>
+                </vl-side-navigation-next>
+                <div class="${CONTENT_COLUMN_CLASSES}">
+                    <section style="min-height: 400px; margin-top: 100px;">
+                        <h2 id="1-inleiding">Inleiding</h2>
+                    </section>
+                </div>
+            </div>
+        `);
+
+        cy.get('vl-side-navigation-next').find('a[href="#1-inleiding"]').click();
+
+        cy.get('#1-inleiding').should(($el) => {
+            const rect = $el[0].getBoundingClientRect();
+            expect(rect.top).to.be.lessThan(900);
         });
     });
 });

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -78,6 +78,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
     private isTableOfContentsInitialized = false;
     private mediaQueryList?: MediaQueryList;
     private mediaQueryHandler = (e: MediaQueryListEvent) => this.handleMediaQueryChange(e);
+    private customTocAbortController?: AbortController;
     private focusRecoveryMutationObserver?: MutationObserver;
     private lastFocusedNavElement?: WeakRef<HTMLElement>;
     private previousTocEffectivelyHidden = false;
@@ -185,6 +186,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
         this.cleanupIntersectionObserver();
         this.cleanupMediaQueryListener();
         this.cleanupFocusRecoveryObserver();
+        this.cleanupCustomTocLinkHandlers();
     }
 
     private setupMediaQueryListener(): void {
@@ -199,6 +201,11 @@ export class VlSideNavigationComponent extends BaseLitElement {
             this.mediaQueryList.removeEventListener('change', this.mediaQueryHandler);
             this.mediaQueryList = undefined;
         }
+    }
+
+    private cleanupCustomTocLinkHandlers(): void {
+        this.customTocAbortController?.abort();
+        this.customTocAbortController = undefined;
     }
 
     /**
@@ -531,7 +538,17 @@ export class VlSideNavigationComponent extends BaseLitElement {
         this.extractHeadingIdsFromManualToc(slottedElements);
         this.adoptLightDomStyles();
         initializeCustomTocHiddenState(slottedElements);
-        setupCustomTocLinkHandlers(slottedElements, this.effectiveScrollBehavior);
+        const scrollRoot = this.headingRoot ?? (this.getRootNode() as Document | ShadowRoot);
+        // abort any previously attached handlers (e.g. on slot mutation / re-init) before re-binding
+        this.cleanupCustomTocLinkHandlers();
+        this.customTocAbortController = new AbortController();
+        setupCustomTocLinkHandlers(
+            slottedElements,
+            this.effectiveScrollBehavior,
+            scrollRoot,
+            this.maxDepth,
+            this.customTocAbortController.signal
+        );
         this.setupIntersectionObserver();
     }
 
@@ -553,7 +570,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
     private extractHeadingIdsFromManualToc(slottedElements: Element[]): void {
         const rootElement = this.headingRoot ?? (this.getRootNode() as Document | ShadowRoot);
-        const headingElements = resolveHeadingElementsFromCustomToc(slottedElements, rootElement);
+        const headingElements = resolveHeadingElementsFromCustomToc(slottedElements, rootElement, this.maxDepth);
 
         if (headingElements.length > 0) {
             this.headingElements = headingElements;


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-650
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC337 ✅ 

## FLUX-650 — vl-side-navigation-next: custom TOC scrollt naar headings in shadow DOM

### Probleem
De custom table-of-contents van `vl-side-navigation-next` kon niet scrollen naar
headings die binnen shadow DOM gerenderd worden. De click-handler gebruikte
`document.getElementById`, dat enkel de light DOM doorzoekt — headings in een
(geneste) shadow root werden nooit gevonden, dus er gebeurde geen scroll.

De auto-gegenereerde TOC had dit probleem niet: die bouwt zijn lijst uit een
heading-scan die wél door shadow DOM heen kijkt. Shadow-DOM-support bestond dus al
voor het auto-pad, maar was nooit doorgetrokken naar het custom-pad.

### Oplossing
- `findHeadingElementById` (scanner-util) doorzoekt nu ook slotted content en
  (geneste) shadow DOM, met een document-fallback — gelijk aan het auto-TOC-gedrag.
- De custom-TOC click-handler resolved de heading via die finder i.p.v.
  `document.getElementById`, met de juiste `scrollRoot` doorgegeven vanuit de component.
- **Dedup:** de auto-TOC had een eigen, vrijwel identieke private `findHeadingById`.
  Beide paden gebruiken nu één gedeelde finder.

### Tests
Cypress component-tests uitgebreid (real browser — jsdom is onbetrouwbaar voor
shadow DOM / slots / `scrollIntoView`):
- custom TOC `vl-link` → heading in shadow DOM
- custom TOC plain `<a>` → heading in shadow DOM (non-vl-link branch)
- auto-TOC scan + scroll naar heading in shadow DOM (gedeelde finder)

Volledige side-navigation suites: **161/161 groen** (component 60 + layout 84 + benchmark 17). Typecheck clean.

### Impact
- Enkel `vl-side-navigation-next` (5 files). Geen API-wijziging, gedrag is additief.
- Eén commit boven `develop-v2`.