### PR TITLE
feat: FLUX-223 - vl-form-message - success- en annotation-variant

### DIFF
--- a/libs/components/src/atom/text/stories/vl-text.stories-doc.mdx
+++ b/libs/components/src/atom/text/stories/vl-text.stories-doc.mdx
@@ -10,6 +10,11 @@ import * as VlTextStories from './vl-text.stories';
 
 Gebruik de `text` component om een tekst af te beelden op andere wijze.<br/>
 
+`vl-text` is puur stilistisch en heeft geen koppeling met form-controls of validatie. Wil je een boodschap tonen die
+hoort bij een form-control (bv. een fout-, success- of toelichtingsboodschap), gebruik dan
+[`vl-form-message`](/docs/components-form-form-message--documentatie): die werkt samen met de validatie-lifecycle en
+zorgt voor de juiste `aria`-koppeling.
+
 
 ## Voorbeeld
 
@@ -46,6 +51,10 @@ import { VlTextComponent } from '@domg-wc/components/atom';
 
 <Canvas of={VlTextStories.TextSuccess} />
 
+> Hoort de boodschap bij een form-control? Gebruik dan
+> [`vl-form-message`](/docs/components-form-form-message--documentatie) met `variant="success"` (of `state="valid"` voor
+> een automatische success-boodschap). `vl-text` is enkel voor stijl, niet voor forms.
+
 ### Warning
 
 <Canvas of={VlTextStories.TextWarning} />
@@ -54,9 +63,17 @@ import { VlTextComponent } from '@domg-wc/components/atom';
 
 <Canvas of={VlTextStories.TextError} />
 
+> Hoort de boodschap bij een form-control? Gebruik dan
+> [`vl-form-message`](/docs/components-form-form-message--documentatie) (default `variant="error"`). `vl-text` is enkel
+> voor stijl, niet voor forms.
+
 ### Annotation
 
 <Canvas of={VlTextStories.TextAnnotation} />
+
+> Hoort de boodschap bij een form-control? Gebruik dan
+> [`vl-form-message`](/docs/components-form-form-message--documentatie) met `variant="annotation"`. `vl-text` is enkel
+> voor stijl, niet voor forms.
 
 ### Small
 

--- a/libs/components/src/form/form-control/form-control.ts
+++ b/libs/components/src/form/form-control/form-control.ts
@@ -24,8 +24,19 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     // Sticky once true (reset via resetFormControl). Enables live re-validation on input after the first error.
     private erroredOnce = false;
 
+    // Pas success-styling toe zodra de control valid is geworden na een eerste validatie.
+    // Zonder die controle zou een veld dat van bij aanvang geldig is meteen groen worden.
+    private hasBeenValidated = false;
+
+    // De form waarop de validatiecyclus-listeners hangen.
+    private validatedForm: HTMLFormElement | null = null;
+
+    // Voorkomt dat er per update-cyclus meerdere message-refreshes ingepland worden.
+    private formMessageRefreshScheduled = false;
+
     // Variables
     protected submitFormOnEnter = true;
+    protected formMessageText: string | undefined | null;
 
     static formControlValidators = [requiredValidator, programmaticValidator];
 
@@ -52,6 +63,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         this.addEventListener('invalid', this.onInvalid);
         this.addEventListener('vl-input', this.onUserMutation);
         this.addEventListener('focusout', this.onFocusOut);
+        this.addEventListener('vl-valid', this.onValid);
     }
 
     disconnectedCallback() {
@@ -61,6 +73,27 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         this.removeEventListener('invalid', this.onInvalid);
         this.removeEventListener('vl-input', this.onUserMutation);
         this.removeEventListener('focusout', this.onFocusOut);
+        this.removeEventListener('vl-valid', this.onValid);
+
+        this.unbindFormValidationListeners();
+    }
+
+    // Verplaats de validatie-cyclus-listeners mee wanneer de control aan de form gekoppeld
+    // wordt. Wordt door de browser aangeroepen omdat de control form-associated is.
+    formAssociatedCallback(form: HTMLFormElement | null) {
+        if (this.validatedForm === form) {
+            return;
+        }
+
+        this.unbindFormValidationListeners();
+
+        this.validatedForm = form;
+        this.validatedForm?.addEventListener('submit', this.onFormValidated);
+    }
+
+    private unbindFormValidationListeners() {
+        this.validatedForm?.removeEventListener('submit', this.onFormValidated);
+        this.validatedForm = null;
     }
 
     updated(changedProperties: Map<string, unknown>) {
@@ -76,7 +109,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
 
         if (!changedProperties.has('isInvalid')) {
             this.isInvalid = false;
-            this.hideFormMessages();
+            this.scheduleFormMessageRefresh();
         }
     }
 
