### PR TITLE
fix: FLUX-634 - agents - profile-permissies mergen i.p.v. symlinken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ storybook-static
 
 # AI Agent local settings
 .claude/settings.local.json
+.claude/.profile-injected.json
 .claude/worktrees/
 .cursor/
 .cline/
@@ -48,7 +49,10 @@ storybook-static
 .claude/plans/
 
 # AI Agent profile activation (zie ai/profiles/README.md)
-# Deze paden zijn symlinks naar het actieve profile en blijven per-machine.
+# .claude/skills, /AGENTS.md en /SKILLS.md zijn symlinks naar het actieve profile.
+# .claude/settings.local.json wordt door Claude Code zelf beheerd; het script
+# mergt de profile-allowlist erin (geen symlink). Welke entries het script zelf
+# injecteerde, staat in .claude/.profile-injected.json (hierboven genegeerd).
 # .claude/settings.json wordt WEL gecommit (team-wide hook + permissies),
 # zie ai/profiles/README.md.
 CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,11 @@ Dit project gebruikt **AI configuratie via profiles**: er zijn verschillende pro
 
    Dit maakt/vervangt in één keer:
    - `CLAUDE.local.md` (gitignored) met de import `@ai/profiles/{profile-naam}/CLAUDE.md`
-   - `.claude/settings.local.json` (gitignored) → symlink naar `../ai/profiles/{profile-naam}/settings.json` (profile-specifieke permissies)
+   - `.claude/settings.local.json` (gitignored) → de profile-permissies worden hierin **gemerged** (geen symlink). Dit bestand wordt door Claude Code zelf beheerd (het schrijft er jouw "altijd toelaten"-keuzes in); het script laat die keuzes staan en voegt enkel de profile-allowlist toe. Bij een profielwissel wordt de vorige profile-laag weer verwijderd. Vergt `jq`.
    - `.claude/skills` (gitignored) → symlink naar `../ai/profiles/{profile-naam}/skills`
    - `AGENTS.md` / `SKILLS.md` op de project-root — alleen als het profile die bestanden heeft (cross-tool support voor Cursor/Codex/Aider; overslaan als je enkel Claude Code gebruikt)
+
+   Welke permissie-entries het script zelf injecteerde, onthoudt het in `.claude/.profile-injected.json` (gitignored) zodat een profielwissel netjes opruimt zonder jouw eigen keuzes te wissen. Alles blijft per-repo: andere checkouts/worktrees worden nooit geraakt.
 
    Het bestand `.claude/settings.json` is gecommit en wordt door dit script níet aangeraakt — daarin staan team-wide hooks en eventuele gedeelde permissies (zie [`ai/profiles/README.md`](ai/profiles/README.md)).
 
@@ -30,5 +32,6 @@ Als `CLAUDE.local.md` ontbreekt, vraagt een `SessionStart` hook in het gecommitt
 ## Niet personaliseerbaar
 
 - `.claude/settings.json` — **gecommit** team-wide config: bootstrap-check hook + eventuele gedeelde permissies. Wijzig dit enkel als de aanpassing voor het hele team relevant is.
-- `.claude/settings.local.json` — symlink naar het actieve profile (`ai/profiles/{naam}/settings.json`), gitignored. Wordt door `set-ai-profile.sh` beheerd.
+- `.claude/settings.local.json` — gitignored, **door Claude Code zelf beheerd** (jouw "altijd toelaten"-keuzes). `set-ai-profile.sh` mergt de profile-allowlist erin en laat de rest staan. Geen symlink (zou keuzes naar git lekken en in worktrees botsen).
+- `.claude/.profile-injected.json` — gitignored geheugenbriefje: welke permissie-entries het script injecteerde, voor nette opkuis bij een profielwissel. Niet manueel bewerken.
 - `.claude/plans/`, `.claude/worktrees/` — lokale werkmappen, gitignored

--- a/ai/profiles/README.md
+++ b/ai/profiles/README.md
@@ -28,17 +28,19 @@ De meeste profiles hebben een `CLAUDE.md` als entrypoint, maar het kan ook bewus
 
 ## Welke paden moeten waarheen wijzen?
 
-Claude Code leest een aantal **vaste paden** in de project-root. Voor elk profile wijzen die via symlinks naar de bijbehorende folder — `set-ai-profile.sh` regelt het volledig, maar dit is wat het script onder de motorkap doet:
+Claude Code leest een aantal **vaste paden** in de project-root. `set-ai-profile.sh` regelt het volledig, maar dit is wat het script onder de motorkap doet:
 
 ### Verplicht (Claude Code minimaal werkend)
 
-| Vast pad | Wijst naar |
+| Vast pad | Hoe gevuld |
 |----------|--------------|
 | `CLAUDE.local.md` (gitignored, géén symlink) | bevat `@ai/profiles/{profile-naam}/CLAUDE.md`, of een marker-commentaar voor opt-out profiles |
