### PR TITLE
feat: FLUX-645 - form controls - blur-validation attribuut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ storybook-static
 .cline/
 .windsurf/
 .claude/plans/
+.claude/launch.json
 
 # AI Agent profile activation (zie ai/profiles/README.md)
 # Deze paden zijn symlinks naar het actieve profile en blijven per-machine.

--- a/apps/playground-lit/src/app/form/form-blur-poc.component.ts
+++ b/apps/playground-lit/src/app/form/form-blur-poc.component.ts
@@ -1,0 +1,216 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import {
+    SelectOption,
+    VlCheckboxComponent,
+    VlDatepickerComponent,
+    VlFormLabelComponent,
+    VlFormMessageComponent,
+    VlInputFieldComponent,
+    VlSelectComponent,
+} from '@domg-wc/components/form';
+import { css, CSSResult, html, LitElement, PropertyDeclarations, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * Showcase for the `blur-validation` attribute across multiple form controls.
+ * Two side-by-side forms: left is default (submit-only), right has blur-validation on.
+ * Each set has input-field, select, datepicker and checkbox, all required.
+ */
+@customElement('form-blur-poc')
+export class FormBlurPocComponent extends LitElement {
+    private defaultResult = '';
+    private blurResult = '';
+
+    private readonly landOptions: SelectOption[] = [
+        { label: 'Selecteer...', value: '' },
+        { label: 'België', value: 'be' },
+        { label: 'Nederland', value: 'nl' },
+        { label: 'Frankrijk', value: 'fr' },
+    ];
+
+    static {
+        registerWebComponents([
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlInputFieldComponent,
+            VlSelectComponent,
+            VlDatepickerComponent,
+            VlCheckboxComponent,
+            VlButtonComponent,
+        ]);
+    }
+
+    static get properties(): PropertyDeclarations {
+        return {
+            defaultResult: { type: String, state: true },
+            blurResult: { type: String, state: true },
+        };
+    }
+
+    static get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                :host {
+                    display: block;
+                    padding: 2rem;
+                    font-family: 'Flanders Art Sans', sans-serif;
+                    max-width: 1200px;
+                    margin: 0 auto;
+                }
+                .poc-grid {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 2rem;
+                    margin-top: 2rem;
+                    align-items: start;
+                }
+                .poc-col {
+                    border: 1px solid #cbd2da;
+                    padding: 1.5rem;
+                    border-radius: 4px;
+                    background: #fafbfc;
+                }
+                .poc-col.with-attr {
+                    border-color: #05c;
+                    background: #eef4fb;
+                }
+                .poc-col h3 {
+                    margin: 0 0 0.5rem;
+                    font-size: 1.6rem;
+                }
+                .poc-col p.desc {
+                    font-size: 1.3rem;
+                    color: #4a4a4a;
+                    margin: 0 0 1.5rem;
+                }
+                .poc-actions {
+                    display: flex;
+                    gap: 1rem;
+                    margin-top: 1.5rem;
+                }
+                .poc-result {
+                    margin-top: 1rem;
+                    font-size: 1.3rem;
+                    color: #555;
+                    min-height: 1.6rem;
+                }
+                code {
+                    background: #e6e9ec;
+                    padding: 0.1rem 0.4rem;
+                    border-radius: 3px;
+                    font-size: 0.9em;
+                }
+            `,
+        ];
+    }
+
+    private handleSubmit(e: Event, target: 'default' | 'blur'): void {
+        // Native constraint validation blocks submit on invalid forms (browser fires
+        // 'invalid' events which FormControl handles). So this handler only runs on valid forms.
+        e.preventDefault();
+        const result = '✓ geldig, verstuurd';
+        if (target === 'default') {
+            this.defaultResult = result;
+        } else {
+            this.blurResult = result;
+        }
+    }
+
+    private handleReset(target: 'default' | 'blur'): void {
+        if (target === 'default') {
+            this.defaultResult = '';
+        } else {
+            this.blurResult = '';
+        }
+    }
+
+    /** `p` is an id prefix so both forms have unique ids/for couples. `blur` toggles the attribute on every control. */
+    private renderControls(p: string, blur: boolean): TemplateResult {
+        return html`
+            <vl-form-label for="${p}-naam" label="Voornaam *" block></vl-form-label>
+            <vl-input-field
+                id="${p}-naam"
+                name="naam"
+                block
+                required
+                min-length="3"
+                pattern="^[a-zA-Z]+$"
+                ?blur-validation=${blur}
+            ></vl-input-field>
+            <vl-form-message for="${p}-naam" state="valueMissing">Gelieve een voornaam in te vullen.</vl-form-message>
+            <vl-form-message for="${p}-naam" state="tooShort">Minimum 3 karakters.</vl-form-message>
+            <vl-form-message for="${p}-naam" state="patternMismatch">Enkel letters toegestaan.</vl-form-message>
+
+            <vl-form-label for="${p}-land" label="Land *" block></vl-form-label>
+            <vl-select
+                id="${p}-land"
+                name="land"
+                block
+                required
+                .options=${this.landOptions}
+                ?blur-validation=${blur}
+            ></vl-select>
+            <vl-form-message for="${p}-land" state="valueMissing">Gelieve een land te kiezen.</vl-form-message>
+
+            <vl-form-label for="${p}-datum" label="Geboortedatum *" block></vl-form-label>
+            <vl-datepicker id="${p}-datum" name="datum" block required ?blur-validation=${blur}></vl-datepicker>
+            <vl-form-message for="${p}-datum" state="valueMissing">Gelieve een datum in te vullen.</vl-form-message>
+
+            <vl-checkbox id="${p}-akkoord" name="akkoord" required ?blur-validation=${blur}>
+                Ik ga akkoord *
+            </vl-checkbox>
+            <vl-form-message for="${p}-akkoord" state="valueMissing">Gelieve te bevestigen.</vl-form-message>
+        `;
+    }
+
+    render(): TemplateResult {
+        return html`
+            <h1>POC: <code>blur-validation</code> attribuut</h1>
+            <p>
+                Twee identieke form-sets (vl-input-field, vl-select, vl-datepicker, vl-checkbox, allen
+                <strong>required</strong>), elk in een eigen form met eigen submit/reset. Enkel de rechtse set
+                heeft <code>blur-validation</code> aan, zodat je het verschil per control-type kan vergelijken.
+            </p>
+            <p>
+                Probeer per control: (1) interageer en verlaat zonder geldige waarde; (2) corrigeer en kijk wanneer
+                de fout verdwijnt; (3) klik Verstuur. Links verschijnt feedback pas op submit, rechts al op blur.
+            </p>
+            <div class="poc-grid">
+                <form class="poc-col" @submit=${(e: Event) => this.handleSubmit(e, 'default')} @reset=${() => this.handleReset('default')}>
+                    <h3>Zonder attribute (default)</h3>
+                    <p class="desc">Validatie pas op submit. Tijdens interactie / blur: geen feedback.</p>
+                    ${this.renderControls('default', false)}
+                    <div class="poc-actions">
+                        <vl-button type="submit">Verstuur</vl-button>
+                        <vl-button type="reset" secondary>Reset</vl-button>
+                    </div>
+                    <div class="poc-result">${this.defaultResult}</div>
+                </form>
+
+                <form class="poc-col with-attr" @submit=${(e: Event) => this.handleSubmit(e, 'blur')} @reset=${() => this.handleReset('blur')}>
+                    <h3>Met <code>blur-validation</code></h3>
+                    <p class="desc">
+                        Op blur (na focus, ook zonder mutatie): toon fout. Daarna: live re-validate tot geldig. Submit blijft
+                        autoritatief.
+                    </p>
+                    ${this.renderControls('blur', true)}
+                    <div class="poc-actions">
+                        <vl-button type="submit">Verstuur</vl-button>
+                        <vl-button type="reset" secondary>Reset</vl-button>
+                    </div>
+                    <div class="poc-result">${this.blurResult}</div>
+                </form>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'form-blur-poc': FormBlurPocComponent;
+    }
+}

