### PR TITLE
feat: FLUX-172 - iconen via glyph-naam i.p.v. hard-coded codepoints

### DIFF
--- a/libs/components/src/block/pill/vl-pill.component.ts
+++ b/libs/components/src/block/pill/vl-pill.component.ts
@@ -5,6 +5,7 @@ import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { createRef, ref } from 'lit/directives/ref.js';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { vlPillFluxStyles } from './vl-pill.flux-css';
 import { TYPE } from './vl-pill.model';
 
@@ -29,7 +30,7 @@ export class VlPillComponent extends BaseLitElement {
     }
 
     static get styles() {
-        return [vlResetStyles, vlPillFluxStyles, vlAccessibilityStyles];
+        return [vlResetStyles, vlIconStyles, vlPillFluxStyles, vlAccessibilityStyles];
     }
 
     static get properties() {
@@ -125,7 +126,7 @@ export class VlPillComponent extends BaseLitElement {
             <div class="${classMap(closableClasses)}" aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}>
                 <slot></slot>
                 <button
-                    class="vl-pill__close"
+                    class="vl-pill__close vl-icon vl-icon--cross"
                     type="button"
                     ?disabled=${this.disabled}
                     @click=${() => this.dispatchEvent(new CustomEvent('close'))}
@@ -168,7 +169,7 @@ export class VlPillComponent extends BaseLitElement {
                         );
                     }}
                 />
-                <span aria-hidden="true"></span>
+                <span class="vl-icon vl-icon--check" aria-hidden="true"></span>
                 <slot></slot>
             </label>
         `;

--- a/libs/components/src/block/pill/vl-pill.flux-css.ts
+++ b/libs/components/src/block/pill/vl-pill.flux-css.ts
@@ -75,10 +75,10 @@ export const vlPillFluxStyles: CSSResult = css`
             padding-right: 0;
 
             .vl-pill__close {
-                font-family: 'vlaanderen-icon' !important;
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
+                font-size: 1.3rem;
                 color: var(--vl-pill--text-color);
                 width: 2.4rem;
                 height: 2.4rem;
@@ -95,10 +95,6 @@ export const vlPillFluxStyles: CSSResult = css`
                 margin-right: -0.1rem;
                 margin-bottom: -0.1rem;
                 min-width: 2.4rem;
-
-                &::before {
-                    content: '\\f181';
-                }
             }
 
             &:not(.vl-pill--disabled) .vl-pill__close {
@@ -217,20 +213,7 @@ export const vlPillFluxStyles: CSSResult = css`
                     top: -0.1rem;
                     border: 0.1rem solid var(--vl-pill--border-color);
 
-                    &::before,
-                    &::after {
-                        font-family: 'vlaanderen-icon' !important;
-                        -webkit-font-smoothing: antialiased;
-                        -moz-osx-font-smoothing: grayscale;
-                        font-style: normal;
-                        font-variant: normal;
-                        font-weight: normal;
-                        text-decoration: none;
-                        text-transform: none;
-                    }
-
                     &::before {
-                        content: '\\f15c';
                         position: absolute;
                         display: block;
                         font-size: 0.8rem;

--- a/libs/components/src/block/side-navigation/vl-side-navigation.css.ts
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.css.ts
@@ -96,28 +96,13 @@ export const vlSideNavigationStyles: CSSResult = css`
         cursor: pointer;
     }
 
-    .js-vl-scrollspy__content .js-vl-scrollspy__toggle::before,
-    .js-vl-scrollspy__content .js-vl-scrollspy__toggle::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-    }
-
-    .js-vl-scrollspy__content .js-vl-scrollspy__toggle::before {
-        content: '\\f13f';
-    }
-
     .js-vl-scrollspy__content .js-vl-scrollspy__toggle::before {
         position: absolute;
         top: 50%;
         right: 1rem;
         transform: translateY(-50%);
         color: #fff;
+        font-family: var(--vl-icon-font, 'vlaanderen-icon');
         font-size: 1.1rem;
     }
 
@@ -346,21 +331,8 @@ export const vlSideNavigationStyles: CSSResult = css`
         cursor: pointer;
         z-index: 5;
     }
-    .js-vl-scrollspy__close::before,
-    .js-vl-scrollspy__close::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-    }
     .js-vl-scrollspy__close::before {
-        content: '\\f181';
-    }
-    .js-vl-scrollspy__close::before {
+        font-family: var(--vl-icon-font, 'vlaanderen-icon');
         font-size: 1.2rem;
         line-height: 2.6rem;
     }