-| `.claude/settings.local.json` (gitignored) | symlink → `../ai/profiles/{profile-naam}/settings.json` |
+| `.claude/settings.local.json` (gitignored, géén symlink) | de profile-allowlist wordt erin **gemerged** (zie waarschuwing hieronder) |
 | `.claude/skills` (gitignored) | symlink → `../ai/profiles/{profile-naam}/skills` |
 
-> **Belangrijk:** profile-settings cascaderen via `.claude/settings.local.json` (persoonlijk, lokaal). Het bestand `.claude/settings.json` op de project-root is **gecommit en team-wide** — het bevat de SessionStart bootstrap-check hook en wordt door `set-ai-profile.sh` níet aangeraakt. Zie [Team-wide vs persoonlijk](#wat-blijft-team-breed) hieronder.
+> **Belangrijk — waarom `settings.local.json` geen symlink is:** dit bestand wordt door **Claude Code zelf beheerd**: het programma schrijft er jouw "altijd toelaten"-permissiekeuzes in weg. Een symlink naar de profile-folder zou (1) die runtime-keuzes naar de gecommitte profile-folder laten lekken en (2) in worktrees botsen omdat het bestand daar al bestaat. Daarom **mergt** het script in plaats daarvan de profile-allowlist erin: bestaande keuzes blijven staan, de profile-allowlist wordt toegevoegd, en bij een profielwissel wordt enkel de vorige profile-laag verwijderd. Het script onthoudt zijn eigen injecties in `.claude/.profile-injected.json` (gitignored). De merge vergt `jq` en gebeurt **enkel** bij het draaien van `set-ai-profile.sh` — verder raakt niets dit bestand aan, en alleen de huidige repo/worktree wordt geraakt.
+>
+> Het bestand `.claude/settings.json` op de project-root is **gecommit en team-wide** — het bevat de SessionStart bootstrap-check hook en wordt door `set-ai-profile.sh` níet aangeraakt. Zie [Team-wide vs persoonlijk](#wat-blijft-team-breed) hieronder.
 
 ### Optioneel (enkel voor cross-tool support — Cursor, Codex, Aider, …)
 
@@ -59,10 +61,10 @@ Gebruik altijd het meegeleverde script vanuit de project-root:
 
 Het script:
 
-- maakt/vervangt `CLAUDE.local.md` (gewoon bestand, geen symlink) en de symlinks hierboven in één keer
+- maakt/vervangt `CLAUDE.local.md` (gewoon bestand, geen symlink), mergt de profile-allowlist in `.claude/settings.local.json`, en zet de symlinks hierboven — in één keer
 - slaat paden over waarvoor het profile geen bron heeft (bv. een profile zonder `AGENTS.md` krijgt geen `AGENTS.md`-symlink)
 - schrijft **altijd** een `CLAUDE.local.md` — ook voor opt-out profiles zonder `CLAUDE.md` (dan met een marker-commentaar zonder `@`-import). De aanwezigheid van het bestand is daarmee een betrouwbare "profile geactiveerd"-marker voor de bootstrap-check in de project-root `CLAUDE.md`
-- weigert bestaande **niet-symlink** bestanden/folders op de doelpaden te overschrijven — verplaats of verwijder die manueel als dat nodig is
+- weigert bestaande **niet-symlink** bestanden/folders op de symlink-doelpaden (`.claude/skills`, `AGENTS.md`, `SKILLS.md`) te overschrijven — verplaats of verwijder die manueel als dat nodig is. `.claude/settings.local.json` wordt niet geweigerd maar gemerged; een achtergebleven symlink van de oude aanpak wordt automatisch vervangen door een echt bestand
 - **moet uitgevoerd worden, niet gesourced** (anders kan een fout je shell afsluiten en blijven env-wijzigingen plakken)
 
 Na afloop: **herstart Claude Code** zodat de nieuwe configuratie geladen wordt.
@@ -90,10 +92,10 @@ Na afloop: **herstart Claude Code** zodat de nieuwe configuratie geladen wordt.
 ## Wat blijft team-breed?
 
 - `CLAUDE.md` (root) — generieke loader, identiek voor iedereen
-- `.claude/settings.json` (root) — **gecommit** team-wide config: bevat de SessionStart bootstrap-check hook die afdwingt dat elke nieuwe sessie eerst een profile activeert. Hier horen ook permissies die voor het hele team zinvol zijn. Profile-specifieke settings cascaderen er bovenop via `.claude/settings.local.json` (symlink).
+- `.claude/settings.json` (root) — **gecommit** team-wide config: bevat de SessionStart bootstrap-check hook die afdwingt dat elke nieuwe sessie eerst een profile activeert. Hier horen ook permissies die voor het hele team zinvol zijn. Profile-specifieke permissies worden er bovenop gemerged in `.claude/settings.local.json` (geen symlink — zie hierboven).
 - `.gitignore` — regels voor de gitignored symlinks en `CLAUDE.local.md`
 - `.claude/plans/`, `.claude/worktrees/` — lokale werkmappen (al gitignored)
 
 ## Persoonlijke permissies bovenop het profile
 
-`.claude/settings.local.json` is door `set-ai-profile.sh` ingezet als symlink naar je profile. Als je extra persoonlijke overrides wil die níet in je gecommit profile horen, voeg ze toe aan `~/.claude/settings.json` (user-global — geldt cross-project) of, voor project-specifiek persoonlijk, pas je eigen profile-folder aan.
+`.claude/settings.local.json` bevat na activatie de profile-allowlist (gemerged) plus de permissiekeuzes die je tijdens het werken met "altijd toelaten" goedkeurt. Die laatste blijven lokaal en per-repo, en overleven een profielwissel. Wil je extra persoonlijke overrides die níet in je gecommit profile horen én in álle projecten gelden, voeg ze dan toe aan `~/.claude/settings.json` (user-global). Wil je project-specifiek persoonlijke permissies die wél in de repo gecommit worden, pas dan je eigen profile-folder (`settings.json`) aan.

--- a/ai/profiles/karim/AGENTS.md
+++ b/ai/profiles/karim/AGENTS.md
@@ -288,6 +288,11 @@ When creating implementation plans, technical notes, or scratchpad documents:
 - Base branch: `develop-v2`
 - Main branch: `main` (protected)
 
+### Branch Safety (STRIKT)
+
+- **Claude pusht nooit in deze repo** — staande afspraak. Geen `git push` in welke vorm dan ook; pushen doet de gebruiker zelf.
+- **Bij het maken van een branch nooit een upstream / remote-tracking instellen.** Dus geen `git push -u` / `--set-upstream`, en niet aftakken van een remote-branch (`git checkout -b foo origin/...`). Branches blijven puur lokaal zonder gekoppelde origin.
+
 ### Commit Messages
 
 Commit messages describe **only the code changes** — no attribution, no trailers, no metadata about who or what made the changes.

--- a/ai/profiles/karim/settings.json
+++ b/ai/profiles/karim/settings.json
@@ -42,7 +42,8 @@
       "Bash(npm run apps:playground-native:dev*)",
       "Bash(npm run apps:playground-react:dev*)",
       "Bash(ls *)",
-      "Bash(cat package.json)"
+      "Bash(cat package.json)",
+      "mcp__claude-peers__set_summary"
     ]
   }
 }