--- a/apps/playground-lit/src/index.html
+++ b/apps/playground-lit/src/index.html
@@ -9,6 +9,6 @@
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
     </head>
     <body>
-        <app-component></app-component>
+        <form-blur-poc></form-blur-poc>
     </body>
 </html>

--- a/apps/playground-lit/src/main.ts
+++ b/apps/playground-lit/src/main.ts
@@ -1,2 +1,3 @@
 import './preferences';
 import './app/app.component';
+import './app/form/form-blur-poc.component';

--- a/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.mdx
@@ -1,0 +1,73 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as formBlurValidationStories from './formulier-blur-validatie.stories';
+
+<Meta of={formBlurValidationStories} />
+
+# Formulier - Blur-validatie
+
+> Voor de basis van formuliervalidatie, zie
+> [Formulier - Validatie](/docs/patronen-formulier-validatie--documentatie).
+
+Standaard valideren de formulier componenten pas wanneer de form gesubmit wordt. Met het optionele
+`blur-validation` attribuut kan je validatie al tijdens het invullen tonen, zonder dat je hier zelf
+code voor moet schrijven.
+
+## Gedrag
+
+Wanneer `blur-validation` aanstaat:
+
+- Het veld valideert zodra het focus kreeg en weer verlaten wordt (`focusout`), ongeacht of de gebruiker de
+  waarde gewijzigd heeft.
+- Na de eerste foutmelding schakelt het veld over op **live re-validatie tijdens typen**: de foutmelding verdwijnt
+  op het moment dat de waarde geldig wordt, zonder dat de gebruiker opnieuw moet wegklikken.
+- Submit blijft de definitieve check: bij submit wordt nog steeds alles gevalideerd en springt de focus naar het
+  eerste ongeldige veld.
+
+De foutmeldingen lopen via hetzelfde mechanisme als de standaard validatie
+([`vl-form-message`](/docs/components-form-form-message--documentatie) + `ValidityState`). Je hoeft enkel
+het attribuut toe te voegen.
+
+## Per veld
+
+Zet `blur-validation` op een individuele form control.
+
+In onderstaand voorbeeld: tab in het veld en terug eruit zonder te typen om de `valueMissing` fout te zien, of typ
+een ongeldige waarde (bv. een cijfer of één letter) en verlaat het veld. Corrigeer daarna en zie de fout live
+verdwijnen.
+
+<Canvas of={formBlurValidationStories.FormulierBlurValidatiePerVeld} sourceState={'shown'} />
+
+## Op de form (cascade)
+
+Zet `blur-validation` (of `data-blur-validation`) op het `<form>` element om het gedrag in één keer in te schakelen
+voor **alle** form controls eronder. De velden zelf hebben dan geen attribuut nodig.
+
+<Canvas of={formBlurValidationStories.FormulierBlurValidatieForm} sourceState={'shown'} />
+
+Een veld met een eigen `blur-validation` attribuut blijft daarnaast los werken. Form-niveau en veld-niveau zijn
+beide manieren om hetzelfde gedrag aan te zetten (OR-logica, er is geen per-veld opt-out).
+
+## Toegankelijkheid
+
+`blur-validation` is bewust opt-in. Validatie pas op `focusout` (en niet op elke toetsaanslag) beperkt
+ruis voor screenreaders tijdens het invullen.
+
+De foutmelding wordt gerenderd in een `aria-live="polite"` regio (via `vl-form-message`), zodat screen
+readers ze voorlezen zodra ze verschijnt of wijzigt. `aria-atomic="true"` zorgt dat telkens de volledige
+boodschap wordt voorgelezen. De control zelf krijgt `aria-invalid="true"` zodat de ongeldige toestand
+ook los van de melding kenbaar is.
+
+## Lijst componenten met `blur-validation`
+
+Het attribuut zit op de gedeelde `FormControl` base class en werkt dus op alle form controls:
+
+- [vl-input-field](/docs/components-form-input-field--documentatie)
+- [vl-input-field-masked](/docs/components-form-input-field-masked--documentatie)
+- [vl-textarea](/docs/components-form-textarea--documentatie)
+- [vl-textarea-rich](/docs/components-form-textarea-rich--documentatie)
+- [vl-datepicker](/docs/components-form-datepicker--documentatie)
+- [vl-select-rich](/docs/components-form-select-rich--documentatie)
+- [vl-select](/docs/components-form-select--documentatie)
+- [vl-radio-group](/docs/components-form-radio-group--documentatie)
+- [vl-upload](/docs/components-form-upload--documentatie)
+- [vl-checkbox](/docs/components-form-checkbox--documentatie)

