### PR TITLE
fix: FLUX-620 - vl-functional-header - title-label toegevoegd, browser-tooltip weg

### DIFF
--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
@@ -23,6 +23,7 @@ export const functionalHeaderArgs = {
     marginBottom: 'large',
     subTitle: '',
     title: '',
+    titleLabel: '',
     actionsSlot: '',
     backSlot: '',
     backLinkSlot: '',
@@ -147,11 +148,20 @@ export const functionalHeaderArgTypes: ArgTypes<typeof functionalHeaderArgs> = {
     },
     title: {
         name: 'title',
-        description: 'Tekst van de titel.',
+        description: '**Deprecated**: gebruik `title-label`.\n\nTekst van de titel.',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: functionalHeaderArgs.title },
+        },
+    },
+    titleLabel: {
+        name: 'title-label',
+        description: 'Tekst van de titel.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: functionalHeaderArgs.titleLabel },
         },
     },
     actionsSlot: {

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
@@ -61,6 +61,14 @@ demo van deze opzet vind je hier: [Voorbeeld Met Sticky En Side Navigation](/doc
 
 <ArgTypes of={VlFunctionalHeaderStories.FunctionalHeaderDefault} />
 
+<FluxAlert type="warning">
+{`
+Het \`title\`-attribuut is **deprecated**. Gebruik voortaan \`title-label\` om de paginatitel in te stellen.
+Bestaande consumers die \`title\` gebruiken blijven werken: de waarde wordt correct overgenomen
+en het attribuut wordt daarna van het host-element verwijderd zodat de native browser-tooltip niet verschijnt.
+`}
+</FluxAlert>
+
 
 ## Varianten
 

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories.ts
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories.ts
@@ -2,6 +2,7 @@ import { registerWebComponents } from '@domg-wc/common';
 import { story } from '@resources/utils-storybook';
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { action } from 'storybook/actions';
 import { VlBreadcrumbItemComponent } from '../../breadcrumb/vl-breadcrumb-item.component';
@@ -46,6 +47,7 @@ const Template = story(
         marginBottom,
         subTitle,
         title,
+        titleLabel,
         actionsSlot,
         backSlot,
         backLinkSlot,
@@ -67,7 +69,8 @@ const Template = story(
             link=${link}
             margin-bottom=${marginBottom}
             sub-title=${subTitle}
-            title=${title}
+            title=${ifDefined(title || undefined)}
+            title-label=${ifDefined(titleLabel || undefined)}
             skip-to-content-id=${skipToContentId}
             @vl-click-back=${onClickBack}
         >
@@ -96,14 +99,14 @@ export const FunctionalHeaderDefault = Template.bind({});
 FunctionalHeaderDefault.storyName = 'vl-functional-header - default';
 FunctionalHeaderDefault.args = {
     subTitle: subTitleString,
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderActions = Template.bind({});
 FunctionalHeaderActions.storyName = 'vl-functional-header - actions';
 FunctionalHeaderActions.args = {
     subTitle: subTitleString,
-    title: titleString,
+    titleLabel: titleString,
     actionsSlot: actionsSlotString,
 };
 
@@ -121,12 +124,12 @@ FunctionalHeaderSlots.args = {
 
 export const FunctionalHeaderTabs = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${ifDefined(titleLabel || undefined)}
             skip-to-content-id="${skipToContentId}"
         >
             <vl-tabs-next slot="sub-header" horizontal-navigation label="Transportmiddelen">
@@ -139,17 +142,17 @@ export const FunctionalHeaderTabs = story(
 );
 FunctionalHeaderTabs.storyName = 'vl-functional-header - tabs';
 FunctionalHeaderTabs.args = {
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderBreadcrumb = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${ifDefined(titleLabel || undefined)}
             skipToContentId=${skipToContentId}
             hide-back-link
         >
@@ -164,17 +167,17 @@ export const FunctionalHeaderBreadcrumb = story(
 );
 FunctionalHeaderBreadcrumb.storyName = 'vl-functional-header - breadcrumb';
 FunctionalHeaderBreadcrumb.args = {
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderFullWidth = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${ifDefined(titleLabel || undefined)}
             skip-to-content-id=${skipToContentId}
         >
             <span slot="sub-title">Full width</span>
@@ -183,14 +186,14 @@ export const FunctionalHeaderFullWidth = story(
 );
 FunctionalHeaderFullWidth.storyName = 'vl-functional-header - full width';
 FunctionalHeaderFullWidth.args = {
-    title: titleString,
+    titleLabel: titleString,
     fullWidth: true,
 };
 
 export const FunctionalHeaderDisableBackLink = Template.bind({});
 FunctionalHeaderDisableBackLink.storyName = 'vl-functional-header - disable back link';
 FunctionalHeaderDisableBackLink.args = {
-    title: titleString,
+    titleLabel: titleString,
     subTitleSlot: subTitleSlotString,
     back: backString,
     disableBackLink: true,
@@ -203,7 +206,7 @@ FunctionalHeaderDisableBackLink.args = {
 export const FunctionalHeaderHideBackLink = Template.bind({});
 FunctionalHeaderHideBackLink.storyName = 'vl-functional-header - hide back link';
 FunctionalHeaderHideBackLink.args = {
-    title: titleString,
+    titleLabel: titleString,
     subTitleSlot: subTitleSlotString,
     hideBackLink: true,
 };
@@ -211,6 +214,6 @@ FunctionalHeaderHideBackLink.args = {
 export const FunctionalHeaderHideSubHeader = Template.bind({});
 FunctionalHeaderHideSubHeader.storyName = 'vl-functional-header - hide sub header';
 FunctionalHeaderHideSubHeader.args = {
-    title: titleString,
+    titleLabel: titleString,
     hideSubHeader: true,
 };

--- a/libs/components/src/block/functional-header/vl-functional-header.component.cy.ts
+++ b/libs/components/src/block/functional-header/vl-functional-header.component.cy.ts
@@ -688,6 +688,35 @@ describe('cypress-component - block components - vl-functional-header - sticky',
     });
 });
 
+describe('cypress-component - block components - vl-functional-header - title-label attribute', () => {
+    it('should set title text using title-label attribute', () => {
+        cy.mount(html` <vl-functional-header title-label="School en studietoelagen"></vl-functional-header>`);
+
+        shouldSetTitleText();
+    });
+
+    it('should set title text using deprecated title attribute', () => {
+        cy.mount(html` <vl-functional-header title="School en studietoelagen"></vl-functional-header>`);
+
+        shouldSetTitleText();
+    });
+
+    it('should not have title attribute on host after using deprecated title attribute', () => {
+        cy.mount(html` <vl-functional-header title="School en studietoelagen"></vl-functional-header>`);
+
+        cy.get('vl-functional-header').should('not.have.attr', 'title');
+    });
+
+    it('should prefer title-label over deprecated title when both are set', () => {
+        cy.mount(html`
+            <vl-functional-header title="Oude titel" title-label="School en studietoelagen"></vl-functional-header>
+        `);
+
+        shouldSetTitleText();
+        cy.get('vl-functional-header').should('not.have.attr', 'title');
+    });
+});
+
 describe('cypress-component - block components - vl-functional-header - skip-to-content-id', () => {
     it('should not create a skip-link when skip-to-content-id is not set', () => {
         cy.mount(html` <vl-functional-header></vl-functional-header> `);

--- a/libs/components/src/block/functional-header/vl-functional-header.component.ts
+++ b/libs/components/src/block/functional-header/vl-functional-header.component.ts
@@ -92,6 +92,7 @@ export class VlFunctionalHeaderComponent extends BaseHTMLElement {
             'margin-bottom',
             'sub-title',
             'title',
+            'title-label',
             'skip-to-content-id',
         ];
     }
@@ -260,7 +261,16 @@ export class VlFunctionalHeaderComponent extends BaseHTMLElement {
         return this._template(`<li class="vl-functional-header__sub__action">${text}</li>`);
     }
 
+    /** @deprecated Gebruik het `title-label` attribuut om de paginatitel in te stellen. */
     _titleChangedCallback(oldValue: string, newValue: string) {
+        if (!newValue) return;
+        this._titleElement!.innerText = newValue;
+        this.removeAttribute('title');
+    }
+
+    /** Zet de tekst van de paginatitel. */
+    _titleLabelChangedCallback(oldValue: string, newValue: string) {
+        if (!newValue) return;
         this._titleElement!.innerText = newValue;
     }
 


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-620

## Samenvatting
De native browser-tooltip die boven `vl-functional-header` verscheen wanneer een `title` werd ingesteld is weg. Consumers gebruiken voortaan `title-label` voor de paginatitel; bestaande consumers met `title` blijven werken zonder migratie.

## Wijzigingen
- Nieuw `title-label`-attribuut op `vl-functional-header` om de paginatitel in te stellen zonder dat de browser een native tooltip toont over het hele component.
- Het `title`-attribuut blijft werken maar wordt na overname van de host gestript, waardoor de ongewenste tooltip ook voor bestaande consumers verdwijnt.
- Het `title`-attribuut is gemarkeerd als deprecated in Storybook (argType-beschrijving + MDX-waarschuwing).
- Storybook-stories en defaults verschoven van `title` naar `title-label`.
- Cypress-tests uitgebreid: nieuw attribuut, deprecated pad, regressie-test op afwezigheid van `title` op de host na render, en voorrang van `title-label` wanneer beide gezet zijn.

## Backwards compatibility
Additieve wijziging met deprecated path: `title` blijft werken maar is deprecated — gebruik `title-label`. Het `title`-attribuut wordt verwijderd in een volgende major release.

## Succescriteria
- [x] Bij hover over `<vl-functional-header title-label="...">` verschijnt geen native browser-tooltip meer — `title-label` wordt nooit als native HTML-attribuut behandeld en blijft niet op de host staan.
- [x] De titel blijft visueel gerenderd als heading (`#title` in shadow DOM) zoals vandaag — `_titleElement.innerText` wordt in beide callbacks gezet.
- [x] Bestaande consumers die `title` gebruiken blijven werken (geen breaking change) — `_titleChangedCallback` neemt de waarde over en stript het attribuut nadien van de host.
- [x] Een nieuwe, niet-conflicterende attribute `title-label` is gedocumenteerd in `vl-functional-header.stories-arg.ts` en in de Storybook MDX.
- [x] Cypress-tests aangepast/uitgebreid: nieuwe attribute werkt, deprecated pad werkt, host heeft geen `title`-attribuut in de DOM na render (regressie-test op de tooltip-bug).