--- a/set-ai-profile.sh
+++ b/set-ai-profile.sh
@@ -5,14 +5,23 @@
 #
 # Maakt/vervangt:
 #   - CLAUDE.local.md                  (als profile een CLAUDE.md heeft)
-#   - .claude/settings.local.json      symlink (als profile een settings.json heeft)
+#   - .claude/settings.local.json      MERGE (als profile een settings.json heeft)
 #   - .claude/skills                   symlink (als profile een skills/ folder heeft)
 #   - AGENTS.md                        symlink (als profile een AGENTS.md heeft, cross-tool)
 #   - SKILLS.md                        symlink (als profile een SKILLS.md heeft, cross-tool)
 #
 # Let op: .claude/settings.json is GECOMMIT (team-wide hook + permissies) en
-# wordt door dit script NIET aangeraakt. Profile-specifieke settings cascaden
-# via .claude/settings.local.json (gitignored).
+# wordt door dit script NIET aangeraakt.
+#
+# .claude/settings.local.json wordt door Claude Code zelf beheerd: het programma
+# schrijft daar jouw "altijd toelaten"-keuzes in weg. Daarom maken we er GEEN
+# symlink van (dat zou die keuzes naar de gecommitte profile-folder lekken en in
+# worktrees botsen). In plaats daarvan MERGEN we de profile-allowlist erin:
+#   - bestaande entries (incl. door Claude Code weggeschreven keuzes) blijven staan
+#   - de profile-allowlist wordt toegevoegd
+#   - bij een profielwissel wordt enkel de vorige profile-laag verwijderd
+# Welke entries het script zelf injecteerde, onthoudt het in het geheugenbriefje
+# .claude/.profile-injected.json (gitignored). Vergt 'jq'.
 
 # Weiger sourcen: dit script moet als subprocess draaien, anders kan een `exit`
 # de shell van de gebruiker afsluiten en blijven environment-wijzigingen plakken.