--- a/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.stories.ts
+++ b/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.stories.ts
@@ -1,0 +1,48 @@
+import { html } from 'lit';
+import { Meta, StoryFn } from '@storybook/web-components-vite';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormLabelComponent, VlFormMessageComponent, VlInputFieldComponent } from '@domg-wc/components/form';
+
+registerWebComponents([VlInputFieldComponent, VlFormLabelComponent, VlFormMessageComponent]);
+
+export default {
+    title: 'Patronen/Formulier/blur validatie',
+} as Meta;
+
+export const FormulierBlurValidatiePerVeld: StoryFn = () => html`
+    <form onsubmit="return false;">
+        <vl-form-label for="voornaam" label="Voornaam *"></vl-form-label>
+        <vl-input-field
+            id="voornaam"
+            name="voornaam"
+            autocomplete="given-name"
+            required
+            min-length="3"
+            pattern="^[a-zA-Z]*$"
+            blur-validation
+        ></vl-input-field>
+        <vl-form-message for="voornaam" state="valueMissing">Gelieve een voornaam in te vullen.</vl-form-message>
+        <vl-form-message for="voornaam" state="tooShort">Gelieve minimum 3 karakters te gebruiken.</vl-form-message>
+        <vl-form-message for="voornaam" state="patternMismatch"
+            >Gelieve geen nummers of speciale tekens in te vullen.</vl-form-message
+        >
+    </form>
+`;
+FormulierBlurValidatiePerVeld.storyName = 'formulier - blur-validatie per veld';
+
+export const FormulierBlurValidatieForm: StoryFn = () => html`
+    <form onsubmit="return false;" blur-validation>
+        <vl-form-label for="voornaam" label="Voornaam *"></vl-form-label>
+        <vl-input-field id="voornaam" name="voornaam" autocomplete="given-name" required min-length="3">
+        </vl-input-field>
+        <vl-form-message for="voornaam" state="valueMissing">Gelieve een voornaam in te vullen.</vl-form-message>
+        <vl-form-message for="voornaam" state="tooShort">Gelieve minimum 3 karakters te gebruiken.</vl-form-message>
+
+        <vl-form-label for="familienaam" label="Familienaam *"></vl-form-label>
+        <vl-input-field id="familienaam" name="familienaam" autocomplete="family-name" required min-length="2">
+        </vl-input-field>
+        <vl-form-message for="familienaam" state="valueMissing">Gelieve een familienaam in te vullen.</vl-form-message>
+        <vl-form-message for="familienaam" state="tooShort">Gelieve minimum 2 karakters te gebruiken.</vl-form-message>
+    </form>
+`;
+FormulierBlurValidatieForm.storyName = 'formulier - blur-validatie op de form';