@@ -98,6 +131,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     resetFormControl() {
         this.isInvalid = false;
         this.erroredOnce = false;
+        this.hasBeenValidated = false;
         this.hideFormMessages();
         this.dispatchEvent(new Event('vl-reset', { bubbles: true, composed: true }));
     }
@@ -120,6 +154,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         event.preventDefault();
 
         this.isInvalid = true;
+        this.hasBeenValidated = true;
         // Only stick erroredOnce in blur-validation mode (live recovery after submit).
         if (this.blurValidationEnabled) {
             this.erroredOnce = true;
@@ -127,6 +162,24 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         this.focusFirstInvalidInput();
         this.showFormMessage();
     }
+
+    private onValid(event: Event) {
+        if (event.target !== this) {
+            return;
+        }
+
+        if (this.hasBeenValidated && this.validity.valid) {
+            this.showSuccessMessage();
+        }
+    }
+
+    private onFormValidated = () => {
+        this.hasBeenValidated = true;
+
+        if (this.validity.valid) {
+            this.showSuccessMessage();
+        }
+    };
 
     private onUserMutation() {
         if (!this.blurValidationEnabled) return;
@@ -151,10 +204,17 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     private runValidation() {
         if (this.validity.valid) {
             this.isInvalid = false;
-            this.hideFormMessages();
+            // Toon de success-boodschap zodra de control geldig wordt na een eerste validatie,
+            // anders enkel de (eventuele) foutmelding verbergen.
+            if (this.hasBeenValidated) {
+                this.showSuccessMessage();
+            } else {
+                this.hideFormMessages();
+            }
         } else {
             this.isInvalid = true;
             this.erroredOnce = true;
+            this.hasBeenValidated = true;
             this.showFormMessage();
         }
     }
@@ -169,6 +229,9 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     }
 
     private showFormMessage() {
+        // Error en success sluiten elkaar uit: verberg eerst alles, toon dan de error.
+        this.hideFormMessages();
+
         let errorState = '';
 
         for (const key in this.validity) {
@@ -183,21 +246,75 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
             `${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"][state="${errorState}"]`
         );
 
-        // Als er geen error message is voor de huidige error state, zoek dan de algemene error message zonder state attribuut
+        // Als er geen error message is voor de huidige error state, zoek dan de algemene error message zonder state attribuut.
+        // Success- en annotation-messages worden uitgesloten zodat ze nooit als error getoond worden.
         if (!errorMessage) {
-            errorMessage = this.form?.querySelector(`${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]:not([state])`);
+            errorMessage = this.form?.querySelector(
+                `${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]:not([state]):not([variant="success"]):not([variant="annotation"])`
+            );
         }
 
-        if (errorMessage) {
-            errorMessage.setAttribute('validation-message', this.validationMessage);
-            if (!errorMessage.hasAttribute('show')) {
-                errorMessage.setAttribute('show', '');
-            }
+        this.formMessageText = errorMessage?.textContent;
+
+        if (this.formMessageText) {
+            this.validationTarget?.setAttribute('aria-description', this.formMessageText);
+        } else {
+            this.validationTarget?.removeAttribute('aria-description');
+        }
+
+        errorMessage?.setAttribute('validation-message', this.validationMessage);
+        errorMessage?.setAttribute('show', '');
+    }
+
+    private scheduleFormMessageRefresh() {
+        if (this.formMessageRefreshScheduled) {
+            return;
+        }
+
+        this.formMessageRefreshScheduled = true;
+        queueMicrotask(() => this.refreshFormMessage());
+    }
+
+    private refreshFormMessage() {
+        this.formMessageRefreshScheduled = false;
+
+        if (this.hasBeenValidated && this.validity.valid) {
+            this.showSuccessMessage();
+        } else {
+            this.hideFormMessages();
         }
     }
 
+    private showSuccessMessage() {
+        // Altijd eerst verbergen: ook als er geen success-boodschap gedefinieerd is moet een
+        // eerder getoonde foutmelding verdwijnen zodra de control geldig wordt.
+        this.hideFormMessages();
+
+        const successMessage = this.form?.querySelector(
+            `${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"][state="valid"]`
+        );
+
+        if (!successMessage) {
+            return;
+        }
+
+        this.formMessageText = successMessage.textContent;
+
+        if (this.formMessageText) {
+            this.validationTarget?.setAttribute('aria-description', this.formMessageText);
+        }
+
+        successMessage.setAttribute('show', '');
+    }
+
     private hideFormMessages() {
-        const formMessages = this.form?.querySelectorAll(`${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]`);
+        // Annotation-messages zijn louter informatief en blijven altijd zichtbaar; nooit verbergen.
+        const formMessages = this.form?.querySelectorAll(
+            `${FORM_MESSAGE_CUSTOM_TAG}[for="${this.id}"]:not([variant="annotation"])`
+        );
+
+        this.formMessageText = null;
+        this.validationTarget?.removeAttribute('aria-description');
 
         formMessages?.forEach((formMessage) => {
             formMessage.removeAttribute('show');

--- a/libs/components/src/form/form-message/stories/vl-form-message.stories-arg.ts
+++ b/libs/components/src/form/form-message/stories/vl-form-message.stories-arg.ts
@@ -23,11 +23,24 @@ export const formMessageArgTypes: ArgTypes<FormMessageArgs> = {
     },
     state: {
         name: 'state',
-        description: 'De state van het input element waarvoor de message getoond moet worden.',
+        description:
+            'De `ValidityState`-sleutel waarvoor de message getoond moet worden. Gebruik `state="valid"` voor een success-boodschap (groen) die automatisch verschijnt zodra het veld geldig is na een eerste validatie.',
         table: {
             category: CATEGORIES.ATTRIBUTES,
             type: { summary: 'ValidityState' },
             defaultValue: { summary: String(formMessageArgs.state) },
+        },
+    },
+    variant: {
+        name: 'variant',
+        description:
+            'De visuele stijl van de message: `error` (default), `success` of `annotation`. Gebruik `annotation` voor een altijd zichtbare, informatieve tekst. De success-stijl wordt ook automatisch toegepast bij `state="valid"`.',
+        control: { type: 'select' },
+        options: ['error', 'success', 'annotation'],
+        table: {
+            category: CATEGORIES.ATTRIBUTES,
+            type: { summary: 'error | success | annotation' },
+            defaultValue: { summary: String(formMessageArgs.variant) },
         },
     },
     show: {

--- a/libs/components/src/form/form-message/stories/vl-form-message.stories-doc.mdx
+++ b/libs/components/src/form/form-message/stories/vl-form-message.stories-doc.mdx
@@ -11,6 +11,9 @@ import * as VlFormMessageStories from './vl-form-message.stories';
 Gebruik de `form-message` component om een boodschap af te beelden voor een input veld.<br/>
 Zie het [form demo](/docs/patronen-formulier-demo--documentatie) voorbeeld voor het gebruik binnen een form.
 
+Gebruik `vl-form-message` zodra een boodschap aan een form-control gekoppeld is: de component werkt samen met de
+validatie-lifecycle van de control (tonen/verbergen en `aria-description`).
+
 
 ## Voorbeeld
 
@@ -38,10 +41,36 @@ We raden aan 1 form message per validatie te tonen. Als er meerdere validaties z
 De volgorde waarin de form messages getoond worden volgt dezelfde volgorde van `vl-form-message` componenten in
 de DOM. Een voorbeeld hiervan kan je vinden in onze [form demo](/docs/patronen-formulier-demo--documentatie).
 
+### Varianten
+
+Met het `variant` attribuut bepaal je de visuele stijl van de message: `error` (default, rood), `success` (groen) of
+`annotation` (grijs). Bestaande markup zonder `variant` blijft de error-stijl tonen. Een `variant="annotation"` is een
+altijd zichtbare, informatieve tekst.
+
+De success-stijl wordt daarnaast ook automatisch toegepast bij `state="valid"`, zodat een auto-success boodschap geen
+expliciete `variant` nodig heeft (zie [Success](#success)).
+
+<Canvas of={VlFormMessageStories.FormMessageSuccess} />
+
+<Canvas of={VlFormMessageStories.FormMessageAnnotation} />
+
 ### Success
 
-Als je expliciet wil aantonen dat de form-control correct is ingevuld, kan je het `success` attribuut gebruiken op de
-gerelateerde form-control.
+Plaats een `vl-form-message` met `state="valid"` bij het veld om een success-boodschap automatisch te laten verschijnen
+zodra het veld valid is na een eerste validatie. De aanwezigheid van die boodschap is voldoende - er is geen extra
+attribuut op de form-control nodig, en de groene success-stijl wordt automatisch toegepast. De boodschap volgt dezelfde
+lifecycle als een foutmelding: ze verschijnt zodra het veld - na een eerdere foutmelding - correct wordt ingevuld, en
+verdwijnt opnieuw zodra het veld terug invalid is.
+
+```html
+<vl-input-field id="naam" name="naam" required></vl-input-field>
+<vl-form-message for="naam" state="valueMissing">Gelieve een naam in te vullen.</vl-form-message>
+<vl-form-message for="naam" state="valid">Dit veld is correct ingevuld.</vl-form-message>
+```
+
+> Wil je een boodschap los van de validatie-lifecycle manueel in de success-stijl tonen, gebruik dan
+> `variant="success"`. Wil je de form-control zelf in een success-stijl tonen (zonder boodschap), gebruik dan het
+> `success` attribuut op de form-control.
 
 ### Foutmeldingen
 

--- a/libs/components/src/form/form-message/stories/vl-form-message.stories.ts
+++ b/libs/components/src/form/form-message/stories/vl-form-message.stories.ts
@@ -21,19 +21,41 @@ export default {
     },
 } as Meta<typeof formMessageArgs>;
 
-export const FormMessageDefault = story(formMessageArgs, ({ for: forValue, state, show, preLine, defaultSlot }) => {
-    return html`
-        <vl-form-message
-            for=${forValue}
-            state=${state}
-            ?show=${show}
-            ?pre-line=${preLine}
-            validation-message=${defaultSlot}
-        ></vl-form-message>
-    `;
-});
+export const FormMessageDefault = story(
+    formMessageArgs,
+    ({ for: forValue, state, variant, show, preLine, defaultSlot }) => {
+        return html`
+            <vl-form-message
+                for=${forValue}
+                state=${state}
+                variant=${variant}
+                ?show=${show}
+                ?pre-line=${preLine}
+                validation-message=${defaultSlot}
+            ></vl-form-message>
+        `;
+    }
+);
 FormMessageDefault.storyName = 'vl-form-message - default';
 FormMessageDefault.args = {
     show: true,
     defaultSlot: 'Dit is een form message.',
+};
+
+export const FormMessageSuccess = story(formMessageArgs, ({ show, defaultSlot }) => {
+    return html` <vl-form-message variant="success" ?show=${show}>${defaultSlot}</vl-form-message> `;
+});
+FormMessageSuccess.storyName = 'vl-form-message - success';
+FormMessageSuccess.args = {
+    show: true,
+    defaultSlot: 'Dit veld is correct ingevuld.',
+};
+
+export const FormMessageAnnotation = story(formMessageArgs, ({ show, defaultSlot }) => {
+    return html` <vl-form-message variant="annotation" ?show=${show}>${defaultSlot}</vl-form-message> `;
+});
+FormMessageAnnotation.storyName = 'vl-form-message - annotation';
+FormMessageAnnotation.args = {
+    show: true,
+    defaultSlot: 'Extra toelichting bij dit veld.',
 };

--- a/libs/components/src/form/form-message/vl-form-message.component.css.ts
+++ b/libs/components/src/form/form-message/vl-form-message.component.css.ts
@@ -11,20 +11,30 @@ export const vlFormMessageComponentStyles: CSSResult = css`
     }
 
     /* ===================================================================
-       Form Message Base Styles (Error & Success)
+       Form Message Base Styles (Error, Success & Annotation)
        =================================================================== */
 
     .vl-form__error,
-    .vl-form__success {
+    .vl-form__success,
+    .vl-form__annotation {
         font-size: 1.4rem;
-        font-weight: 500;
         margin-top: var(--vl-form-message--margin-top);
         margin-bottom: var(--vl-form-message--margin-bottom);
     }
 
+    .vl-form__error,
+    .vl-form__success {
+        font-weight: 500;
+    }
+
+    .vl-form__annotation {
+        font-weight: 400;
+    }
+
     @media screen and (max-width: 767px) {
         .vl-form__error,
-        .vl-form__success {
+        .vl-form__success,
+        .vl-form__annotation {
             font-size: var(--vl-font-size--small);
         }
     }
@@ -56,6 +66,14 @@ export const vlFormMessageComponentStyles: CSSResult = css`
 
     .vl-form__success {
         color: var(--vl-color--success);
+    }
+
+    /* ===================================================================
+       Form Message Annotation State
+       =================================================================== */
+
+    .vl-form__annotation {
+        color: var(--vl-color--text-subtle);
     }
 
     /* ===================================================================

--- a/libs/components/src/form/form-message/vl-form-message.component.cy.ts
+++ b/libs/components/src/form/form-message/vl-form-message.component.cy.ts
@@ -84,6 +84,44 @@ describe('vl-form-message - properties & states', () => {
             expect(component.state).to.equal('missingValue');
         });
     });
+
+    it('should render error variant by default', () => {
+        cy.mount(html`<vl-form-message show>Test form message</vl-form-message>`);
+
+        cy.get('vl-form-message').shadow().find('p').should('have.class', 'vl-form__error');
+        cy.get('vl-form-message').shadow().find('p').should('not.have.class', 'vl-form__success');
+        cy.get('vl-form-message').shadow().find('p').should('not.have.class', 'vl-form__annotation');
+    });
+
+    it('should render success variant', () => {
+        cy.mount(html`<vl-form-message variant="success" show>Test form message</vl-form-message>`);
+
+        cy.get('vl-form-message').shadow().find('p').should('have.class', 'vl-form__success');
+        cy.get('vl-form-message').shadow().find('p').should('not.have.class', 'vl-form__error');
+        cy.get('vl-form-message').shadow().find('.vl-form__success').should('be.visible');
+    });
+
+    it('should render the success style for state="valid"', () => {
+        cy.mount(html`<vl-form-message state="valid" show>Test form message</vl-form-message>`);
+
+        cy.get('vl-form-message').shadow().find('p').should('have.class', 'vl-form__success');
+        cy.get('vl-form-message').shadow().find('p').should('not.have.class', 'vl-form__error');
+        cy.get('vl-form-message').shadow().find('.vl-form__success').should('be.visible');
+    });
+
+    it('should render annotation variant', () => {
+        cy.mount(html`<vl-form-message variant="annotation" show>Test form message</vl-form-message>`);
+
+        cy.get('vl-form-message').shadow().find('p').should('have.class', 'vl-form__annotation');
+        cy.get('vl-form-message').shadow().find('p').should('not.have.class', 'vl-form__error');
+        cy.get('vl-form-message').shadow().find('.vl-form__annotation').should('be.visible');
+    });
+
+    it('should always show an annotation message even without the show attribute', () => {
+        cy.mount(html`<vl-form-message variant="annotation">Test form message</vl-form-message>`);
+
+        cy.get('vl-form-message').shadow().find('.vl-form__annotation').should('be.visible');
+    });
 });
 
 describe('vl-form-message - content & validation', () => {

--- a/libs/components/src/form/form-message/vl-form-message.component.ts
+++ b/libs/components/src/form/form-message/vl-form-message.component.ts
@@ -3,7 +3,7 @@ import { vlResetStyles } from '@domg-wc/styles';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { vlFormMessageComponentStyles } from './vl-form-message.component.css';
-import { formMessageDefaults } from './vl-form-message.defaults';
+import { FormMessageVariant, formMessageDefaults } from './vl-form-message.defaults';
 
 export const FORM_MESSAGE_CUSTOM_TAG = 'vl-form-message';
 
@@ -14,6 +14,7 @@ export class VlFormMessageComponent extends BaseLitElement {
     private preLine = formMessageDefaults.preLine;
     private for = formMessageDefaults.for; // Wordt enkel gebruikt in de form-control basis klasse
     private state = formMessageDefaults.state; // Wordt enkel gebruikt in de form-control basis klasse
+    private variant: FormMessageVariant = formMessageDefaults.variant;
     private validationMessage = '';
 
     static get styles(): CSSResult[] {
@@ -26,22 +27,30 @@ export class VlFormMessageComponent extends BaseLitElement {
             preLine: { type: Boolean, attribute: 'pre-line' },
             for: { type: String },
             state: { type: String },
+            variant: { type: String },
             validationMessage: { type: String, attribute: 'validation-message' },
         };
     }
 
     render(): TemplateResult {
+        // Success-styling via de expliciete variant of, voor de auto-success lifecycle, via state="valid".
+        const isSuccess = this.variant === 'success' || this.state === 'valid';
+        const isAnnotation = this.variant === 'annotation';
         const classes = {
-            'vl-form__error': true,
+            'vl-form__success': isSuccess,
+            'vl-form__annotation': isAnnotation,
+            // Error is de default-stijl: alles wat geen success of annotation is.
+            'vl-form__error': !isSuccess && !isAnnotation,
             'vl-pre-line': this.preLine,
         };
         // The wrapper is the live region: kept in the a11y tree at all times so that
         // when the inner <p> becomes visible (hidden removed + slot text), screen
         // readers announce the new content. aria-live="polite" waits for an idle
         // moment; aria-atomic ensures the full message is read on each change.
+        // Annotation-messages zijn louter informatief en worden altijd getoond, los van de validatielogica.
         return html`
             <div role="status" aria-live="polite" aria-atomic="true">
-                <p class=${classMap(classes)} part="text" ?hidden=${!this.show}>
+                <p class=${classMap(classes)} part="text" ?hidden=${!this.show && !isAnnotation}>
                     <slot>${this.validationMessage}</slot>
                 </p>
             </div>

--- a/libs/components/src/form/form-message/vl-form-message.defaults.ts
+++ b/libs/components/src/form/form-message/vl-form-message.defaults.ts
@@ -1,6 +1,9 @@
+export type FormMessageVariant = 'error' | 'success' | 'annotation';
+
 export const formMessageDefaults = {
     show: false as boolean,
     preLine: false as boolean,
     for: null as string | null,
     state: null as keyof ValidityState | null,
+    variant: 'error' as FormMessageVariant,
 } as const;

--- a/libs/components/src/form/input-field/vl-input-field.component.cy.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.cy.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { registerWebComponents } from '@domg-wc/common';
 import { VlInputFieldComponent } from './vl-input-field.component';
 import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
@@ -306,5 +306,72 @@ describe('cypress-component - form components - vl-input-field', () => {
             cy.get('vl-input-field').shadow().find('input').focus().blur();
             cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
         });
+    });
+});
+
+describe('cypress-component - form components - vl-input-field - success message', () => {
+    // De aanwezigheid van een vl-form-message met state="valid" is de opt-in voor de auto-success.
+    const mountInForm = (withSuccessMessage = true) =>
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-input-field id="naam" name="naam" required min-length="4"> </vl-input-field>
+                <vl-form-message for="naam" state="valueMissing">Verplicht veld.</vl-form-message>
+                ${withSuccessMessage
+                    ? html`<vl-form-message for="naam" state="valid">Correct ingevuld.</vl-form-message>`
+                    : nothing}
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+    it('should not show the success message before a first validation', () => {
+        mountInForm();
+
+        cy.get('vl-input-field').shadow().find('input').type('test');
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+    });
+
+    it('should show the success message once valid after a validation', () => {
+        mountInForm();
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+
+        cy.get('vl-input-field').shadow().find('input').type('test');
+        cy.get('vl-form-message[state="valid"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+        cy.get('vl-input-field').shadow().find('input').should('have.attr', 'aria-description', 'Correct ingevuld.');
+    });
+
+    it('should show the success message on a clean valid submit without a prior error', () => {
+        mountInForm();
+
+        // Eerst geldig invullen: nog geen success, want er was nog geen validatiecyclus.
+        cy.get('vl-input-field').shadow().find('input').type('test');
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+
+        // De submit is de eerste validatiecyclus; het veld is meteen geldig -> success.
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valid"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+    });
+
+    it('should hide the success message again when the field becomes invalid', () => {
+        mountInForm();
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-input-field').shadow().find('input').type('test');
+        cy.get('vl-form-message[state="valid"]').should('have.attr', 'show');
+
+        cy.get('vl-input-field').shadow().find('input').clear();
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+    });
+
+    it('should not show a success message when no valid-message is present', () => {
+        mountInForm(false);
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-input-field').shadow().find('input').type('test');
+        cy.get('vl-form-message[state="valid"]').should('not.exist');
     });
 });

--- a/libs/components/src/form/radio-group/vl-radio-group.component.cy.ts
+++ b/libs/components/src/form/radio-group/vl-radio-group.component.cy.ts
@@ -411,6 +411,24 @@ describe('vl-radio-group - events', () => {
             .should('deep.equal', { checked: true, value });
     });
 
+    it('should dispatch vl-valid event when a radio is checked', () => {
+        cy.mount(html`
+            <vl-radio-group id="land-zee" name="land-zee" required>
+                <vl-radio value="land">Land</vl-radio>
+                <vl-radio value="zee">Zee</vl-radio>
+                <vl-radio value="lucht">Lucht</vl-radio>
+            </vl-radio-group>
+        `);
+
+        cy.createStubForEvent('vl-radio-group', 'vl-valid');
+        clickRadioWithValue('land');
+
+        cy.get('@vl-valid')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail')
+            .should('deep.equal', { value: 'land' });
+    });
+
     it('should only dispatch vl-change but not vl-input event on checking programmatically', () => {
         cy.mount(html`
             <vl-radio-group id="land-zee" name="land-zee">
@@ -450,6 +468,29 @@ describe('vl-radio-group - in form', () => {
         cy.get('vl-radio-group').find('vl-radio[value="zee"]').should('have.attr', 'checked');
         cy.get('vl-radio-group').find('vl-radio[value="land"]').should('not.have.attr', 'checked');
         cy.get('vl-radio-group').find('vl-radio[value="lucht"]').should('not.have.attr', 'checked');
+    });
+
+    it('should show the success message once a radio is checked after a validation error', () => {
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-radio-group id="land-zee" name="land-zee" required>
+                    <vl-radio value="land">Land</vl-radio>
+                    <vl-radio value="zee">Zee</vl-radio>
+                    <vl-radio value="lucht">Lucht</vl-radio>
+                </vl-radio-group>
+                <vl-form-message for="land-zee" state="valueMissing">Maak een keuze.</vl-form-message>
+                <vl-form-message for="land-zee" state="valid">Geldige keuze.</vl-form-message>
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+
+        clickRadioWithValue('zee');
+        cy.get('vl-form-message[state="valid"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 
     it('should reset to null when the form is reset with no value', () => {

--- a/libs/components/src/form/radio-group/vl-radio-group.component.ts
+++ b/libs/components/src/form/radio-group/vl-radio-group.component.ts
@@ -37,6 +37,7 @@ export class VlRadioGroupComponent extends FormControl {
 
         this.addEventListener('vl-change', this.updateGroupAfterCheck);
         this.addEventListener('keydown', this.handleKeyDown);
+        this.addEventListener('vl-valid', this.suppressChildValid);
     }
 
     updated(changedProperties: Map<string, unknown>) {
@@ -45,6 +46,7 @@ export class VlRadioGroupComponent extends FormControl {
         if (changedProperties.has('value')) {
             this.setValue(this.value);
             this.checkRadioForValue(this.value);
+            this.dispatchEventIfValid({ value: this.value });
         }
 
         if (changedProperties.has('name')) {
@@ -89,7 +91,14 @@ export class VlRadioGroupComponent extends FormControl {
         super.disconnectedCallback();
 
         this.removeEventListener('vl-change', this.updateGroupAfterCheck);
+        this.removeEventListener('vl-valid', this.suppressChildValid);
     }
+
+    private suppressChildValid = (event: Event) => {
+        if (event.target !== this) {
+            event.stopImmediatePropagation();
+        }
+    };
 
     render(): TemplateResult {
         return html`

--- a/libs/components/src/form/upload/vl-upload.component.cy.ts
+++ b/libs/components/src/form/upload/vl-upload.component.cy.ts
@@ -339,6 +339,25 @@ describe('vl-upload - events', () => {
         cy.get('@vl-input').its('callCount').should('eq', 0);
     });
 
+    it('should show the success message once a valid file is added after a validation error', () => {
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-upload id="foto" name="foto" required></vl-upload>
+                <vl-form-message for="foto" state="valueMissing">Kies een bestand.</vl-form-message>
+                <vl-form-message for="foto" state="valid">Geldig bestand.</vl-form-message>
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valid"]').should('not.have.attr', 'show');
+
+        shouldAddPdfFiles(1);
+        cy.get('vl-form-message[state="valid"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+    });
+
     it('should dispatch vl-change events when removing a file', () => {
         cy.mount(html` <vl-upload max-files="4"></vl-upload>`);
 

--- a/libs/components/src/form/upload/vl-upload.component.ts
+++ b/libs/components/src/form/upload/vl-upload.component.ts
@@ -120,6 +120,7 @@ export class VlUploadComponent extends FormControl {
 
         if (changedProperties.has('value')) {
             this.setValue(this.value);
+            this.dispatchEventIfValid({ value: this.value });
         }
 
         if (changedProperties.has('dropzoneInstance')) {
@@ -575,13 +576,14 @@ export class VlUploadComponent extends FormControl {
     }
 
     private updateValue(detail: { type: string; file?: DropzoneFile; value: FormValue }) {
+        // Het zetten van this.value triggert updated(), waar setValue en (na hideFormMessages) de
+        // vl-valid dispatch gebeuren. Zo blijft een gekoppelde state="valid" success-boodschap zichtbaar.
         this.value = this.collectFormData();
         this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
         if (this.dispatchInput) {
             this.dispatchEvent(new CustomEvent('vl-input', { composed: true, bubbles: true, detail }));
             this.dispatchInput = false;
         }
-        this.dispatchEventIfValid(detail);
     }
 
     /**

--- a/libs/integrations/src/form/demo/vl-form-demo.component.ts
+++ b/libs/integrations/src/form/demo/vl-form-demo.component.ts
@@ -120,6 +120,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="naam" state="valueMissing"
                             >Gelieve een naam in te vullen.
                         </vl-form-message>
+                        <vl-form-message for="naam" state="valid"> Deze naam is geldig. </vl-form-message>
                         <vl-form-message for="naam" state="tooShort"
                             >Gelieve minimum 2 karakters te gebruiken.
                         </vl-form-message>
@@ -142,12 +143,16 @@ export class VlFormDemoComponent extends LitElement {
                             mask="rrn"
                             placeholder="bv. 86-12-31-123-45"
                         ></vl-input-field-masked>
+                        <vl-form-message for="rrn" variant="annotation">
+                            Een rijksregisternummer heeft het formaat yy-dd-mm-xyz-cn
+                        </vl-form-message>
                         <vl-form-message for="rrn" state="valueMissing"
                             >Gelieve een rijksregisternummer in te vullen.</vl-form-message
                         >
                         <vl-form-message for="rrn" state="patternMismatch"
                             >Gelieve een geldig rijksregisternummer in te vullen.</vl-form-message
                         >
+                        <vl-form-message for="rrn" state="valid">Dit rijksregisternummer is geldig. </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="geboortedatum" label="Geboortedatum *" block></vl-form-label>
@@ -164,6 +169,9 @@ export class VlFormDemoComponent extends LitElement {
                         </vl-datepicker>
                         <vl-form-message for="geboortedatum" state="valueMissing">
                             Gelieve een geboortedatum in te vullen.
+                        </vl-form-message>
+                        <vl-form-message for="geboortedatum" state="valid">
+                            Deze geboortedatum is geldig.
                         </vl-form-message>
                         <vl-form-message for="geboortedatum" state="patternMismatch">
                             Gelieve het volgende datum formaat te gebruiken: "dd.mm.YYYY", bv. 01.12.1976 of 1.2.1993
@@ -188,6 +196,9 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="geboorteplaats" state="valueMissing"
                             >Gelieve een geboorteplaats te selecteren.
                         </vl-form-message>
+                        <vl-form-message for="geboorteplaats" state="valid"
+                            >Deze geboorteplaats is geldig.
+                        </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="hobbies" label="Hobbies *" block></vl-form-label>
@@ -207,6 +218,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="hobbies" state="valueMissing"
                             >Gelieve een hobby te selecteren.
                         </vl-form-message>
+                        <vl-form-message for="hobbies" state="valid">Deze hobbyselectie is geldig. </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="kinderen" label="Aantal kinderen *" block></vl-form-label>
@@ -223,6 +235,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="kinderen" state="valueMissing"
                             >Gelieve een aantal kinderen te kiezen.
                         </vl-form-message>
+                        <vl-form-message for="kinderen" state="valid">Dit aantal kinderen is geldig. </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="interesses" label="Interesses *" block></vl-form-label>
@@ -241,6 +254,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="interesses" state="valueMissing"
                             >Gelieve je interesses in te vullen.
                         </vl-form-message>
+                        <vl-form-message for="interesses" state="valid">Deze interesses zijn geldig. </vl-form-message>
                         <vl-form-message for="interesses" state="tooShort"
                             >Gelieve minimum 5 karakters te gebruiken.
                         </vl-form-message>
@@ -265,6 +279,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="leeftijd" state="valueMissing"
                             >Gelieve een leeftijd in te vullen.
                         </vl-form-message>
+                        <vl-form-message for="leeftijd" state="valid">Deze leeftijd is geldig. </vl-form-message>
                         <vl-form-message for="leeftijd" state="rangeUnderflow"
                             >De minimum leeftijd is 0 jaar.
                         </vl-form-message>
@@ -284,6 +299,9 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="contactmethode" state="valueMissing">
                             Gelieve een contactmethode te selecteren.
                         </vl-form-message>
+                        <vl-form-message for="contactmethode" state="valid">
+                            Deze contactmethode is geldig.
+                        </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="foto" label="Pasfoto *" block></vl-form-label>
@@ -299,6 +317,7 @@ export class VlFormDemoComponent extends LitElement {
                         <vl-form-message for="foto" state="valueMissing">
                             Gelieve een foto te selecteren.
                         </vl-form-message>
+                        <vl-form-message for="foto" state="valid"> Deze foto is geldig. </vl-form-message>
                     </div>
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="waarheidsgetrouw" label="Waarheidsgetrouw *" block></vl-form-label>
@@ -309,6 +328,9 @@ export class VlFormDemoComponent extends LitElement {
                         </vl-checkbox>
                         <vl-form-message for="waarheidsgetrouw" state="valueMissing">
                             Gelieve te bevestigen dat bovenstaande gegevens naar waarheid zijn ingevuld.
+                        </vl-form-message>
+                        <vl-form-message for="waarheidsgetrouw" state="valid">
+                            Bedankt voor het bevestigen.
                         </vl-form-message>
                     </div>
                     <vl-fieldset horizontal class="vl-column vl-column--12">
@@ -333,8 +355,14 @@ export class VlFormDemoComponent extends LitElement {
                             <vl-form-message for="gerelateerd-1" state="valueMissing"
                                 >Gelieve een waarde in te vullen voor "Gerelateerd veld 1".
                             </vl-form-message>
+                            <vl-form-message for="gerelateerd-1" state="valid"
+                                >"Gerelateerd veld 1" is geldig.
+                            </vl-form-message>
                             <vl-form-message for="gerelateerd-2" state="valueMissing"
                                 >Gelieve een waarde in te vullen voor "Gerelateerd veld 2".
+                            </vl-form-message>
+                            <vl-form-message for="gerelateerd-2" state="valid"
+                                >"Gerelateerd veld 2" is geldig.
                             </vl-form-message>
                         </div>
                     </vl-fieldset>


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-223
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC347

## Samenvatting
`vl-form-message` kan voortaan naast een foutmelding ook een success- en een annotation-boodschap tonen, en een form-control kan een gekoppelde success-boodschap automatisch laten verschijnen zodra het veld geldig is na
validatie.

## Backwards compatibility
Volledig backwards-compatible - geen breaking changes.