@@ -76,7 +85,6 @@ remove_existing_symlink() {
 
 mkdir -p .claude
 
-remove_existing_symlink .claude/settings.local.json
 remove_existing_symlink .claude/skills
 remove_existing_symlink AGENTS.md
 remove_existing_symlink SKILLS.md
@@ -94,8 +102,56 @@ else
 fi
 
 if [ -f "$PROFILE_DIR/settings.json" ]; then
-    ln -s "../$PROFILE_DIR/settings.json" .claude/settings.local.json
-    echo "  .claude/settings.local.json -> ../$PROFILE_DIR/settings.json"
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Fout: 'jq' is nodig om de profile-permissies te mergen, maar niet gevonden." >&2
+        echo "Installeer jq (bv. 'brew install jq') en draai dit script opnieuw." >&2
+        exit 1
+    fi
+
+    SETTINGS_LOCAL=".claude/settings.local.json"
+    MEMO=".claude/.profile-injected.json"
+
+    # Migratie van de oude aanpak: was settings.local.json nog een symlink
+    # (naar een profile), verwijder die. We starten dan met een lege local en
+    # Claude Code vult ze opnieuw met jouw keuzes.
+    if [ -L "$SETTINGS_LOCAL" ]; then
+        rm -f "$SETTINGS_LOCAL"
+    fi
+
+    # Huidige local (of leeg object). Weiger bij ongeldige JSON i.p.v. te overschrijven.
+    if [ -f "$SETTINGS_LOCAL" ]; then
+        if ! jq empty "$SETTINGS_LOCAL" >/dev/null 2>&1; then
+            echo "Fout: '$SETTINGS_LOCAL' bevat ongeldige JSON. Repareer of verwijder het manueel." >&2
+            exit 1
+        fi
+        CURRENT_JSON="$(cat "$SETTINGS_LOCAL")"
+    else
+        CURRENT_JSON='{}'
+    fi
+
+    # Geheugenbriefje: wat injecteerde de vorige activatie? (of lege lijst)
+    if [ -f "$MEMO" ] && jq empty "$MEMO" >/dev/null 2>&1; then
+        PREV_JSON="$(cat "$MEMO")"
+    else
+        PREV_JSON='[]'
+    fi
+
+    PROFILE_ALLOW_JSON="$(jq '.permissions.allow // []' "$PROFILE_DIR/settings.json")"
+
+    # Merge: (huidige allow ZONDER vorige profile-laag) + nieuwe profile-allow.
+    # Overige sleutels (permissions.deny/ask, env, hooks, ...) blijven ongemoeid.
+    NEW_LOCAL_JSON="$(jq -n \
+        --argjson cur "$CURRENT_JSON" \
+        --argjson prev "$PREV_JSON" \
+        --argjson prof "$PROFILE_ALLOW_JSON" \
+        '($cur.permissions.allow // []) as $curAllow
+         | (($curAllow - $prev) + $prof | unique) as $merged
+         | $cur
+         | .permissions = ((.permissions // {}) + {allow: $merged})')"
+
+    printf '%s\n' "$NEW_LOCAL_JSON" > "$SETTINGS_LOCAL"
+    printf '%s\n' "$PROFILE_ALLOW_JSON" > "$MEMO"
+    echo "  .claude/settings.local.json (merge: bestaande keuzes behouden + profile-allow toegevoegd)"
 fi
 
 if [ -d "$PROFILE_DIR/skills" ]; then


### PR DESCRIPTION
## Impact

- **Geen actie nodig** om verder te werken: bestaande profile-setup blijft werken zoals voorheen.
- Bij de volgende `./set-ai-profile.sh` schakelt het script automatisch over naar het nieuwe merge-model.
- **Migratietip** (vóór re-activatie): check `git status ai/profiles/<jouw-profile>/settings.json`. Onder het oude symlink-model werden "altijd toelaten"-keuzes daarin weggeschreven als ongecommitte wijzigingen. Wil je die behouden → committen of handmatig kopiëren naar `.claude/settings.local.json` vóór je re-activeert.

## Waarom

`.claude/settings.local.json` was een symlink naar de profile-folder. Claude Code schrijft zelf in dat bestand ("altijd toelaten"-keuzes), dus die runtime-keuzes lekten naar de gecommitte profile-folder, én activatie in worktrees botste op een al bestaand bestand.

## Aanpak

De profile-allowlist wordt nu **gemerged** in `settings.local.json` (geen symlink). Bestaande keuzes blijven; bij profielwissel wordt enkel de vorige profile-laag verwijderd (geheugen in gitignored `.claude/.profile-injected.json`). Per-repo / per-worktree, raakt geen andere checkouts. Vergt `jq`. Oude symlinks worden automatisch gemigreerd.

## Meelift (karim profile only)

- branch-safety regel in `ai/profiles/karim/AGENTS.md`
- `mcp__claude-peers__set_summary` toegevoegd aan karim allowlist