--- a/libs/components/src/form/checkbox/stories/vl-checkbox.stories.ts
+++ b/libs/components/src/form/checkbox/stories/vl-checkbox.stories.ts
@@ -32,6 +32,7 @@ const CheckboxTemplate = story(
         disabled,
         error,
         success,
+        blurValidation,
         block,
         value,
         checked,
@@ -51,6 +52,7 @@ const CheckboxTemplate = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             ?block=${block}
             value=${value}
             ?checked=${checked}

--- a/libs/components/src/form/checkbox/vl-checkbox.component.cy.ts
+++ b/libs/components/src/form/checkbox/vl-checkbox.component.cy.ts
@@ -2,9 +2,10 @@ import { registerWebComponents } from '@domg-wc/common';
 import { vlGridStyles } from '@domg-wc/styles';
 import { html } from 'lit';
 import { VlCheckboxComponent } from './vl-checkbox.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 import { checkboxDefaults } from './vl-checkbox.defaults';
 
-registerWebComponents([VlCheckboxComponent]);
+registerWebComponents([VlCheckboxComponent, VlFormMessageComponent]);
 type CheckboxDefaultTypes = Partial<typeof checkboxDefaults>;
 
 const value = 'Optie 1';
@@ -799,5 +800,64 @@ describe('vl-checkbox - switch variant', () => {
         shouldHaveErrorStyleSwitch();
         cy.get('button[type="reset"]').click();
         cy.get('vl-form-message[for="confirmation"]').should('not.have.attr', 'show');
+    });
+});
+
+// Base-class isolation tests dispatch events on the host directly; Cypress's click sim does not reliably deliver vl-input.
+describe('vl-checkbox - blur-validation', () => {
+    const mountWithValidation = () => {
+        cy.mount(html`
+            <form>
+                <vl-checkbox id="cb" name="cb" required blur-validation>Bevestig</vl-checkbox>
+                <vl-form-message for="cb" state="valueMissing">Verplicht.</vl-form-message>
+                <button type="reset">Reset</button>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without interaction', () => {
+        mountWithValidation();
+        cy.get('vl-checkbox').shadow().find('input').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should fire blur-validation flow via real user interaction', () => {
+        mountWithValidation();
+        cy.get('vl-checkbox').shadow().find('.vl-checkbox__label').click({ force: true });
+        cy.get('vl-checkbox').shadow().find('.vl-checkbox__label').click({ force: true });
+        cy.get('vl-checkbox').shadow().find('input').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error after click + uncheck + blur (base-class isolation)', () => {
+        mountWithValidation();
+        cy.get('vl-checkbox').then(($el) => {
+            const cb = $el[0] as VlCheckboxComponent;
+            cb.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: null } }));
+            cb.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should live-revalidate when value becomes valid after error', () => {
+        mountWithValidation();
+        cy.get('vl-checkbox').then(($el) => {
+            const cb = $el[0] as VlCheckboxComponent;
+            cb.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: null } }));
+            cb.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+
+        cy.get('vl-checkbox').then(($el) => {
+            const cb = $el[0] as VlCheckboxComponent;
+            cb.checked = true;
+        });
+        cy.waitForLitUpdate('vl-checkbox');
+        cy.get('vl-checkbox').then(($el) => {
+            const cb = $el[0] as VlCheckboxComponent;
+            expect(cb.validity.valid, 'validity must be valid').to.be.true;
+            cb.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: 'on' } }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 });

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
@@ -46,6 +46,7 @@ const DatepickerTemplate = story(
         maxTime,
         amPm,
         success,
+        blurValidation,
         block,
         disabled,
         error,
@@ -81,6 +82,7 @@ const DatepickerTemplate = story(
                             autocomplete=${autocomplete}
                             ?error=${error}
                             ?success=${success}
+                            ?blur-validation=${blurValidation}
                             ?required=${required}
                             ?readonly=${readonly}
                             ?disabled=${disabled}

--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -1738,3 +1738,20 @@ describe('vl-datepicker - mobile', () => {
         cy.checkA11y('vl-datepicker');
     });
 });
+
+describe('vl-datepicker - blur-validation', () => {
+    it('should show error on blur after focus, even without input', () => {
+        cy.mount(html`
+            <form>
+                <vl-datepicker id="dp" name="dp" required blur-validation></vl-datepicker>
+                <vl-form-message for="dp" state="valueMissing">Gelieve een datum in te vullen.</vl-form-message>
+            </form>
+        `);
+        cy.get('vl-datepicker').shadow().find('input.vl-input-field').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    // Note: flatpickr filters invalid chars before they reach validity, so deeper
+    // typed-input blur-validation tests are not reliable. The focus-then-blur test
+    // above covers the core path; submit flow has its own existing coverage.
+});

--- a/libs/components/src/form/form-control/form-control.defaults.ts
+++ b/libs/components/src/form/form-control/form-control.defaults.ts
@@ -6,4 +6,5 @@ export const formControlDefaults = {
     disabled: false as boolean,
     error: false as boolean,
     success: false as boolean,
+    blurValidation: false as boolean,
 } as const;

--- a/libs/components/src/form/form-control/form-control.ts
+++ b/libs/components/src/form/form-control/form-control.ts
@@ -15,13 +15,17 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     protected disabled = formControlDefaults.disabled;
     protected error = formControlDefaults.error;
     protected success = formControlDefaults.success;
+    /** Validate on blur (after focus) with live recovery, instead of only on submit. */
+    protected blurValidation = formControlDefaults.blurValidation;
 
     // State
     protected isInvalid = false;
 
+    // Sticky once true (reset via resetFormControl). Enables live re-validation on input after the first error.
+    private erroredOnce = false;
+
     // Variables
     protected submitFormOnEnter = true;
-    protected formMessageText: string | undefined | null;
 
     static formControlValidators = [requiredValidator, programmaticValidator];
 
@@ -36,6 +40,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
             disabled: { type: Boolean },
             error: { type: Boolean },
             success: { type: Boolean },
+            blurValidation: { type: Boolean, attribute: 'blur-validation' },
             isInvalid: { type: Boolean, state: true },
         };
     }
@@ -45,6 +50,8 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
 
         this.addEventListener('keydown', this.onKeydown);
         this.addEventListener('invalid', this.onInvalid);
+        this.addEventListener('vl-input', this.onUserMutation);
+        this.addEventListener('focusout', this.onFocusOut);
     }
 
     disconnectedCallback() {
@@ -52,10 +59,20 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
 
         this.removeEventListener('keydown', this.onKeydown);
         this.removeEventListener('invalid', this.onInvalid);
+        this.removeEventListener('vl-input', this.onUserMutation);
+        this.removeEventListener('focusout', this.onFocusOut);
     }
 
     updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
+
+        if (this.blurValidationEnabled) {
+            // update error after programmatic value change (no vl-input fired).
+            if (this.isInvalid && !changedProperties.has('isInvalid')) {
+                this.runValidation();
+            }
+            return;
+        }
 
         if (!changedProperties.has('isInvalid')) {
             this.isInvalid = false;
@@ -65,8 +82,22 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
 
     abstract get validationTarget(): HTMLElement | undefined | null;
 
+    /**
+     * True when `blur-validation` is set on this control, or when the associated
+     * `<form>` has `blur-validation` or `data-blur-validation` (cascade). OR-logic,
+     * no per-field opt-out.
+     */
+    protected get blurValidationEnabled(): boolean {
+        return (
+            this.blurValidation ||
+            !!this.form?.hasAttribute('blur-validation') ||
+            !!this.form?.hasAttribute('data-blur-validation')
+        );
+    }
+
     resetFormControl() {
         this.isInvalid = false;
+        this.erroredOnce = false;
         this.hideFormMessages();
         this.dispatchEvent(new Event('vl-reset', { bubbles: true, composed: true }));
     }
@@ -89,8 +120,43 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         event.preventDefault();
 
         this.isInvalid = true;
+        // Only stick erroredOnce in blur-validation mode (live recovery after submit).
+        if (this.blurValidationEnabled) {
+            this.erroredOnce = true;
+        }
         this.focusFirstInvalidInput();
         this.showFormMessage();
+    }
+
+    private onUserMutation() {
+        if (!this.blurValidationEnabled) return;
+        // Live recovery only after the first error, so pristine input stays silent.
+        if (this.erroredOnce) {
+            this.runValidation();
+        }
+    }
+
+    private onFocusOut() {
+        if (!this.blurValidationEnabled) return;
+
+        // Defer to next tick so document.activeElement reflects the new focus target.
+        // With delegatesFocus, activeElement is the host on internal shadow focus shifts.
+        setTimeout(() => {
+            if (!this.isConnected) return;
+            if (document.activeElement === this) return;
+            this.runValidation();
+        }, 0);
+    }
+
+    private runValidation() {
+        if (this.validity.valid) {
+            this.isInvalid = false;
+            this.hideFormMessages();
+        } else {
+            this.isInvalid = true;
+            this.erroredOnce = true;
+            this.showFormMessage();
+        }
     }
 
     private focusFirstInvalidInput() {
@@ -122,22 +188,16 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
             errorMessage = this.form?.querySelector(`${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]:not([state])`);
         }
 
-        this.formMessageText = errorMessage?.textContent;
-
-        if (this.formMessageText) {
-            this.validationTarget?.setAttribute('aria-description', this.formMessageText);
-        } else {
-            this.validationTarget?.removeAttribute('aria-description');
+        if (errorMessage) {
+            errorMessage.setAttribute('validation-message', this.validationMessage);
+            if (!errorMessage.hasAttribute('show')) {
+                errorMessage.setAttribute('show', '');
+            }
         }
-
-        errorMessage?.setAttribute('validation-message', this.validationMessage);
-        errorMessage?.setAttribute('show', '');
     }
 
     private hideFormMessages() {
         const formMessages = this.form?.querySelectorAll(`${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]`);
-
-        this.formMessageText = null;
 
         formMessages?.forEach((formMessage) => {
             formMessage.removeAttribute('show');

--- a/libs/components/src/form/form-control/stories/form-control.stories-arg.ts
+++ b/libs/components/src/form/form-control/stories/form-control.stories-arg.ts
@@ -77,6 +77,24 @@ export const formControlArgTypes: ArgTypes<FormControlArgs> = {
             defaultValue: { summary: String(formControlArgs.success) },
         },
     },
+    blurValidation: {
+        name: 'blur-validation',
+        description:
+            'Activeert on-blur validatie met live recovery.<br>' +
+            'Wanneer aan: het veld valideert op `focusout` zodra het focus had en weer ' +
+            'verlaten wordt (ongeacht of de waarde gewijzigd is). Na de eerste foutmelding ' +
+            'schakelt het veld over op live re-validatie tijdens typen, tot de waarde geldig is. ' +
+            'Submit blijft de definitieve check.<br>' +
+            'Cascade: je kan dit ook in één keer voor alle form controls onder een form inschakelen ' +
+            'door `blur-validation` of `data-blur-validation` op het `<form>` element te zetten. ' +
+            'Een veld met het eigen attribuut blijft daarnaast los werken.<br>' +
+            'Default: `false` (gedrag van vóór deze feature, validatie enkel op submit).',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(formControlArgs.blurValidation) },
+        },
+    },
     onVlReset: {
         name: 'vl-reset',
         description: 'Event dat afgevuurd wordt wanneer het veld gereset wordt.',

--- a/libs/components/src/form/form-message/vl-form-message.component.cy.ts
+++ b/libs/components/src/form/form-message/vl-form-message.component.cy.ts
@@ -134,4 +134,13 @@ describe('vl-form-message - content & validation', () => {
                 expect(assignedNodes[0].textContent).to.contain('custom validation message');
             });
     });
+
+    it('should expose a polite aria-live region so screen readers announce changes', () => {
+        cy.mount(html`<vl-form-message validation-message="msg"></vl-form-message>`);
+        cy.get('vl-form-message')
+            .shadow()
+            .find('[role="status"]')
+            .should('have.attr', 'aria-live', 'polite')
+            .and('have.attr', 'aria-atomic', 'true');
+    });
 });

--- a/libs/components/src/form/form-message/vl-form-message.component.ts
+++ b/libs/components/src/form/form-message/vl-form-message.component.ts
@@ -35,10 +35,16 @@ export class VlFormMessageComponent extends BaseLitElement {
             'vl-form__error': true,
             'vl-pre-line': this.preLine,
         };
+        // The wrapper is the live region: kept in the a11y tree at all times so that
+        // when the inner <p> becomes visible (hidden removed + slot text), screen
+        // readers announce the new content. aria-live="polite" waits for an idle
+        // moment; aria-atomic ensures the full message is read on each change.
         return html`
-            <p class=${classMap(classes)} part="text" ?hidden=${!this.show}>
-                <slot>${this.validationMessage}</slot>
-            </p>
+            <div role="status" aria-live="polite" aria-atomic="true">
+                <p class=${classMap(classes)} part="text" ?hidden=${!this.show}>
+                    <slot>${this.validationMessage}</slot>
+                </p>
+            </div>
         `;
     }
 }

--- a/libs/components/src/form/input-field-masked/stories/vl-input-field-masked.stories.ts
+++ b/libs/components/src/form/input-field-masked/stories/vl-input-field-masked.stories.ts
@@ -43,6 +43,7 @@ const InputFieldMaskedTemplate = story(
         disabled,
         error,
         success,
+        blurValidation,
         block,
         readonly,
         value,
@@ -73,6 +74,7 @@ const InputFieldMaskedTemplate = story(
                 ?disabled=${disabled}
                 ?error=${error}
                 ?success=${success}
+                ?blur-validation=${blurValidation}
                 ?block=${block}
                 ?readonly=${readonly}
                 value=${value}

--- a/libs/components/src/form/input-field-masked/vl-input-field-masked.component.cy.ts
+++ b/libs/components/src/form/input-field-masked/vl-input-field-masked.component.cy.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlInputFieldMaskedComponent } from './vl-input-field-masked.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlInputFieldMaskedComponent]);
+registerWebComponents([VlInputFieldMaskedComponent, VlFormMessageComponent]);
 
 describe('cypress-component - form components - vl-input-field-masked', () => {
     it('should mount', () => {
@@ -237,5 +238,29 @@ describe('cypress-component - form components - vl-input-field-masked', () => {
         cy.get('@vl-valid').should('have.been.calledOnce');
         cy.get('@vl-valid').its('firstCall.args.0.detail').should('deep.equal', { value: '+32 12 34 56 78' });
         cy.checkA11y('vl-input-field-masked');
+    });
+
+    describe('blur-validation', () => {
+        const mount = () => {
+            cy.mount(html`
+                <form>
+                    <vl-input-field-masked id="ifm" name="ifm" required mask="rrn" blur-validation></vl-input-field-masked>
+                    <vl-form-message for="ifm" state="valueMissing">Verplicht.</vl-form-message>
+                    <vl-form-message for="ifm" state="patternMismatch">Ongeldig.</vl-form-message>
+                </form>
+            `);
+        };
+
+        it('should show error on blur after focus, even without mutation', () => {
+            mount();
+            cy.get('vl-input-field-masked').shadow().find('input').focus().blur();
+            cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        });
+
+        it('should show error after typing invalid + blur', () => {
+            mount();
+            cy.get('vl-input-field-masked').shadow().find('input').type('1').blur();
+            cy.get('vl-form-message[show]').should('have.length.gte', 1);
+        });
     });
 });

--- a/libs/components/src/form/input-field/stories/vl-input-field.stories.ts
+++ b/libs/components/src/form/input-field/stories/vl-input-field.stories.ts
@@ -31,6 +31,7 @@ const InputFieldTemplate = story(
         disabled,
         error,
         success,
+        blurValidation,
         block,
         readonly,
         type,
@@ -59,6 +60,7 @@ const InputFieldTemplate = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             ?block=${block}
             ?readonly=${readonly}
             type=${type}
@@ -89,4 +91,14 @@ export const InputFieldNumber = InputFieldTemplate.bind({});
 InputFieldNumber.storyName = 'vl-input-field - number';
 InputFieldNumber.args = {
     type: 'number',
+};
+
+export const InputFieldBlurValidation = InputFieldTemplate.bind({});
+InputFieldBlurValidation.storyName = 'vl-input-field - blur validation';
+InputFieldBlurValidation.args = {
+    required: true,
+    minLength: 3,
+    pattern: '^[a-zA-Z]+$',
+    blurValidation: true,
+    placeholder: 'Min. 3 letters',
 };

--- a/libs/components/src/form/input-field/vl-input-field.component.cy.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.cy.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlInputFieldComponent } from './vl-input-field.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlInputFieldComponent]);
+registerWebComponents([VlInputFieldComponent, VlFormMessageComponent]);
 
 describe('cypress-component - form components - vl-input-field', () => {
     it('should mount', () => {
@@ -192,5 +193,118 @@ describe('cypress-component - form components - vl-input-field', () => {
         cy.get('vl-input-field').shadow().find('input').type('test');
         cy.get('@vl-valid').should('have.been.calledOnce');
         cy.get('@vl-valid').its('firstCall.args.0.detail').should('deep.equal', { value: 'test' });
+    });
+
+    describe('blur-validation attribuut', () => {
+        const mountWithValidation = () => {
+            cy.mount(html`
+                <form>
+                    <vl-input-field
+                        id="field"
+                        name="field"
+                        required
+                        min-length="3"
+                        pattern="^[a-zA-Z]+$"
+                        blur-validation
+                    ></vl-input-field>
+                    <vl-form-message for="field" state="valueMissing"
+                        >Gelieve een waarde in te vullen.</vl-form-message
+                    >
+                    <vl-form-message for="field" state="tooShort">Minimum 3 karakters.</vl-form-message>
+                    <vl-form-message for="field" state="patternMismatch">Enkel letters toegestaan.</vl-form-message>
+                    <button type="reset">Reset</button>
+                </form>
+            `);
+        };
+
+        it('should show error on blur after focus, even without mutation', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').focus().blur();
+            cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        });
+
+        it('should show error on blur after typing invalid value', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+        });
+
+        it('should live-revalidate after first error and clear when valid', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+
+            cy.get('vl-input-field').shadow().find('input').focus().type('b');
+            cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+
+            cy.get('vl-input-field').shadow().find('input').type('c');
+            cy.get('vl-form-message[state="tooShort"]').should('not.have.attr', 'show');
+        });
+
+        it('should switch error state when validation reason changes during recovery', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+
+            cy.get('vl-input-field').shadow().find('input').clear().type('1');
+            // Either tooShort or patternMismatch can fire first depending on ValidityState iteration order.
+            cy.get('vl-form-message[state="tooShort"], vl-form-message[state="patternMismatch"]')
+                .filter('[show]')
+                .should('have.length.gte', 1);
+        });
+
+        it('should clear error + erroredOnce state on form reset', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+
+            cy.get('button[type="reset"]').click();
+            cy.get('vl-form-message[state="tooShort"]').should('not.have.attr', 'show');
+
+            cy.get('vl-input-field').shadow().find('input').focus().type('a');
+            cy.get('vl-form-message[state="tooShort"]').should('not.have.attr', 'show');
+        });
+
+        it('should mark the input invalid via aria-invalid when the error shows', () => {
+            mountWithValidation();
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-input-field').shadow().find('input').should('have.attr', 'aria-invalid', 'true');
+
+            cy.get('vl-input-field').shadow().find('input').focus().type('bc');
+            cy.get('vl-input-field').shadow().find('input').should('not.have.attr', 'aria-invalid');
+        });
+
+        it('should leave default submit-only behavior intact when attr is absent', () => {
+            cy.mount(html`
+                <form>
+                    <vl-input-field id="field2" name="field2" required min-length="3"></vl-input-field>
+                    <vl-form-message for="field2" state="tooShort">tooShort</vl-form-message>
+                </form>
+            `);
+            cy.get('vl-input-field').shadow().find('input').type('a').blur();
+            cy.get('vl-form-message[state="tooShort"]').should('not.have.attr', 'show');
+        });
+
+        it('should cascade from blur-validation on the parent form (no attr on field)', () => {
+            cy.mount(html`
+                <form blur-validation>
+                    <vl-input-field id="f3" name="f3" required min-length="3"></vl-input-field>
+                    <vl-form-message for="f3" state="valueMissing">Verplicht.</vl-form-message>
+                </form>
+            `);
+            cy.get('vl-input-field').shadow().find('input').focus().blur();
+            cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        });
+
+        it('should cascade from data-blur-validation on the parent form', () => {
+            cy.mount(html`
+                <form data-blur-validation>
+                    <vl-input-field id="f4" name="f4" required min-length="3"></vl-input-field>
+                    <vl-form-message for="f4" state="valueMissing">Verplicht.</vl-form-message>
+                </form>
+            `);
+            cy.get('vl-input-field').shadow().find('input').focus().blur();
+            cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        });
     });
 });

--- a/libs/components/src/form/radio-group/stories/vl-radio-group.stories.ts
+++ b/libs/components/src/form/radio-group/stories/vl-radio-group.stories.ts
@@ -31,6 +31,7 @@ export const RadioGroupDefault = story(
         disabled,
         error,
         success,
+        blurValidation,
         label,
         name,
         value,
@@ -49,6 +50,7 @@ export const RadioGroupDefault = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             @vl-change=${onVlChange}
             @vl-input=${onVlInput}
             @vl-reset=${onVlReset}
@@ -66,4 +68,15 @@ RadioGroupDefault.args = {
     name: 'land-zee',
     label: 'land-zee',
     value: 'land',
+};
+
+export const RadioGroupBlurValidation = RadioGroupDefault.bind({});
+RadioGroupBlurValidation.storyName = 'vl-radio-group - blur validation';
+RadioGroupBlurValidation.args = {
+    id: 'land-zee-validation',
+    name: 'land-zee-validation',
+    label: 'land-zee-validation',
+    value: '',
+    required: true,
+    blurValidation: true,
 };

--- a/libs/components/src/form/radio-group/vl-radio-group.component.cy.ts
+++ b/libs/components/src/form/radio-group/vl-radio-group.component.cy.ts
@@ -2,8 +2,9 @@ import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlRadioComponent } from './vl-radio.component';
 import { VlRadioGroupComponent } from './vl-radio-group.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlRadioComponent, VlRadioGroupComponent]);
+registerWebComponents([VlRadioComponent, VlRadioGroupComponent, VlFormMessageComponent]);
 
 const clickRadioWithValue = (value: string) => {
     cy.get(`vl-radio[value="${value}"]`).shadow().find('input').click({ force: true });
@@ -515,5 +516,45 @@ describe('vl-radio-group - in form', () => {
         cy.get('vl-radio-group').find('vl-radio[value="zee"]').should('not.have.attr', 'checked');
         cy.get('vl-radio-group').find('vl-radio[value="lucht"]').should('not.have.attr', 'checked');
         cy.checkA11y('vl-radio-group');
+    });
+});
+
+describe('vl-radio-group - blur-validation', () => {
+    const mount = () => {
+        cy.mount(html`
+            <form>
+                <vl-radio-group id="rg" name="rg" required blur-validation>
+                    <vl-radio value="a">A</vl-radio>
+                    <vl-radio value="b">B</vl-radio>
+                </vl-radio-group>
+                <vl-form-message for="rg" state="valueMissing">Verplicht.</vl-form-message>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without selection', () => {
+        mount();
+        cy.get('vl-radio-group').then(($el) => {
+            const rg = $el[0] as VlRadioGroupComponent;
+            rg.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error when touched + invalid + blur (base-class isolation)', () => {
+        mount();
+        cy.get('vl-radio-group').then(($el) => {
+            const rg = $el[0] as VlRadioGroupComponent;
+            rg.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: null } }));
+            rg.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should not show error after real radio selection + blur (selection makes valid)', () => {
+        mount();
+        cy.get('vl-radio[value="a"]').shadow().find('input').click({ force: true });
+        cy.get('vl-radio[value="a"]').shadow().find('input').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 });

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
@@ -32,6 +32,7 @@ const SelectRichTemplate = story(
         disabled,
         error,
         success,
+        blurValidation,
         options,
         placeholder,
         notDeletable,
@@ -57,6 +58,7 @@ const SelectRichTemplate = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             .options=${options}
             placeholder=${placeholder}
             ?not-deletable=${notDeletable}

--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -3,8 +3,9 @@ import { html } from 'lit';
 import { parseFormData } from '../utils';
 import { SelectRichOption } from './index';
 import { VlSelectRichComponent } from './vl-select-rich.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlSelectRichComponent]);
+registerWebComponents([VlSelectRichComponent, VlFormMessageComponent]);
 
 describe('cypress-component - form components - vl-select-rich - single', () => {
     const options: SelectRichOption[] = [
@@ -2235,5 +2236,51 @@ describe('cypress-component - form components - vl-select-rich - search strategi
             .should('have.length', 4);
 
         cy.checkA11y('vl-select-rich');
+    });
+});
+
+describe('vl-select-rich - blur-validation', () => {
+    const mount = () => {
+        cy.mount(html`
+            <form>
+                <vl-select-rich
+                    id="sr"
+                    name="sr"
+                    required
+                    blur-validation
+                    .options=${[
+                        { label: 'Een', value: 'een' },
+                        { label: 'Twee', value: 'twee' },
+                    ] as SelectRichOption[]}
+                ></vl-select-rich>
+                <vl-form-message for="sr" state="valueMissing">Verplicht.</vl-form-message>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without selection', () => {
+        mount();
+        cy.get('vl-select-rich').then(($el) => {
+            const sr = $el[0] as VlSelectRichComponent;
+            sr.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error after simulated user-mutation + blur (base-class isolation)', () => {
+        mount();
+        cy.get('vl-select-rich').then(($el) => {
+            const sr = $el[0] as VlSelectRichComponent;
+            sr.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: '' } }));
+            sr.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should not show error after real option pick (selection makes valid)', () => {
+        mount();
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich').shadow().find('.vl-select__list .vl-select__item').first().click();
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 });

--- a/libs/components/src/form/select/stories/vl-select.stories.ts
+++ b/libs/components/src/form/select/stories/vl-select.stories.ts
@@ -31,6 +31,7 @@ const SelectTemplate = story(
         disabled,
         error,
         success,
+        blurValidation,
         options,
         placeholder,
         notDeletable,
@@ -49,6 +50,7 @@ const SelectTemplate = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             .options=${options}
             placeholder=${placeholder}
             ?not-deletable=${notDeletable}

--- a/libs/components/src/form/select/vl-select.component.cy.ts
+++ b/libs/components/src/form/select/vl-select.component.cy.ts
@@ -2,8 +2,9 @@ import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
 import { VlSelectComponent } from './vl-select.component';
 import { SelectOption } from './vl-select.model';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlSelectComponent]);
+registerWebComponents([VlSelectComponent, VlFormMessageComponent]);
 
 const options: SelectOption[] = [
     { label: 'Hasselt', value: 'hasselt' },
@@ -711,5 +712,48 @@ describe('vl-select - declarative options', () => {
         cy.wait(100);
         cy.get('vl-select').shadow().find('select option').should('have.length', 3);
         cy.get('vl-select').shadow().find('select option').last().should('contain', 'Lier');
+    });
+});
+
+describe('vl-select - blur-validation', () => {
+    const mount = () => {
+        cy.mount(html`
+            <form>
+                <vl-select
+                    id="sel"
+                    name="sel"
+                    required
+                    blur-validation
+                    .options=${[
+                        { label: 'Kies...', value: '' },
+                        { label: 'Een', value: 'een' },
+                    ]}
+                ></vl-select>
+                <vl-form-message for="sel" state="valueMissing">Verplicht.</vl-form-message>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without selection', () => {
+        mount();
+        cy.get('vl-select').shadow().find('select').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error after simulated user-mutation + blur (base-class isolation)', () => {
+        mount();
+        cy.get('vl-select').then(($el) => {
+            const sel = $el[0] as VlSelectComponent;
+            sel.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: '' } }));
+            sel.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should not show error after real option pick + blur (selection makes valid)', () => {
+        mount();
+        cy.get('vl-select').shadow().find('select').select('een');
+        cy.get('vl-select').shadow().find('select').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 });

--- a/libs/components/src/form/textarea-rich/stories/vl-textarea-rich.stories.ts
+++ b/libs/components/src/form/textarea-rich/stories/vl-textarea-rich.stories.ts
@@ -34,6 +34,7 @@ const Template = story(
         disabled,
         error,
         success,
+        blurValidation,
         readonly,
         value,
         autocomplete,
@@ -57,6 +58,7 @@ const Template = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             ?readonly=${readonly}
             value=${value}
             autocomplete=${autocomplete}

--- a/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
+++ b/libs/components/src/form/textarea-rich/vl-textarea-rich.component.cy.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlTextareaRichComponent } from './vl-textarea-rich.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlTextareaRichComponent]);
+registerWebComponents([VlTextareaRichComponent, VlFormMessageComponent]);
 
 describe('vl-textarea-rich - vl-input event', () => {
     beforeEach(() => {
@@ -183,5 +184,36 @@ describe('vl-textarea-rich - properties & states', () => {
         cy.get('vl-textarea-rich').shadow().find('.tox-tinymce').invoke('outerHeight').should('be.gte', 350);
 
         cy.get('.snapshot-wrapper').matchImageSnapshot('textarea-rich-height-large');
+    });
+});
+
+describe('vl-textarea-rich - blur-validation', () => {
+    const mount = () => {
+        cy.mount(html`
+            <form>
+                <vl-textarea-rich id="tar" name="tar" required blur-validation></vl-textarea-rich>
+                <vl-form-message for="tar" state="valueMissing">Verplicht.</vl-form-message>
+            </form>
+        `);
+        cy.wait(500); // tinymce init
+    };
+
+    it('should not show error on untouched blur', () => {
+        mount();
+        cy.get('vl-textarea-rich').then(($el) => {
+            const tar = $el[0] as VlTextareaRichComponent;
+            tar.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+    });
+
+    it('should show error after simulated user-mutation + blur', () => {
+        mount();
+        cy.get('vl-textarea-rich').then(($el) => {
+            const tar = $el[0] as VlTextareaRichComponent;
+            tar.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: '' } }));
+            tar.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
     });
 });

--- a/libs/components/src/form/textarea/stories/vl-textarea.stories.ts
+++ b/libs/components/src/form/textarea/stories/vl-textarea.stories.ts
@@ -31,6 +31,7 @@ export const TextareaDefault = story(
         disabled,
         error,
         success,
+        blurValidation,
         block,
         readonly,
         value,
@@ -53,6 +54,7 @@ export const TextareaDefault = story(
             ?disabled=${disabled}
             ?error=${error}
             ?success=${success}
+            ?blur-validation=${blurValidation}
             ?block=${block}
             ?readonly=${readonly}
             value=${value}
@@ -70,3 +72,12 @@ export const TextareaDefault = story(
     }
 );
 TextareaDefault.storyName = 'vl-textarea - default';
+
+export const TextareaBlurValidation = TextareaDefault.bind({});
+TextareaBlurValidation.storyName = 'vl-textarea - blur validation';
+TextareaBlurValidation.args = {
+    required: true,
+    minLength: 5,
+    blurValidation: true,
+    placeholder: 'Min. 5 karakters',
+};

--- a/libs/components/src/form/textarea/vl-textarea.component.cy.ts
+++ b/libs/components/src/form/textarea/vl-textarea.component.cy.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlTextareaComponent } from './vl-textarea.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlTextareaComponent]);
+registerWebComponents([VlTextareaComponent, VlFormMessageComponent]);
 
 describe('vl-textarea - properties & states', () => {
     beforeEach(() => {
@@ -215,5 +216,38 @@ describe('vl-textarea - form integration', () => {
         cy.get('vl-textarea').shadow().find('textarea').should('have.value', 'gewijzigd');
         cy.get('button[type="reset"]').click();
         cy.get('vl-textarea').shadow().find('textarea').should('have.value', 'initieel');
+    });
+});
+
+describe('vl-textarea - blur-validation', () => {
+    const mountWithValidation = () => {
+        cy.mount(html`
+            <form>
+                <vl-textarea id="ta" name="ta" required min-length="3" blur-validation></vl-textarea>
+                <vl-form-message for="ta" state="valueMissing">Gelieve een waarde in te vullen.</vl-form-message>
+                <vl-form-message for="ta" state="tooShort">Minimum 3 karakters.</vl-form-message>
+                <button type="reset">Reset</button>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without mutation', () => {
+        mountWithValidation();
+        cy.get('vl-textarea').shadow().find('textarea').focus().blur();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error on blur after typing invalid value', () => {
+        mountWithValidation();
+        cy.get('vl-textarea').shadow().find('textarea').type('a').blur();
+        cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+    });
+
+    it('should live-revalidate to valid', () => {
+        mountWithValidation();
+        cy.get('vl-textarea').shadow().find('textarea').type('a').blur();
+        cy.get('vl-form-message[state="tooShort"]').should('have.attr', 'show');
+        cy.get('vl-textarea').shadow().find('textarea').focus().type('bc');
+        cy.get('vl-form-message[state="tooShort"]').should('not.have.attr', 'show');
     });
 });

--- a/libs/components/src/form/upload/stories/vl-upload.stories.ts
+++ b/libs/components/src/form/upload/stories/vl-upload.stories.ts
@@ -33,6 +33,7 @@ export const UploadDefault = story(
         readonly,
         error,
         success,
+        blurValidation,
         url,
         disallowDuplicates,
         maxSize,
@@ -84,6 +85,7 @@ export const UploadDefault = story(
                 ?readonly=${readonly}
                 ?error=${error}
                 ?success=${success}
+                ?blur-validation=${blurValidation}
                 ?disallow-duplicates=${disallowDuplicates}
                 ?auto-process=${autoProcess}
                 accepted-files=${acceptedFiles}

--- a/libs/components/src/form/upload/vl-upload.component.cy.ts
+++ b/libs/components/src/form/upload/vl-upload.component.cy.ts
@@ -1,8 +1,9 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
 import { VlUploadComponent } from './vl-upload.component';
+import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
-registerWebComponents([VlUploadComponent]);
+registerWebComponents([VlUploadComponent, VlFormMessageComponent]);
 
 const pdfFileFixturePath = 'fixtures/upload/file.pdf';
 const txtFileFixturePath = 'fixtures/upload/file.txt';
@@ -599,6 +600,36 @@ describe('vl-upload - upload', () => {
         cy.get('@vl-upload-progress').should('have.been.called');
         cy.get('@vl-success').should('have.been.called');
         cy.get('@vl-complete').should('have.been.called');
+    });
+});
+
+describe('vl-upload - blur-validation', () => {
+    const mount = () => {
+        cy.mount(html`
+            <form>
+                <vl-upload id="up" name="up" required blur-validation></vl-upload>
+                <vl-form-message for="up" state="valueMissing">Verplicht.</vl-form-message>
+            </form>
+        `);
+    };
+
+    it('should show error on blur after focus, even without files', () => {
+        mount();
+        cy.get('vl-upload').then(($el) => {
+            const up = $el[0] as VlUploadComponent;
+            up.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+    });
+
+    it('should show error after simulated user-mutation + blur (base-class isolation)', () => {
+        mount();
+        cy.get('vl-upload').then(($el) => {
+            const up = $el[0] as VlUploadComponent;
+            up.dispatchEvent(new CustomEvent('vl-input', { bubbles: true, composed: true, detail: { value: null } }));
+            up.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+        });
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
     });
 });
 

--- a/libs/components/src/form/upload/vl-upload.component.ts
+++ b/libs/components/src/form/upload/vl-upload.component.ts
@@ -187,13 +187,6 @@ export class VlUploadComponent extends FormControl {
 
         if (changedProperties.has('isInvalid')) {
             this.updateInputForAttribute('isInvalid');
-            if (this.isInvalid) {
-                if (this.formMessageText) {
-                    this.getUploadButton()?.setAttribute('aria-description', this.formMessageText);
-                }
-            } else {
-                this.getUploadButton()?.removeAttribute('aria-description');
-            }
         }
 
         if (changedProperties.has('success')) {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-645
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC336 ✅ 

<img width="900" height="506" alt="flux645-v4" src="https://github.com/user-attachments/assets/13fee952-b292-41ba-b874-a7c5a7451c20" />

## Wat doet deze PR

Form controls valideren standaard pas op submit, waardoor de gebruiker tussentijds
geen feedback krijgt. Dit ticket voegt een opt-in attribuut `blur-validation` toe
aan de gedeelde `FormControl` base class, zodat een veld kan valideren zodra het
focus had en weer verlaten wordt.

In de GIF hierboven zie je het verschil tussen de twee gedragingen naast elkaar.

**Linkse form (default).** Zoals vandaag, TAB valideert niet

**Rechtse form (met `blur-validation`).** Elk veld valideert zelf zodra het
verlaten wordt. 

## Hoe inschakelen

Per veld:

```html
<vl-input-field blur-validation required></vl-input-field>
```
Per form (cascade, werkt voor alle controls binnen de form):

```html
<form blur-validation>
    ...
</form>
```

`data-blur-validation` op het form werkt als alternatief voor dezelfde cascade.

##  Geen breaking change
Wanneer het attribuut niet gezet is gedraagt alles zich identiek aan voor deze
PR. Validatie gebeurt dan, zoals vandaag, enkel op submit.