### PR TITLE
feat: FLUX-463 - vl-popover - max-height met interne scrolling

### DIFF
--- a/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
@@ -113,4 +113,14 @@ export const popoverArgTypes: ArgTypes<typeof popoverDefaultArgs> = {
             defaultValue: { summary: popoverDefaultArgs.strategy },
         },
     },
+    maxHeight: {
+        name: 'max-height',
+        description:
+            'Optionele maximumhoogte van de popover-inhoud (CSS-lengte, bv. `300px` of `50vh`). Bij overschrijding scrollt de inhoud verticaal. De effectieve hoogte is het minimum van deze waarde en de automatisch berekende viewport-ruimte.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: popoverDefaultArgs.maxHeight },
+        },
+    },
 };

--- a/libs/components/src/block/popover/stories/vl-popover.stories.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories.ts
@@ -1,7 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { story } from '@resources/utils-storybook';
 import { Meta } from '@storybook/web-components-vite';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { action } from 'storybook/actions';
 import { VlButtonComponent } from '../../../atom/button';
 import { VlPopoverActionListComponent } from '../vl-popover-action-list.component';
@@ -31,7 +31,7 @@ const relativePositionDecorator = (story: () => unknown) =>
 
 const PopoverTemplate = story(
     popoverDefaultArgs,
-    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy }) => {
+    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy, maxHeight }) => {
         const actionListClickHandler = (event: CustomEvent) => {
             const actionElement = event.target as VlPopoverActionComponent;
             action('click')('vl-popover-action clicked > ' + actionElement.action);
@@ -55,6 +55,7 @@ const PopoverTemplate = story(
                 distance=${distance}
                 strategy=${strategy}
                 content-padding=${contentPadding}
+                max-height=${maxHeight || nothing}
             >
                 <vl-popover-action-list @click=${actionListClickHandler}>
                     <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>

--- a/libs/components/src/block/popover/vl-floating-ui.controller.ts
+++ b/libs/components/src/block/popover/vl-floating-ui.controller.ts
@@ -1,4 +1,4 @@
-import { isSafari } from '@domg-wc/common';
+import { findElementsThroughShadowRoot, isSafari } from '@domg-wc/common';
 import {
     arrow,
     computePosition,
@@ -7,6 +7,7 @@ import {
     offset,
     platform,
     shift,
+    size,
     Strategy,
     type Placement,
 } from '@floating-ui/dom';
@@ -23,6 +24,7 @@ export type FloatingControllerOptions = {
     hideDelay: number;
     hideOnClick: boolean;
     strategy: Strategy;
+    maxHeight: string;
     type: POPOVER_TYPE;
     // Een tooltip kan dienst doen als "label" van de trigger knop of als extra "description" voor de trigger
     ariaType?: POPOVER_ARIA_TYPE;
@@ -141,6 +143,10 @@ export default class FloatingController implements ReactiveController {
         return this.host.shadowRoot!.querySelector('i#popover-arrow')!;
     }
 
+    private getScrollElement(): HTMLElement | null {
+        return this.host.shadowRoot?.querySelector('.popover-scroll') ?? null;
+    }
+
     private buildMiddlewares(): Middleware[] {
         return [
             // https://floating-ui.com/docs/offset
@@ -150,6 +156,14 @@ export default class FloatingController implements ReactiveController {
             flip(),
             // https://floating-ui.com/docs/shift
             shift(),
+            // https://floating-ui.com/docs/size
+            // size() na flip(), zodat de beschikbare hoogte voor de uiteindelijk gekozen kant wordt gemeten.
+            size({
+                padding: 16,
+                apply: ({ availableHeight }) => {
+                    this.applyMaxHeight(availableHeight);
+                },
+            }),
             // https://floating-ui.com/docs/arrow
             // arrow() should generally be placed toward the end of your middleware array, after shift().
             arrow({ element: this.getArrowElement(), padding: 8 }),
@@ -182,6 +196,40 @@ export default class FloatingController implements ReactiveController {
                 [staticSide!]: `${-this.getArrowElement().offsetWidth / 2}px`,
             });
         }
+
+        this.updateScrollableState();
+    }
+
+    // Beperkt de inhoud op het minimum van het optionele max-height attribuut en de beschikbare viewport-ruimte.
+    private applyMaxHeight(availableHeight: number): void {
+        const scrollElement = this.getScrollElement();
+        if (!scrollElement) return;
+
+        const available = `${Math.max(0, Math.round(availableHeight))}px`;
+        const maxHeight = this.options.maxHeight;
+        scrollElement.style.maxHeight = maxHeight ? `min(${maxHeight}, ${available})` : available;
+    }
+
+    // Zorgt dat de focus op het scrollable-element (of op het eerste kind erin) kan komen - WCAG 2.1.1.
+    private updateScrollableState(): void {
+        const scrollElement = this.getScrollElement();
+        if (!scrollElement) return;
+
+        const isScrollable = scrollElement.scrollHeight > scrollElement.clientHeight;
+        if (isScrollable && !this.hasFocusableContent(scrollElement)) {
+            scrollElement.setAttribute('tabindex', '0');
+        } else {
+            scrollElement.removeAttribute('tabindex');
+        }
+    }
+
+    private hasFocusableContent(scrollElement: HTMLElement): boolean {
+        return (
+            findElementsThroughShadowRoot(
+                scrollElement,
+                'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+            ).length > 0
+        );
     }
 
     setOptions(options: FloatingControllerOptions): void {
@@ -260,7 +308,7 @@ export default class FloatingController implements ReactiveController {
             this.triggerButton.removeEventListener('focusin', this.handleFocusIn, true);
         }
         this.triggerButton.removeEventListener('focusout', this.handleFocusOut, true);
-        
+
         this.host.removeEventListener('focusout', this.handleHostFocusOut);
         this.host.removeEventListener('keydown', this.handleKeyDown);
 
@@ -297,7 +345,7 @@ export default class FloatingController implements ReactiveController {
                 else this.handleMouseOut();
             },
             // A minimum delay of 100ms is added to prevent the popover from hiding too quickly when moving the mouse from the reference to the popover.
-            this.options.hideDelay > 100 ? this.options.hideDelay : 100
+            this.options.hideDelay > 100 ? this.options.hideDelay : 100,
         );
     };
 

--- a/libs/components/src/block/popover/vl-popover.component.cy.ts
+++ b/libs/components/src/block/popover/vl-popover.component.cy.ts
@@ -45,6 +45,88 @@ const mountDefault = ({
     `);
 };
 
+const mountTall = ({ maxHeight }: { maxHeight?: string } = {}) => {
+    const actions = Array.from(
+        { length: 30 },
+        (_, i) => html`<vl-popover-action icon="search" .action=${`action-${i}`}>Actie ${i}</vl-popover-action>`
+    );
+    return cy.mount(html`
+        <vl-button ghost icon="nav-show-more-vertical" id="btn-acties" label="Acties"></vl-button>
+        <vl-popover id="popover" for="btn-acties" open max-height=${maxHeight || nothing}>
+            <vl-popover-action-list aria-label="Acties">${actions}</vl-popover-action-list>
+        </vl-popover>
+    `);
+};
+
+const mountTallText = ({ maxHeight }: { maxHeight?: string } = {}) => {
+    const paragraphs = Array.from(
+        { length: 20 },
+        (_, i) => html`<p>Lange tooltip-tekst zonder focusbare inhoud, regel ${i}.</p>`
+    );
+    return cy.mount(html`
+        <vl-button ghost icon="nav-show-more-vertical" id="btn-info" label="Info"></vl-button>
+        <vl-popover id="popover" for="btn-info" type="tooltip" open max-height=${maxHeight || nothing}>
+            ${paragraphs}
+        </vl-popover>
+    `);
+};
+
+describe('cypress-component - block components - vl-popover - max-height', () => {
+    it('should make the content scrollable when it exceeds max-height', () => {
+        cy.injectAxe();
+        mountTall({ maxHeight: '200px' });
+
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll')
+            .then(($el) => {
+                expect($el[0].scrollHeight).to.be.greaterThan($el[0].clientHeight);
+                expect($el[0].clientHeight).to.be.lessThan(250);
+            });
+        cy.checkA11y('vl-popover');
+    });
+
+    it('should not add a redundant tabindex when the scrollable content already has focusable children', () => {
+        // De knoppen van de action-list zijn elk al een tab-stop, dus het scroll-gebied is
+        // al toetsenbord-bereikbaar. Een eigen tabindex zou enkel een lege focus-ring toevoegen.
+        mountTall({ maxHeight: '200px' });
+
+        cy.get('vl-popover').shadow().find('.popover-scroll').should('not.have.attr', 'tabindex');
+    });
+
+    it('should make the scrollable content keyboard reachable when it has no focusable children', () => {
+        cy.injectAxe();
+        mountTallText({ maxHeight: '200px' });
+
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll')
+            .then(($el) => {
+                expect($el[0].scrollHeight).to.be.greaterThan($el[0].clientHeight);
+            });
+        cy.get('vl-popover').shadow().find('.popover-scroll').should('have.attr', 'tabindex', '0');
+        cy.checkA11y('vl-popover');
+    });
+
+    it('should keep the arrow when scrolling', () => {
+        mountTall({ maxHeight: '200px' });
+
+        cy.get('vl-popover').shadow().find('i#popover-arrow').should('exist');
+    });
+
+    it('should not force a scrollbar or tabindex when content fits', () => {
+        mountDefault({ open: true });
+
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll')
+            .then(($el) => {
+                expect($el[0].scrollHeight).to.eq($el[0].clientHeight);
+            });
+        cy.get('vl-popover').shadow().find('.popover-scroll').should('not.have.attr', 'tabindex');
+    });
+});
+
 describe('cypress-component - block components - vl-popover - default', () => {
     it('should mount', () => {
         mountDefault({});

--- a/libs/components/src/block/popover/vl-popover.component.ts
+++ b/libs/components/src/block/popover/vl-popover.component.ts
@@ -24,6 +24,7 @@ export class VlPopoverComponent extends BaseLitElement {
     protected contentPadding = popoverDefaults.contentPadding;
     private hideOnClick = popoverDefaults.hideOnClick;
     private strategy = popoverDefaults.strategy;
+    private maxHeight = popoverDefaults.maxHeight;
 
     static {
         registerWebComponents([VlPopoverActionComponent, VlPopoverActionListComponent]);
@@ -44,6 +45,7 @@ export class VlPopoverComponent extends BaseLitElement {
             hideArrow: { type: Boolean, attribute: 'hide-arrow' },
             hideOnClick: { type: Boolean, attribute: 'hide-on-click' },
             strategy: { type: String, attribute: 'strategy' },
+            maxHeight: { type: String, attribute: 'max-height' },
         };
     }
 
@@ -73,13 +75,15 @@ export class VlPopoverComponent extends BaseLitElement {
     }
 
     protected render(): TemplateResult {
-        const classes = {
-            'popover-content': true,
+        const scrollClasses = {
+            'popover-scroll': true,
             [`padding-${this.contentPadding}`]: true,
         };
         return html`
-            <div class=${classMap(classes)} aria-hidden="${!this.open}">
-                <slot></slot>
+            <div class="popover-content" aria-hidden="${!this.open}">
+                <div class=${classMap(scrollClasses)}>
+                    <slot></slot>
+                </div>
                 ${!this.hideArrow ? html`<i id="popover-arrow" role="presentation"></i>` : null}
             </div>
         `;
@@ -114,6 +118,7 @@ export class VlPopoverComponent extends BaseLitElement {
             hideDelay: 0,
             hideOnClick: this.hideOnClick,
             strategy: this.strategy,
+            maxHeight: this.maxHeight,
             type: this.trigger.includes('click') ? POPOVER_TYPE.POPOVER : POPOVER_TYPE.TOOLTIP,
             ariaType: this.trigger.includes('click') ? undefined : POPOVER_ARIA_TYPE.DESCRIPTION,
         };

--- a/libs/components/src/block/popover/vl-popover.defaults.ts
+++ b/libs/components/src/block/popover/vl-popover.defaults.ts
@@ -10,6 +10,7 @@ export type PopoverDefaults = {
     open: boolean;
     distance: number;
     strategy: Strategy;
+    maxHeight: string;
 };
 
 export const popoverDefaults: PopoverDefaults = {
@@ -22,4 +23,5 @@ export const popoverDefaults: PopoverDefaults = {
     open: false,
     distance: 10,
     strategy: 'absolute',
+    maxHeight: '',
 };

--- a/libs/components/src/block/popover/vl-popover.flux-css.ts
+++ b/libs/components/src/block/popover/vl-popover.flux-css.ts
@@ -26,9 +26,14 @@ export const vlPopoverFluxStyles: CSSResult = css`
             drop-shadow(0 0 0.1rem var(--vl-color--border-default));
         will-change: filter;
         background-color: #fff;
-        padding: 1rem;
         max-width: 100vw;
         word-break: break-all;
+    }
+
+    .popover-scroll {
+        box-sizing: border-box;
+        padding: 1rem;
+        overflow: auto;
 
         &.padding-none {
             padding: 0;


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-463
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC343

## Samenvatting
De `vl-popover` blijft nu binnen het zichtbare scherm wanneer de inhoud langer is dan de beschikbare ruimte: in plaats van buiten beeld te vallen krijgt de inhoud een verticale scrollbar. Consumers kunnen optioneel een eigen maximumhoogte opleggen.

## Wijzigingen
- De popover meet automatisch de beschikbare hoogte tot de viewport-rand en scrollt intern bij overschrijding (rekening houdend met de gekozen positie na `flip`).
- Nieuw optioneel `max-height` attribuut ; de effectieve hoogte is het minimum van deze waarde en de viewport-ruimte.
- De scrollbare regio wordt toetsenbord-bereikbaar (`tabindex`) wanneer hij overloopt, zodat scrollen met het toetsenbord werkt.
- De popover sluit niet langer bij window-resize maar herpositioneert, zodat hij ook na resize correct binnen beeld blijft.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Popover blijft binnen het viewport-gebied — `size` middleware begrenst de hoogte op de beschikbare viewport-ruimte.
- [x] Verticale scrollbar bij overschrijding — `.popover-scroll` met `overflow-y: auto`.
- [x] `flip`-logica blijft werken — `size()` meet ná `flip()` de uiteindelijk gekozen kant.
- [x] Optionele consumer-max-height — nieuw `max-height` attribuut .
- [x] Geen visuele regressie wanneer inhoud past — geen scrollbar of `tabindex` wanneer niet nodig (getest).