--- a/libs/components/src/block/side-navigation/vl-side-navigation.scrollspy.lib.js
+++ b/libs/components/src/block/side-navigation/vl-side-navigation.scrollspy.lib.js
@@ -69,6 +69,7 @@ const _scrollSpyMobile = (elements, wrapper, contentWrapper) => {
         closeButton.innerHTML = 'Navigatie sluiten';
 
         vl.util.addClass(closeButton, ssCloseClass);
+        vl.util.addClass(closeButton, `vl-icon--cross`);
         placeholder.insertBefore(closeButton, placeholder.firstChild);
 
         // Generate toggle button
@@ -90,6 +91,7 @@ const _scrollSpyMobile = (elements, wrapper, contentWrapper) => {
             openButton.innerHTML = scrollSpyBtnLabel || 'Navigatie';
 
             vl.util.addClass(openButton, ssToggleClass);
+            vl.util.addClass(openButton, `vl-icon--burger-alt`);
             vl.util.addClass(openButton, `vl-button`);
             vl.util.addClass(openButton, `vl-button--block`);
             contentWrapper.appendChild(openButton);

--- a/libs/components/src/block/tabs/vl-tabs.component.ts
+++ b/libs/components/src/block/tabs/vl-tabs.component.ts
@@ -15,6 +15,7 @@ import { CSSResult, html, PropertyDeclarations, PropertyValues, TemplateResult }
 import { VlTabSectionComponent } from './vl-tab-section.component';
 import { VlTabComponent } from './vl-tab.component';
 import { VlTabsPaneComponent } from './vl-tabs-pane.component';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { tabsStyle } from './vl-tabs.css';
 import { vlTabsFluxStyles } from './vl-tabs.flux-css';
 
@@ -98,7 +99,7 @@ export class VlTabsComponent extends BaseLitElement {
     }
 
     static get styles(): CSSResult[] {
-        return [resetStyle, tabsStyle, vlTabsFluxStyles, linkStyle, baseStyle, ...vlLegacyStyles ];
+        return [resetStyle, vlIconStyles, tabsStyle, vlTabsFluxStyles, linkStyle, baseStyle, ...vlLegacyStyles ];
     }
 
     render(): TemplateResult {
@@ -106,7 +107,7 @@ export class VlTabsComponent extends BaseLitElement {
             <div id="tabs" tabs tabs-responsive-label="Navigatie">
                 <div id="tabs-wrapper" class="vl-tabs__wrapper">
                     <ul id="tab-list" class="vl-tabs" tabs-list role="tablist" aria-label="tabs"></ul>
-                    <button type="button" tabs-toggle class="vl-tabs__toggle" close="false">
+                    <button type="button" tabs-toggle class="vl-tabs__toggle vl-icon vl-icon--arrow" close="false">
                         <span id="tabs-responsive-label">Navigatie</span>
                     </button>
                 </div>

--- a/libs/components/src/block/tabs/vl-tabs.css.ts
+++ b/libs/components/src/block/tabs/vl-tabs.css.ts
@@ -12,56 +12,6 @@ export const tabsStyle: CSSResult = css`
         --vl-theme-fg-color-70: #707070;
     }
 
-    .vl-vi::before,
-    .vl-vi::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-        display: inline-block;
-        vertical-align: middle;
-    }
-
-    .vl-vi.vl-vi-u-180deg::before {
-        display: inline-block;
-        transform: rotate(180deg);
-        vertical-align: middle;
-    }
-
-    .vl-vi-u-xs::before {
-        font-size: 0.8rem;
-    }
-
-    .vl-vi-u-s::before {
-        font-size: 1.3rem;
-    }
-
-    .vl-vi-u-m::before {
-        font-size: 1.7rem;
-    }
-
-    .vl-vi-u-l::before {
-        font-size: 2rem;
-    }
-
-    .vl-vi-u-xl::before {
-        font-size: 2.2rem;
-    }
-
-    .vl-vi-u-90deg::before {
-        display: inline-block;
-        transform: rotate(90deg);
-    }
-
-    .vl-vi-u-180deg::before {
-        display: inline-block;
-        transform: rotate(180deg);
-    }
-
     .vl-tabs {
         margin-bottom: 3rem;
         border-bottom: 1px #cbd2da solid;
@@ -294,24 +244,9 @@ export const tabsStyle: CSSResult = css`
         color: #05c;
     }
 
-    .vl-tabs__toggle::before,
-    .vl-tabs__toggle::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-    }
-
-    .vl-tabs__toggle::before {
-        content: '\\f126';
-    }
-
     .vl-tabs__toggle::before {
         position: absolute;
+        font-family: var(--vl-icon-font);
         font-size: 1.4rem;
     }
 
@@ -368,10 +303,6 @@ export const tabsStyle: CSSResult = css`
 
     .vl-tabs__toggle[close='true']::after {
         display: none;
-    }
-
-    .vl-tabs__toggle[close='true']::before {
-        content: '\\f181';
     }
 
     .vl-tabs__toggle[close='true']::before {

--- a/libs/components/src/block/tabs/vl-tabs.lib.js
+++ b/libs/components/src/block/tabs/vl-tabs.lib.js
@@ -74,6 +74,8 @@ class TabsNext {
             tabsList.setAttribute('aria-hidden', isListOpen ? 'true' : 'false');
             toggleBtnEl.setAttribute('aria-expanded', isListOpen ? 'true' : 'false');
             toggleBtnEl.setAttribute(tabCloseAtt, isListOpen ? 'false' : 'true');
+            toggleBtnEl.classList.toggle('vl-icon--cross', !isListOpen);
+            toggleBtnEl.classList.toggle('vl-icon--arrow', isListOpen);
         }
     }
 

--- a/libs/components/src/form/checkbox/vl-checkbox.component.css.ts
+++ b/libs/components/src/form/checkbox/vl-checkbox.component.css.ts
@@ -11,24 +11,6 @@ export const vlCheckboxComponentStyles: CSSResult = css`
     }
 
     /* ===================================================================
-       Shared Icon Styles (for both checkbox and switch)
-       =================================================================== */
-
-    .vl-checkbox__box::before,
-    .vl-checkbox__box::after,
-    .vl-checkbox--switch__label span::before,
-    .vl-checkbox--switch__label span::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-    }
-
-    /* ===================================================================
        Visually Hidden Input (for both checkbox and switch)
        =================================================================== */
 
@@ -141,16 +123,9 @@ export const vlCheckboxComponentStyles: CSSResult = css`
         }
     }
 
-    /* Checked state */
-
-    .vl-checkbox__toggle:checked + .vl-checkbox__label .vl-checkbox__box::before {
-        content: '\\f15c';
-    }
-
     /* Indeterminate state */
 
     .vl-checkbox__toggle:indeterminate + .vl-checkbox__label .vl-checkbox__box::before {
-        content: '\\f20e';
         font-size: var(--vl-checkbox--icon-size);
         font-weight: bold;
     }
@@ -306,7 +281,7 @@ export const vlCheckboxComponentStyles: CSSResult = css`
         display: block;
         margin: 0.3rem 0 0 0.3rem;
         font-size: var(--vl-checkbox--icon-size);
-        content: '\\f15c';
+        line-height: 1rem;
         opacity: 0;
         visibility: hidden;
         transform: translate(0.4rem, 0.4rem) scale(0.6);

--- a/libs/components/src/form/checkbox/vl-checkbox.component.ts
+++ b/libs/components/src/form/checkbox/vl-checkbox.component.ts
@@ -2,6 +2,7 @@ import { webComponent } from '@domg-wc/common';
 import { vlResetStyles } from '@domg-wc/styles';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { FormControl } from '../form-control';
 import { vlCheckboxComponentStyles } from './vl-checkbox.component.css';
 import { checkboxDefaults } from './vl-checkbox.defaults';
@@ -23,7 +24,7 @@ export class VlCheckboxComponent extends FormControl {
     private dispatchInput = false;
 
     static get styles(): CSSResult[] {
-        return [vlResetStyles, vlCheckboxComponentStyles];
+        return [vlResetStyles, vlIconStyles, vlCheckboxComponentStyles];
     }
 
     static get properties(): PropertyDeclarations {
@@ -117,7 +118,15 @@ export class VlCheckboxComponent extends FormControl {
                     @click=${this.toggle}
                 />
                 <div class="vl-checkbox__label">
-                    <i class="vl-checkbox__box" aria-hidden="true"></i>
+                    <i
+                        class=${classMap({
+                            'vl-checkbox__box': true,
+                            'vl-icon': true,
+                            'vl-icon--check': this.checked,
+                            'vl-icon--minus': this.indeterminate && !this.checked,
+                        })}
+                        aria-hidden="true"
+                    ></i>
                     <span>
                         <slot></slot>
                     </span>
@@ -152,7 +161,7 @@ export class VlCheckboxComponent extends FormControl {
                 />
                 <label for=${this.id} class="vl-checkbox__label">
                     <span class="vl-checkbox--switch__label">
-                        <span aria-hidden="true"></span>
+                        <span class="vl-icon vl-icon--check" aria-hidden="true"></span>
                     </span>
                     <span>
                         <slot></slot>

--- a/libs/components/src/form/datepicker/vl-datepicker.component.css.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.css.ts
@@ -26,24 +26,6 @@ export const vlDatepickerComponentStyles: CSSResult = css`
         cursor: pointer;
     }
 
-    /* ===================================================================
-       Icon Font Base
-       =================================================================== */
-
-    .vl-vi::before,
-    .vl-vi::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-        display: inline-block;
-        vertical-align: middle;
-    }
-
     .vl-vi.vl-vi-u-180deg::before {
         display: inline-block;
         transform: rotate(180deg);
@@ -78,18 +60,6 @@ export const vlDatepickerComponentStyles: CSSResult = css`
     .vl-vi-u-180deg::before {
         display: inline-block;
         transform: rotate(180deg);
-    }
-
-    /* ===================================================================
-       Icon Definitions
-       =================================================================== */
-
-    .vl-vi-calendar::before {
-        content: '\\f14b';
-    }
-
-    .vl-vi-clock::before {
-        content: '\\f15e';
     }
 
     /* ===================================================================

--- a/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.cy.ts
@@ -2325,7 +2325,7 @@ describe('vl-datepicker - interaction', () => {
         cy.mount(html`<vl-datepicker type="date" label="date"></vl-datepicker>`);
         cy.injectAxe();
 
-        cy.get('vl-datepicker').shadow().find('button .vl-vi-calendar').should('exist');
+        cy.get('vl-datepicker').shadow().find('button .vl-icon--calendar').should('exist');
         cy.checkA11y('vl-datepicker');
     });
 
@@ -2333,7 +2333,7 @@ describe('vl-datepicker - interaction', () => {
         cy.mount(html`<vl-datepicker type="time" label="time"></vl-datepicker>`);
         cy.injectAxe();
 
-        cy.get('vl-datepicker').shadow().find('button .vl-vi-clock').should('exist');
+        cy.get('vl-datepicker').shadow().find('button .vl-icon--clock').should('exist');
         cy.checkA11y('vl-datepicker');
     });
 

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -9,6 +9,7 @@ import { CSSResult, html, nothing, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { vlInputAddonStyles } from '../../atom/button';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { FormControl } from '../form-control';
 import { inputFieldStyles } from '../input-field';
 import { CleaveInstance, MaskOptions } from '../models/cleave.model';
@@ -66,6 +67,7 @@ export class VlDatepickerComponent extends FormControl {
     static get styles(): CSSResult[] {
         return [
             vlResetStyles,
+            vlIconStyles,
             inputFieldStyles,
             vlDatepickerComponentStyles,
             vlDatepickerPositioningStyles,
@@ -276,7 +278,7 @@ export class VlDatepickerComponent extends FormControl {
                     @click=${this.toggleCalendar}
                 >
                     <span
-                        class="vl-icon vl-icon--small vl-vi vl-vi-${this.type === 'time' ? 'clock' : 'calendar'}"
+                        class="vl-icon vl-icon--small vl-vi vl-icon--${this.type === 'time' ? 'clock' : 'calendar'}"
                         aria-hidden="true"
                     ></span>
                 </button>

--- a/libs/components/src/form/select-rich/vl-select-rich.component.css.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.css.ts
@@ -11,32 +11,6 @@ export const vlSelectRichComponentStyles: CSSResult = css`
     }
 
     /* ===================================================================
-       Icon Font Base
-       =================================================================== */
-
-    .vl-vi::before,
-    .vl-vi::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-        display: inline-block;
-        vertical-align: middle;
-    }
-
-    .vl-vi-nav-down::before {
-        content: '\\f21a';
-    }
-
-    .vl-vi-close::before {
-        content: '\\f162';
-    }
-
-    /* ===================================================================
        Choices.js Container (Outer)
        =================================================================== */
 
@@ -70,7 +44,13 @@ export const vlSelectRichComponentStyles: CSSResult = css`
        Nav-Down Icon
        =================================================================== */
 
-    .js-vl-select.vl-vi.vl-vi-nav-down:before {
+    /* De nav-down pijl staat op de combobox-container via ::before. We gebruiken
+       enkel .vl-icon--nav-down (codepoint uit de gedeelde icon-mapping, FLUX-172),
+       niet de .vl-icon basis-class: die zet display/font-family/font-size op het
+       element zelf, wat in de dropdown-kinderen zou lekken. Het icon-font zetten we
+       daarom hier rechtstreeks op de pseudo. */
+    .js-vl-select.vl-icon--nav-down:before {
+        font-family: var(--vl-icon-font);
         color: var(--vl-select-rich--nav-icon-color);
         position: absolute;
         right: 1.3rem;
@@ -250,6 +230,13 @@ export const vlSelectRichComponentStyles: CSSResult = css`
         margin-left: auto;
     }
 
+    /* Vroeger erfde dit kruisje de UA-default button-grootte (~1.3rem). Sinds de
+       .vl-icon class (FLUX-172) zet font-size: 1em die op de oudergrootte (1.6rem),
+       waardoor het kruisje groter werd. Expliciet terugzetten op de oude grootte. */
+    .js-vl-select[data-type*='select-one'] .vl-pill__close.vl-icon--close::before {
+        font-size: 1.3rem;
+    }
+
     .js-vl-select[data-type='select-one'] .vl-select__inner .vl-pill__close {
         margin: 0.1rem 0 0 auto;
         border-radius: 0.3rem;
@@ -329,6 +316,12 @@ export const vlSelectRichComponentStyles: CSSResult = css`
     .js-vl-select .vl-select__list--multiple .vl-select__item {
         margin: 0.2rem 0.6rem 0.5rem 0;
         display: inline-flex;
+        /* De algemene .vl-select__item regel forceert height: 2.3rem; voor een pill
+           is dat 0.1rem te laag t.o.v. de close-button (2.4rem + negatieve marges),
+           waardoor de onderrand onder het kruisje dubbel/verschoven oogt. De pill
+           zijn natuurlijke hoogte (line-height + randen = 2.4rem) teruggeven. */
+        height: auto;
+        min-height: 0;
     }
 
     .js-vl-select .vl-select__list--multiple .vl-select__item[data-deletable] {

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -4,6 +4,7 @@ import { FormValue } from '@open-wc/form-control/src/types';
 import Choices, { Options } from 'choices.js';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { FormControl } from '../form-control';
 import { vlSelectRichComponentStyles } from './vl-select-rich.component.css';
 import { selectRichDefaults } from './vl-select-rich.defaults';
@@ -44,7 +45,7 @@ export class VlSelectRichComponent extends FormControl {
     }
 
     static get styles(): CSSResult[] {
-        return [vlResetStyles, vlSelectRichComponentStyles];
+        return [vlResetStyles, vlIconStyles, vlSelectRichComponentStyles];
     }
 
     static get properties(): PropertyDeclarations {
@@ -434,7 +435,7 @@ export class VlSelectRichComponent extends FormControl {
                         return template(
                             `
                             <div
-                                class="js-vl-select vl-vi vl-vi-nav-down"
+                                class="js-vl-select vl-icon--nav-down"
                                 data-type="${this.multiple ? 'select-multiple' : 'select-one'}"
                                 ${this.search ? 'aria-autocomplete="list"' : ''}
                                 part="vl-select-rich__combobox"
@@ -486,11 +487,11 @@ export class VlSelectRichComponent extends FormControl {
                                     <button type="button"
                                     ${isPlaceholder ? '' : 'role="option"'}
                                      class="vl-pill__close ${
-                                         !this.multiple ? 'vl-vi vl-vi-close' : ''
+                                         !this.multiple ? 'vl-icon vl-icon--close' : ''
                                      }" data-button aria-label="verwijder ${data.label}">
                                         ${
                                             this.multiple
-                                                ? `<span class="vl-pill__close__icon vl-vi vl-vi-close" aria-hidden="true"></span>`
+                                                ? `<span class="vl-pill__close__icon vl-icon vl-icon--close" aria-hidden="true"></span>`
                                                 : ''
                                         }
                                     </button>

--- a/libs/components/src/form/select/vl-select.component.css.ts
+++ b/libs/components/src/form/select/vl-select.component.css.ts
@@ -11,32 +11,6 @@ export const vlSelectComponentStyles: CSSResult = css`
     }
 
     /* ===================================================================
-       Icon Font Base
-       =================================================================== */
-
-    .vl-vi::before,
-    .vl-vi::after {
-        font-family: 'vlaanderen-icon' !important;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-style: normal;
-        font-variant: normal;
-        font-weight: normal;
-        text-decoration: none;
-        text-transform: none;
-        display: inline-block;
-        vertical-align: middle;
-    }
-
-    .vl-vi-nav-down::before {
-        content: '\\f21a';
-    }
-
-    .vl-vi-close::before {
-        content: '\\f162';
-    }
-
-    /* ===================================================================
        Select Container
        =================================================================== */
 
@@ -230,12 +204,12 @@ export const vlSelectComponentStyles: CSSResult = css`
        Nav-Down Icon
        =================================================================== */
 
-    .vl-vi.vl-vi-nav-down:before {
+    .vl-icon.vl-icon--nav-down:before {
         color: var(--vl-select--nav-icon-color);
         position: absolute;
         right: 1.3rem;
         font-size: 1.3rem;
-        top: 0.8rem;
+        top: 1.1rem;
         pointer-events: none;
     }
 

--- a/libs/components/src/form/select/vl-select.component.cy.ts
+++ b/libs/components/src/form/select/vl-select.component.cy.ts
@@ -165,7 +165,7 @@ describe('vl-select - properties & states', () => {
         cy.injectAxe();
 
         cy.checkA11y('vl-select');
-        cy.get('vl-select').shadow().find('button.vl-select__button span.vl-icon.vl-vi.vl-vi-close');
+        cy.get('vl-select').shadow().find('button.vl-select__button span.vl-icon.vl-icon--close');
     });
 
     it('should set not-deletable', () => {

--- a/libs/components/src/form/select/vl-select.component.ts
+++ b/libs/components/src/form/select/vl-select.component.ts
@@ -3,6 +3,7 @@ import { vlResetStyles } from '@domg-wc/styles';
 import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
+import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { FormControl } from '../form-control';
 import { vlSelectComponentStyles } from './vl-select.component.css';
 import { selectDefaults } from './vl-select.defaults';
@@ -27,7 +28,7 @@ export class VlSelectComponent extends FormControl {
     private parsedOptions: SelectOption[] = [];
 
     static get styles(): CSSResult[] {
-        return [vlResetStyles, vlSelectComponentStyles];
+        return [vlResetStyles, vlIconStyles, vlSelectComponentStyles];
     }
 
     static get properties(): PropertyDeclarations {
@@ -123,7 +124,7 @@ export class VlSelectComponent extends FormControl {
                     ${hasGroups ? this.renderGroupedOptions() : this.renderSelectOptions(this.getAllOptions())}
                 </select>
                 ${hasValue && !this.notDeletable ? this.renderClearButton() : nothing}
-                <span class="vl-icon vl-vi vl-vi-nav-down" aria-hidden="true"></span>
+                <span class="vl-icon vl-icon--nav-down" aria-hidden="true"></span>
             </div>
             <div class="slot-container">
                 <slot @slotchange=${this.onSlotChange}></slot>
@@ -145,7 +146,7 @@ export class VlSelectComponent extends FormControl {
                 aria-label=${`Verwijder ${this.label} keuze ${this.getSelectedOption()?.label || this.value || ''}`}
                 @click=${this.clearValue}
             >
-                <span class="vl-icon vl-vi vl-vi-close" aria-hidden="true"></span>
+                <span class="vl-icon vl-icon--close" aria-hidden="true"></span>
             </button>
         `;
     }


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-172
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC349

## Samenvatting
De iconen in vl-pill, vl-tabs, vl-side-navigation, vl-select(-rich), vl-checkbox en
vl-datepicker komen nu uit het gedeelde vl-icon-mechanisme i.p.v. eigen hard-coded
font-codepoints. Bij een toekomstige font-update volgen ze automatisch de juiste glyph,
zonder handmatige sync. Voor consumers verandert er niets zichtbaar.

## Wijzigingen
- Zes componenten gebruiken nu `vlIconStyles`/`vlIconMapping` en refereren iconen via
  glyph-naam (`vl-icon--cross`, `vl-icon--check`, …) i.p.v. magische codepoints.
- Gedupliceerde inline `font-family: 'vlaanderen-icon'`-blokken en hard-coded
  `content: '\fXXX'`-regels verwijderd; positionering/size ongewijzigd.
- Imperatieve glyph-wissels behouden: tabs-toggle (arrow ↔ cross) en checkbox-box
  (check ↔ minus) wisselen mee met respectievelijk het `close`-attribuut en de
  checked/indeterminate-status.
- Cypress-selectors voor vl-select en vl-datepicker meegemigreerd naar de nieuwe
  glyph-classes.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Geen hard-gecodeerde `content: '\fXXX'` / inline `font-family: 'vlaanderen-icon'` meer — alle iconen in de zes componenten via glyph-naam.
- [x] Refereren via het bestaande `vlIconStyles`/`vlIconMapping`-mechanisme — zelfde patroon als de 20+ bestaande gebruikers.
- [x] Font-versiebump werkt automatisch door — alles leunt op `vl-icon-style-mapping.css.ts`, geen lokale codepoints.
- [x] Visueel gedrag identiek — elke glyph-naam levert exact dezelfde codepoint als de verwijderde hard-code; positionering behouden.
- [x] Bestaande publieke API blijft backwards-compatible — puur additief, geen attribute/property/event/slot-wijziging.
