### PR TITLE
feat: FLUX-463 - vl-popover - max-height met scrolling en automatische viewport-aanpassing

### DIFF
--- a/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
@@ -113,4 +113,15 @@ export const popoverArgTypes: ArgTypes<typeof popoverDefaultArgs> = {
             defaultValue: { summary: popoverDefaultArgs.strategy },
         },
     },
+    maxHeight: {
+        name: 'max-height',
+        description:
+            'Optionele maximale hoogte van de popover in pixels. De popover past zich automatisch aan de beschikbare viewport-hoogte aan; dit attribuut legt een bijkomende hardere limiet op.',
+        control: { type: CONTROLS.RANGE, min: 50, max: 800, step: 10 },
+        table: {
+            type: { summary: TYPES.NUMBER },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: 'onbeperkt' },
+        },
+    },
 };

--- a/libs/components/src/block/popover/stories/vl-popover.stories.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories.ts
@@ -1,7 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { story } from '@resources/utils-storybook';
 import { Meta } from '@storybook/web-components-vite';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { action } from 'storybook/actions';
 import { VlButtonComponent } from '../../../atom/button';
 import { VlPopoverActionListComponent } from '../vl-popover-action-list.component';
@@ -31,7 +31,7 @@ const relativePositionDecorator = (story: () => unknown) =>
 
 const PopoverTemplate = story(
     popoverDefaultArgs,
-    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy }) => {
+    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy, maxHeight }) => {
         const actionListClickHandler = (event: CustomEvent) => {
             const actionElement = event.target as VlPopoverActionComponent;
             action('click')('vl-popover-action clicked > ' + actionElement.action);
@@ -55,6 +55,7 @@ const PopoverTemplate = story(
                 distance=${distance}
                 strategy=${strategy}
                 content-padding=${contentPadding}
+                max-height=${maxHeight ?? nothing}
             >
                 <vl-popover-action-list @click=${actionListClickHandler}>
                     <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>

--- a/libs/components/src/block/popover/vl-floating-ui.controller.ts
+++ b/libs/components/src/block/popover/vl-floating-ui.controller.ts
@@ -7,6 +7,7 @@ import {
     offset,
     platform,
     shift,
+    size,
     Strategy,
     type Placement,
 } from '@floating-ui/dom';
@@ -148,6 +149,15 @@ export default class FloatingController implements ReactiveController {
             offset(this.options.distance),
             // https://floating-ui.com/docs/flip
             flip(),
+            // https://floating-ui.com/docs/size
+            // size() runs after flip() so it measures available height on the final chosen side.
+            // padding: 10 leaves room for the drop-shadow on .popover-content without viewport clipping.
+            size({
+                padding: 10,
+                apply({ availableHeight, elements }) {
+                    elements.floating.style.setProperty('--available-height', `${availableHeight}px`);
+                },
+            }),
             // https://floating-ui.com/docs/shift
             shift(),
             // https://floating-ui.com/docs/arrow
@@ -354,7 +364,7 @@ export default class FloatingController implements ReactiveController {
 
     private handleResize = (): void => {
         if (this.host.open) {
-            this.hide();
+            this.updatePosition();
         }
     };
 

--- a/libs/components/src/block/popover/vl-popover.component.cy.ts
+++ b/libs/components/src/block/popover/vl-popover.component.cy.ts
@@ -135,6 +135,80 @@ describe('cypress-component - block components - vl-popover - default', () => {
     });
 });
 
+const mountWithMaxHeight = (maxHeight: number) => {
+    return cy.mount(html`
+        <vl-button ghost icon="nav-show-more-vertical" id="btn-scroll" label="Acties"></vl-button>
+        <vl-popover id="popover-scroll" for="btn-scroll" max-height=${maxHeight}>
+            <vl-popover-action-list aria-label="Lange actielijst">
+                <vl-popover-action icon="search" .action=${'a1'}>Item 1</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a2'}>Item 2</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a3'}>Item 3</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a4'}>Item 4</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a5'}>Item 5</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a6'}>Item 6</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a7'}>Item 7</vl-popover-action>
+                <vl-popover-action icon="search" .action=${'a8'}>Item 8</vl-popover-action>
+            </vl-popover-action-list>
+        </vl-popover>
+    `);
+};
+
+describe('cypress-component - block components - vl-popover - scroll', () => {
+    it('should have overflow-y: auto on popover-content', () => {
+        mountDefault({});
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').shadow().find('.popover-content').should('have.css', 'overflow-y', 'auto');
+    });
+
+    it('should have tabindex on popover-content when open', () => {
+        mountDefault({});
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').shadow().find('.popover-content').should('have.attr', 'tabindex', '0');
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').shadow().find('.popover-content').should('not.have.attr', 'tabindex');
+    });
+
+    it('should not have tabindex on tooltip popover-content', () => {
+        mountDefault({ trigger: 'hover' });
+
+        cy.get('#btn-acties').trigger('mouseover', { force: true });
+        cy.get('vl-popover').shadow().find('.popover-content').should('not.have.attr', 'tabindex');
+    });
+
+    it('should respect max-height attribute', () => {
+        mountWithMaxHeight(100);
+
+        cy.get('#btn-scroll').click();
+        cy.get('vl-popover#popover-scroll')
+            .shadow()
+            .find('.popover-content')
+            .should('have.css', 'max-height', '100px');
+    });
+
+    it('should be scrollable when content exceeds max-height', () => {
+        mountWithMaxHeight(100);
+
+        cy.get('#btn-scroll').click();
+        cy.get('vl-popover#popover-scroll')
+            .shadow()
+            .find('.popover-content')
+            .then(($el) => {
+                expect($el[0].scrollHeight).to.be.greaterThan($el[0].clientHeight);
+            });
+    });
+
+    it('should be accessible when scrollable', () => {
+        mountWithMaxHeight(100);
+        cy.injectAxe();
+
+        cy.get('#btn-scroll').click();
+        cy.checkA11y('vl-popover#popover-scroll');
+    });
+});
+
 describe('cypress-component - block components - vl-popover - hover', () => {
     beforeEach(() => {
         mountDefault({ trigger: 'hover' });

--- a/libs/components/src/block/popover/vl-popover.component.ts
+++ b/libs/components/src/block/popover/vl-popover.component.ts
@@ -1,7 +1,7 @@
 import { BaseLitElement, registerWebComponents } from '@domg-wc/common';
 import { vlLegacyStyles } from '@domg-wc/styles';
 import { resetStyle } from '@domg/govflanders-style/common';
-import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
+import { CSSResult, html, nothing, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import FloatingController, { FloatingControllerOptions } from './vl-floating-ui.controller';
@@ -24,6 +24,7 @@ export class VlPopoverComponent extends BaseLitElement {
     protected contentPadding = popoverDefaults.contentPadding;
     private hideOnClick = popoverDefaults.hideOnClick;
     private strategy = popoverDefaults.strategy;
+    maxHeight: number | undefined = popoverDefaults.maxHeight;
 
     static {
         registerWebComponents([VlPopoverActionComponent, VlPopoverActionListComponent]);
@@ -44,6 +45,7 @@ export class VlPopoverComponent extends BaseLitElement {
             hideArrow: { type: Boolean, attribute: 'hide-arrow' },
             hideOnClick: { type: Boolean, attribute: 'hide-on-click' },
             strategy: { type: String, attribute: 'strategy' },
+            maxHeight: { type: Number, attribute: 'max-height' },
         };
     }
 
@@ -77,8 +79,15 @@ export class VlPopoverComponent extends BaseLitElement {
             'popover-content': true,
             [`padding-${this.contentPadding}`]: true,
         };
+        // tabindex="0" maakt de scrollbare container keyboard-bereikbaar (WCAG 2.1.1).
+        // Niet op tooltips: die zijn niet interactief en mogen geen extra tab-stop worden.
+        const isTooltip = !this.trigger.includes('click');
         return html`
-            <div class=${classMap(classes)} aria-hidden="${!this.open}">
+            <div
+                class=${classMap(classes)}
+                aria-hidden="${!this.open}"
+                tabindex=${this.open && !isTooltip ? '0' : nothing}
+            >
                 <slot></slot>
                 ${!this.hideArrow ? html`<i id="popover-arrow" role="presentation"></i>` : null}
             </div>
@@ -86,6 +95,14 @@ export class VlPopoverComponent extends BaseLitElement {
     }
 
     protected updated(changedProperties: PropertyValues<this>) {
+        if (changedProperties.has('maxHeight')) {
+            if (this.maxHeight != null) {
+                this.style.setProperty('--vl-popover-max-height', `${this.maxHeight}px`);
+            } else {
+                this.style.removeProperty('--vl-popover-max-height');
+            }
+        }
+
         if (changedProperties.has('open')) {
             this.handleOpenChange();
         } else {

--- a/libs/components/src/block/popover/vl-popover.defaults.ts
+++ b/libs/components/src/block/popover/vl-popover.defaults.ts
@@ -10,6 +10,7 @@ export type PopoverDefaults = {
     open: boolean;
     distance: number;
     strategy: Strategy;
+    maxHeight?: number;
 };
 
 export const popoverDefaults: PopoverDefaults = {
@@ -22,4 +23,5 @@ export const popoverDefaults: PopoverDefaults = {
     open: false,
     distance: 10,
     strategy: 'absolute',
+    maxHeight: undefined,
 };

--- a/libs/components/src/block/popover/vl-popover.flux-css.ts
+++ b/libs/components/src/block/popover/vl-popover.flux-css.ts
@@ -29,6 +29,9 @@ export const vlPopoverFluxStyles: CSSResult = css`
         padding: 1rem;
         max-width: 100vw;
         word-break: break-all;
+        overflow-y: auto;
+        /* 9999px = geen limiet als fallback; echte beperking komt van --available-height of consumer */
+        max-height: min(var(--vl-popover-max-height, 9999px), var(--available-height, 9999px));
 
         &.padding-none {
             padding: 0;


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-463

## Samenvatting
De `vl-popover` blijft binnen het zichtbare viewport en toont een interne verticale scrollbar zodra de inhoud niet meer past, in plaats van buiten beeld te vallen. Consumers kunnen optioneel zelf een hardere bovengrens opleggen via een nieuw `max-height` attribuut.

## Wijzigingen
- Popover beperkt zijn hoogte automatisch tot de beschikbare ruimte richting de viewport-rand (Floating-UI `size`-middleware).
- `.popover-content` is scrollbaar bij overflow (`overflow-y: auto`) en krijgt in dat geval `tabindex="0"` zodat keyboard-gebruikers met Page Up/Down kunnen scrollen — tooltips blijven uitgesloten.
- Nieuw `max-height` attribuut (number, px) laat consumers een eigen bovengrens opleggen; effectieve hoogte is `min(consumer, viewport)`.
- `flip`-logica blijft prioriteit hebben — `size` wordt na `flip` toegepast op de uiteindelijk gekozen zijde.
- Window resize houdt de popover open en herpositioneert (voorheen: sluiten), zodat de viewport-aanpassing ook na resize zichtbaar blijft.
- Storybook-arg en doc voor `max-height` toegevoegd; 6 nieuwe Cypress-tests dekken overflow, scrollbaarheid, keyboard-toegankelijkheid en a11y.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `vl-popover` blijft binnen het zichtbare viewport-gebied wanneer de inhoud langer is dan de beschikbare ruimte — `size`-middleware berekent en respecteert de beschikbare hoogte bij elke positionering.
- [x] Bij overschrijding krijgt de popover-content een verticale scrollbar — `overflow-y: auto` op `.popover-content`.
- [x] De `flip`-logica blijft werken — `size` staat na `flip` in de middleware-keten, conform Floating-UI docs.
- [x] Consumers kunnen optioneel zelf een max-height opleggen — nieuw `max-height` attribuut, gecombineerd via CSS `min()`.
- [x] Bestaande popovers die binnen viewport passen vertonen geen visuele regressie — `9999px`-fallback in `min()` zorgt dat er geen limiet geldt zolang content past.