### PR TITLE
fix: FLUX-620 - vl-functional-header - title-label-attribuut, geen native tooltip meer

### DIFF
--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-arg.ts
@@ -23,6 +23,7 @@ export const functionalHeaderArgs = {
     marginBottom: 'large',
     subTitle: '',
     title: '',
+    titleLabel: '',
     actionsSlot: '',
     backSlot: '',
     backLinkSlot: '',
@@ -145,9 +146,21 @@ export const functionalHeaderArgTypes: ArgTypes<typeof functionalHeaderArgs> = {
             defaultValue: { summary: functionalHeaderArgs.subTitle },
         },
     },
+    titleLabel: {
+        name: 'title-label',
+        description: 'Tekst van de titel.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: functionalHeaderArgs.titleLabel },
+        },
+    },
     title: {
         name: 'title',
-        description: 'Tekst van de titel.',
+        description:
+            '**Deprecated** - gebruik `title-label`. Het standaard HTML `title`-attribuut toont een ongewenste' +
+            ' native browser-tooltip. Bestaande `title`-waarden blijven werken (de tooltip wordt weggenomen), maar' +
+            ' migreer best naar `title-label`.',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
@@ -57,6 +57,18 @@ pagina, houdt die rekening met de hoogte van de sticky functional header bij het
 demo van deze opzet vind je hier: [Voorbeeld Met Sticky En Side Navigation](/docs/patronen-navigatie-functionele-header-sticky-met-side-navigation--documentatie).
 
 
+## Titel
+
+Zet de titel met het `title-label`-attribuut.
+
+<FluxAlert type="warning">
+{`
+    Het standaard HTML \`title\`-attribuut wordt afgeraden: de browser toont het als native tooltip. Gebruik in
+    plaats daarvan \`title-label\`. Bestaande \`title\`-waarden blijven werken - de tooltip wordt automatisch
+    weggenomen - migreer naar \`title-label\`.
+`}
+</FluxAlert>
+
 ## Configuratie
 
 <ArgTypes of={VlFunctionalHeaderStories.FunctionalHeaderDefault} />

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories.ts
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories.ts
@@ -1,12 +1,12 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { story } from '@resources/utils-storybook';
 import { Meta } from '@storybook/web-components-vite';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { action } from 'storybook/actions';
 import { VlBreadcrumbItemComponent } from '../../breadcrumb/vl-breadcrumb-item.component';
 import { VlBreadcrumbComponent } from '../../breadcrumb/vl-breadcrumb.component';
-import { VlTabsComponent } from '../../next/tabs';
+import { VlTabsComponent } from '../../next/tabs/vl-tabs.component';
 import { VlSearchComponent } from '../../search';
 import { VlFunctionalHeaderComponent } from '../vl-functional-header.component';
 import { functionalHeaderArgs, functionalHeaderArgTypes } from './vl-functional-header.stories-arg';
@@ -46,6 +46,7 @@ const Template = story(
         marginBottom,
         subTitle,
         title,
+        titleLabel,
         actionsSlot,
         backSlot,
         backLinkSlot,
@@ -67,7 +68,8 @@ const Template = story(
             link=${link}
             margin-bottom=${marginBottom}
             sub-title=${subTitle}
-            title=${title}
+            title=${title || nothing}
+            title-label=${titleLabel || nothing}
             skip-to-content-id=${skipToContentId}
             @vl-click-back=${onClickBack}
         >
@@ -96,14 +98,14 @@ export const FunctionalHeaderDefault = Template.bind({});
 FunctionalHeaderDefault.storyName = 'vl-functional-header - default';
 FunctionalHeaderDefault.args = {
     subTitle: subTitleString,
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderActions = Template.bind({});
 FunctionalHeaderActions.storyName = 'vl-functional-header - actions';
 FunctionalHeaderActions.args = {
     subTitle: subTitleString,
-    title: titleString,
+    titleLabel: titleString,
     actionsSlot: actionsSlotString,
 };
 
@@ -121,12 +123,12 @@ FunctionalHeaderSlots.args = {
 
 export const FunctionalHeaderTabs = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${titleLabel}
             skip-to-content-id="${skipToContentId}"
         >
             <vl-tabs-next slot="sub-header" horizontal-navigation label="Transportmiddelen">
@@ -139,17 +141,17 @@ export const FunctionalHeaderTabs = story(
 );
 FunctionalHeaderTabs.storyName = 'vl-functional-header - tabs';
 FunctionalHeaderTabs.args = {
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderBreadcrumb = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${titleLabel}
             skipToContentId=${skipToContentId}
             hide-back-link
         >
@@ -164,17 +166,17 @@ export const FunctionalHeaderBreadcrumb = story(
 );
 FunctionalHeaderBreadcrumb.storyName = 'vl-functional-header - breadcrumb';
 FunctionalHeaderBreadcrumb.args = {
-    title: titleString,
+    titleLabel: titleString,
 };
 
 export const FunctionalHeaderFullWidth = story(
     functionalHeaderArgs,
-    ({ fullWidth, marginBottom, title, link, skipToContentId }) => html`
+    ({ fullWidth, marginBottom, titleLabel, link, skipToContentId }) => html`
         <vl-functional-header
             ?full-width=${fullWidth}
             link=${link}
             margin-bottom=${marginBottom}
-            title=${title}
+            title-label=${titleLabel}
             skip-to-content-id=${skipToContentId}
         >
             <span slot="sub-title">Full width</span>
@@ -183,14 +185,14 @@ export const FunctionalHeaderFullWidth = story(
 );
 FunctionalHeaderFullWidth.storyName = 'vl-functional-header - full width';
 FunctionalHeaderFullWidth.args = {
-    title: titleString,
+    titleLabel: titleString,
     fullWidth: true,
 };
 
 export const FunctionalHeaderDisableBackLink = Template.bind({});
 FunctionalHeaderDisableBackLink.storyName = 'vl-functional-header - disable back link';
 FunctionalHeaderDisableBackLink.args = {
-    title: titleString,
+    titleLabel: titleString,
     subTitleSlot: subTitleSlotString,
     back: backString,
     disableBackLink: true,
@@ -203,7 +205,7 @@ FunctionalHeaderDisableBackLink.args = {
 export const FunctionalHeaderHideBackLink = Template.bind({});
 FunctionalHeaderHideBackLink.storyName = 'vl-functional-header - hide back link';
 FunctionalHeaderHideBackLink.args = {
-    title: titleString,
+    titleLabel: titleString,
     subTitleSlot: subTitleSlotString,
     hideBackLink: true,
 };
@@ -211,6 +213,6 @@ FunctionalHeaderHideBackLink.args = {
 export const FunctionalHeaderHideSubHeader = Template.bind({});
 FunctionalHeaderHideSubHeader.storyName = 'vl-functional-header - hide sub header';
 FunctionalHeaderHideSubHeader.args = {
-    title: titleString,
+    titleLabel: titleString,
     hideSubHeader: true,
 };

--- a/libs/components/src/block/functional-header/vl-functional-header.component.cy.ts
+++ b/libs/components/src/block/functional-header/vl-functional-header.component.cy.ts
@@ -131,6 +131,28 @@ describe('cypress-component - block components - vl-functional-header', () => {
 
         shouldSetTitleText();
     });
+
+    it('should set title text via title-label', () => {
+        cy.mount(html` <vl-functional-header title-label="School en studietoelagen"></vl-functional-header>`);
+
+        shouldSetTitleText();
+    });
+
+    it('should not keep the title attribute on the host (no native tooltip)', () => {
+        cy.mount(html` <vl-functional-header title="School en studietoelagen"></vl-functional-header>`);
+
+        shouldSetTitleText();
+        cy.get('vl-functional-header').should('not.have.attr', 'title');
+    });
+
+    it('should prefer title-label over deprecated title when both are set', () => {
+        cy.mount(html`
+            <vl-functional-header title="Oude titel" title-label="School en studietoelagen"></vl-functional-header>
+        `);
+
+        shouldSetTitleText();
+        cy.get('vl-functional-header').should('not.have.attr', 'title');
+    });
 });
 
 describe('cypress-component - block components - vl-functional-header - actions', () => {

--- a/libs/components/src/block/functional-header/vl-functional-header.component.ts
+++ b/libs/components/src/block/functional-header/vl-functional-header.component.ts
@@ -92,6 +92,7 @@ export class VlFunctionalHeaderComponent extends BaseHTMLElement {
             'margin-bottom',
             'sub-title',
             'title',
+            'title-label',
             'skip-to-content-id',
         ];
     }
@@ -260,7 +261,16 @@ export class VlFunctionalHeaderComponent extends BaseHTMLElement {
         return this._template(`<li class="vl-functional-header__sub__action">${text}</li>`);
     }
 
+    /** @deprecated Gebruik het `title-label` attribuut om de paginatitel te zetten. */
     _titleChangedCallback(oldValue: string, newValue: string) {
+        if (newValue == null) {
+            return;
+        }
+        this._titleElement!.innerText = newValue;
+        this.removeAttribute('title');
+    }
+
+    _titleLabelChangedCallback(oldValue: string, newValue: string) {
         this._titleElement!.innerText = newValue;
     }
 


### PR DESCRIPTION
Nieuw `title-label`-attribuut voor de paginatitel. Het `title`-attribuut blijft werken maar is deprecated: de waarde wordt overgenomen en het attribuut wordt van de host gestript zodat de native browser-tooltip verdwijnt; `title-label` krijgt voorrang wanneer beide gezet zijn.

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-620
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC346