### PR TITLE
feat: FLUX-463 - vl-popover - max-height met interne scroll en automatische viewport-positionering

### DIFF
--- a/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories-arg.ts
@@ -113,4 +113,14 @@ export const popoverArgTypes: ArgTypes<typeof popoverDefaultArgs> = {
             defaultValue: { summary: popoverDefaultArgs.strategy },
         },
     },
+    maxHeight: {
+        name: 'max-height',
+        description:
+            'Optionele harde bovengrens voor de hoogte van de popover-content (CSS-lengte, bv. `300px` of `50vh`). De effectieve hoogte is het minimum van deze waarde en de ruimte tot de viewport-rand; bij overschrijding scrollt de content verticaal.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: popoverDefaultArgs.maxHeight },
+        },
+    },
 };

--- a/libs/components/src/block/popover/stories/vl-popover.stories-doc.mdx
+++ b/libs/components/src/block/popover/stories/vl-popover.stories-doc.mdx
@@ -56,6 +56,14 @@ dichtstbijzijnde gepositioneerde parent-element (bv. een element met `position: 
 
 Om te vermijden dat de popover gepositioneerd wordt tegenover het verkeerde element, kan je best de eerste parent van de popover instellen op `position: relative` zodat de popover steeds gepositioneerd wordt zoals verwacht.
 
+### Maximum-hoogte & scrollen
+
+De popover blijft automatisch binnen de zichtbare viewport: als de inhoud langer is dan de beschikbare ruimte tot de viewport-rand, krijgt de content een verticale scrollbar in plaats van buiten beeld te vallen. De scrollbare regio is met het toetsenbord bedienbaar (pijl-, Page Up/Down-toetsen).
+
+Met het optionele `max-height` attribuut kan je daarbovenop zelf een hardere bovengrens opleggen (een CSS-lengte, bv. `300px` of `50vh`). De effectieve hoogte is dan het minimum van die waarde en de ruimte tot de viewport-rand.
+
+<Canvas of={VlPopoverStories.PopoverScroll} />
+
 ## Varianten
 
 ### Hover / Tooltip

--- a/libs/components/src/block/popover/stories/vl-popover.stories.ts
+++ b/libs/components/src/block/popover/stories/vl-popover.stories.ts
@@ -1,7 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { story } from '@resources/utils-storybook';
 import { Meta } from '@storybook/web-components-vite';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { action } from 'storybook/actions';
 import { VlButtonComponent } from '../../../atom/button';
 import { VlPopoverActionListComponent } from '../vl-popover-action-list.component';
@@ -31,7 +31,7 @@ const relativePositionDecorator = (story: () => unknown) =>
 
 const PopoverTemplate = story(
     popoverDefaultArgs,
-    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy }) => {
+    ({ trigger, contentPadding, open, placement, hideArrow, hideOnClick, distance, strategy, maxHeight }) => {
         const actionListClickHandler = (event: CustomEvent) => {
             const actionElement = event.target as VlPopoverActionComponent;
             action('click')('vl-popover-action clicked > ' + actionElement.action);
@@ -55,6 +55,7 @@ const PopoverTemplate = story(
                 distance=${distance}
                 strategy=${strategy}
                 content-padding=${contentPadding}
+                max-height=${maxHeight || nothing}
             >
                 <vl-popover-action-list @click=${actionListClickHandler}>
                     <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
@@ -71,6 +72,37 @@ PopoverDefault.storyName = 'vl-popover - default';
 PopoverDefault.decorators = [relativePositionDecorator];
 PopoverDefault.args = {
     placement: 'bottom-start',
+};
+
+export const PopoverScroll = story(
+    popoverDefaultArgs,
+    ({ contentPadding, placement, maxHeight }) => html`
+        <vl-button ghost icon="nav-show-more-vertical" id="btn-acties-scroll" label="Acties"></vl-button>
+        <vl-popover
+            for="btn-acties-scroll"
+            placement=${placement}
+            content-padding=${contentPadding}
+            max-height=${maxHeight || nothing}
+        >
+            <vl-popover-action-list aria-label="Acties">
+                ${Array.from(
+                    { length: 20 },
+                    (_, i) => html`<vl-popover-action icon="pin" .action=${`actie-${i + 1}`}>Actie ${i + 1}</vl-popover-action>`
+                )}
+            </vl-popover-action-list>
+        </vl-popover>
+    `
+);
+PopoverScroll.storyName = 'vl-popover - scroll';
+PopoverScroll.decorators = [relativePositionDecorator];
+PopoverScroll.args = {
+    placement: 'bottom-start',
+    maxHeight: '200px',
+};
+PopoverScroll.parameters = {
+    controls: {
+        include: ['content-padding', 'placement', 'max-height'],
+    },
 };
 
 export const PopoverHover = PopoverTemplate.bind({});

--- a/libs/components/src/block/popover/vl-floating-ui.controller.ts
+++ b/libs/components/src/block/popover/vl-floating-ui.controller.ts
@@ -7,12 +7,17 @@ import {
     offset,
     platform,
     shift,
+    size,
     Strategy,
     type Placement,
 } from '@floating-ui/dom';
 import { offsetParent } from 'composed-offset-position';
 import { LitElement, ReactiveController } from 'lit';
 import { POPOVER_ARIA_TYPE, POPOVER_TYPE } from './vl-popover.model';
+
+// Ruimte (px) die de size-middleware vrijhoudt tot de viewport-rand zodat de drop-shadow van
+// .popover-content niet wordt afgeknipt (zie filter in vl-popover.flux-css.ts).
+const VIEWPORT_PADDING = 12;
 
 export type FloatingControllerOptions = {
     reference: string;
@@ -141,6 +146,10 @@ export default class FloatingController implements ReactiveController {
         return this.host.shadowRoot!.querySelector('i#popover-arrow')!;
     }
 
+    private getScrollContainer(): HTMLElement | null {
+        return this.host.shadowRoot?.querySelector<HTMLElement>('.popover-scroll-container') ?? null;
+    }
+
     private buildMiddlewares(): Middleware[] {
         return [
             // https://floating-ui.com/docs/offset
@@ -150,6 +159,17 @@ export default class FloatingController implements ReactiveController {
             flip(),
             // https://floating-ui.com/docs/shift
             shift(),
+            // https://floating-ui.com/docs/size
+            // size() runs after flip() so the available height is measured on the side that flip() chose.
+            size({
+                padding: VIEWPORT_PADDING,
+                apply: ({ availableHeight }) => {
+                    this.getScrollContainer()?.style.setProperty(
+                        '--vl-popover-available-height',
+                        `${Math.max(availableHeight, 0)}px`
+                    );
+                },
+            }),
             // https://floating-ui.com/docs/arrow
             // arrow() should generally be placed toward the end of your middleware array, after shift().
             arrow({ element: this.getArrowElement(), padding: 8 }),
@@ -181,6 +201,23 @@ export default class FloatingController implements ReactiveController {
                 top: y != null ? `${y}px` : '',
                 [staticSide!]: `${-this.getArrowElement().offsetWidth / 2}px`,
             });
+        }
+
+        this.updateScrollability();
+    }
+
+    // Een scrollbare regio moet met het toetsenbord bediend kunnen worden (WCAG 2.1.1): maak de
+    // content focusbaar zodra ze scrollt, zodat pijl-/PageUp-/PageDown-toetsen werken, ook als er
+    // geen focusbare children in de slot zitten.
+    private updateScrollability(): void {
+        const scrollContainer = this.getScrollContainer();
+        if (!scrollContainer) return;
+
+        const isScrollable = scrollContainer.scrollHeight > scrollContainer.clientHeight;
+        if (isScrollable) {
+            scrollContainer.setAttribute('tabindex', '0');
+        } else {
+            scrollContainer.removeAttribute('tabindex');
         }
     }
 

--- a/libs/components/src/block/popover/vl-popover.component.cy.ts
+++ b/libs/components/src/block/popover/vl-popover.component.cy.ts
@@ -14,6 +14,7 @@ const mountDefault = ({
     hideArrow,
     hideOnClick,
     distance,
+    maxHeight,
 }: {
     trigger?: string;
     contentPadding?: string;
@@ -22,6 +23,7 @@ const mountDefault = ({
     hideArrow?: boolean;
     hideOnClick?: boolean;
     distance?: number;
+    maxHeight?: string;
 }) => {
     return cy.mount(html`
         <vl-button ghost icon="nav-show-more-vertical" id="btn-acties" label="Acties"></vl-button>
@@ -35,11 +37,26 @@ const mountDefault = ({
             hide-on-click=${hideOnClick || nothing}
             distance=${distance || nothing}
             content-padding=${contentPadding || nothing}
+            max-height=${maxHeight || nothing}
         >
             <vl-popover-action-list aria-label="Acties">
                 <vl-popover-action icon="search" .action=${'search'}>Zoeken</vl-popover-action>
                 <vl-popover-action icon="bell" .action=${'report'}>Rapportenoverzicht</vl-popover-action>
                 <vl-popover-action icon="pin" .action=${'locate'}>Vind locatie</vl-popover-action>
+            </vl-popover-action-list>
+        </vl-popover>
+    `);
+};
+
+const mountLongList = ({ maxHeight }: { maxHeight?: string } = {}) => {
+    return cy.mount(html`
+        <vl-button ghost icon="nav-show-more-vertical" id="btn-acties" label="Acties"></vl-button>
+        <vl-popover id="popover" for="btn-acties" placement="bottom-start" max-height=${maxHeight || nothing}>
+            <vl-popover-action-list aria-label="Acties">
+                ${Array.from(
+                    { length: 30 },
+                    (_, i) => html`<vl-popover-action icon="pin" .action=${`actie-${i + 1}`}>Actie ${i + 1}</vl-popover-action>`
+                )}
             </vl-popover-action-list>
         </vl-popover>
     `);
@@ -132,6 +149,68 @@ describe('cypress-component - block components - vl-popover - default', () => {
 
         cy.get('#btn-acties').shadow().find('button').focus();
         cy.get('vl-popover').should('be.visible');
+    });
+});
+
+describe('cypress-component - block components - vl-popover - max-height / scroll', () => {
+    it('should not make the content scrollable when it fits', () => {
+        mountDefault({});
+        cy.injectAxe();
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').shadow().find('.popover-scroll-container').should('not.have.attr', 'tabindex');
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll-container')
+            .should(($el) => {
+                expect($el[0].scrollHeight).to.be.at.most($el[0].clientHeight);
+            });
+        cy.checkA11y('vl-popover');
+    });
+
+    it('should show a scrollbar and stay within max-height when content overflows', () => {
+        mountLongList({ maxHeight: '150px' });
+        cy.injectAxe();
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll-container')
+            .should(($el) => {
+                const el = $el[0];
+                expect(el.scrollHeight).to.be.greaterThan(el.clientHeight);
+                expect(el.clientHeight).to.be.at.most(150);
+            });
+        cy.checkA11y('vl-popover');
+    });
+
+    it('should make the scroll container keyboard focusable when scrollable', () => {
+        mountLongList({ maxHeight: '150px' });
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover').shadow().find('.popover-scroll-container').should('have.attr', 'tabindex', '0');
+    });
+
+    it('should stay within the viewport when content is longer than the available space', () => {
+        cy.viewport(500, 320);
+        mountLongList({});
+        cy.injectAxe();
+
+        cy.get('#btn-acties').click();
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-content')
+            .should(($el) => {
+                const rect = $el[0].getBoundingClientRect();
+                expect(rect.bottom).to.be.at.most(Cypress.config('viewportHeight'));
+            });
+        cy.get('vl-popover')
+            .shadow()
+            .find('.popover-scroll-container')
+            .should(($el) => {
+                expect($el[0].scrollHeight).to.be.greaterThan($el[0].clientHeight);
+            });
+        cy.checkA11y('vl-popover');
     });
 });
 

--- a/libs/components/src/block/popover/vl-popover.component.ts
+++ b/libs/components/src/block/popover/vl-popover.component.ts
@@ -4,6 +4,7 @@ import { resetStyle } from '@domg/govflanders-style/common';
 import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 import FloatingController, { FloatingControllerOptions } from './vl-floating-ui.controller';
 import { VlPopoverActionListComponent } from './vl-popover-action-list.component';
 import { VlPopoverActionComponent } from './vl-popover-action.component';
@@ -25,6 +26,13 @@ export class VlPopoverComponent extends BaseLitElement {
     private hideOnClick = popoverDefaults.hideOnClick;
     private strategy = popoverDefaults.strategy;
 
+    /**
+     * Optionele harde bovengrens voor de hoogte van de popover-content, als CSS-lengte (bv. `300px` of `50vh`).
+     * De effectieve hoogte is altijd het minimum van deze waarde en de ruimte tot de viewport-rand; bij
+     * overschrijding scrollt de content verticaal. Leeg laten betekent: enkel beperkt door de viewport.
+     */
+    private maxHeight = popoverDefaults.maxHeight;
+
     static {
         registerWebComponents([VlPopoverActionComponent, VlPopoverActionListComponent]);
     }
@@ -44,6 +52,7 @@ export class VlPopoverComponent extends BaseLitElement {
             hideArrow: { type: Boolean, attribute: 'hide-arrow' },
             hideOnClick: { type: Boolean, attribute: 'hide-on-click' },
             strategy: { type: String, attribute: 'strategy' },
+            maxHeight: { type: String, attribute: 'max-height' },
         };
     }
 
@@ -77,9 +86,12 @@ export class VlPopoverComponent extends BaseLitElement {
             'popover-content': true,
             [`padding-${this.contentPadding}`]: true,
         };
+        const contentStyles = this.maxHeight ? { '--vl-popover-max-height': this.maxHeight } : {};
         return html`
-            <div class=${classMap(classes)} aria-hidden="${!this.open}">
-                <slot></slot>
+            <div class=${classMap(classes)} style=${styleMap(contentStyles)} aria-hidden="${!this.open}">
+                <div class="popover-scroll-container">
+                    <slot></slot>
+                </div>
                 ${!this.hideArrow ? html`<i id="popover-arrow" role="presentation"></i>` : null}
             </div>
         `;

--- a/libs/components/src/block/popover/vl-popover.defaults.ts
+++ b/libs/components/src/block/popover/vl-popover.defaults.ts
@@ -10,6 +10,7 @@ export type PopoverDefaults = {
     open: boolean;
     distance: number;
     strategy: Strategy;
+    maxHeight: string;
 };
 
 export const popoverDefaults: PopoverDefaults = {
@@ -22,4 +23,5 @@ export const popoverDefaults: PopoverDefaults = {
     open: false,
     distance: 10,
     strategy: 'absolute',
+    maxHeight: '',
 };

--- a/libs/components/src/block/popover/vl-popover.flux-css.ts
+++ b/libs/components/src/block/popover/vl-popover.flux-css.ts
@@ -21,23 +21,34 @@ export const vlPopoverFluxStyles: CSSResult = css`
     }
 
     .popover-content {
+        --vl-popover-content-padding: 1rem;
         filter: drop-shadow(0 0.2rem 0.6rem rgba(106, 118, 134, 0.15))
             drop-shadow(0 0 0.1rem var(--vl-color--border-default))
             drop-shadow(0 0 0.1rem var(--vl-color--border-default));
         will-change: filter;
         background-color: #fff;
-        padding: 1rem;
+        padding: var(--vl-popover-content-padding);
         max-width: 100vw;
         word-break: break-all;
 
         &.padding-none {
-            padding: 0;
+            --vl-popover-content-padding: 0;
         }
         &.padding-small {
-            padding: 0.5rem;
+            --vl-popover-content-padding: 0.5rem;
         }
         &.padding-large {
-            padding: 2rem;
+            --vl-popover-content-padding: 2rem;
         }
+    }
+
+    /* De scroll-container draagt overflow i.p.v. .popover-content, zodat de arrow (die buiten de
+       content-box uitsteekt) en de drop-shadow niet door overflow worden afgeknipt. */
+    .popover-scroll-container {
+        overflow-y: auto;
+        max-height: min(
+            calc(var(--vl-popover-available-height, 100vh) - 2 * var(--vl-popover-content-padding)),
+            var(--vl-popover-max-height, 100vh)
+        );
     }
 `;


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-463

## Samenvatting
De `vl-popover` blijft voortaan binnen het zichtbare scherm: wanneer de inhoud langer is dan de beschikbare ruimte krijgt de content een verticale scrollbar in plaats van buiten beeld te vallen. Consumers kunnen optioneel een hardere bovengrens opleggen via een nieuw `max-height` attribuut.

## Wijzigingen
- Popover meet automatisch de beschikbare hoogte tot de viewport-rand en beperkt de content daartoe; bij overschrijding scrollt de content verticaal.
- De automatische positionering (flip boven/onder) blijft werken en wordt nu gevolgd door de hoogtemeting op de gekozen kant.
- Nieuw optioneel `max-height` attribuut (CSS-lengte) als hardere bovengrens; de effectieve hoogte is het minimum van die waarde en de viewport-ruimte.
- De scrollbare regio is met het toetsenbord bedienbaar (focusbaar zodra ze scrollt, WCAG 2.1.1).

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. Het `max-height` attribuut is additief en opt-in; popovers die binnen de viewport passen gedragen zich ongewijzigd.

## Succescriteria
- [x] Popover blijft binnen de viewport bij lange inhoud — `size` middleware + `max-height: min(beschikbaar, …)`.
- [x] Verticale scrollbar bij overschrijding — `overflow-y: auto` op de scroll-container.
- [x] flip-logica blijft werken — hoogte gemeten ná flip, op de gekozen kant.
- [x] Optionele consumer-max-height — nieuw `max-height` attribuut.
- [x] Geen regressie bij passende popovers — geen scrollbar/tabindex wanneer de inhoud past.