### PR TITLE
feat: FLUX-673 - vl-map-wfs-layer - cql-filter met hybride geometry-name

### DIFF
--- a/libs/map/src/components/action/draw-action/draw-point-action/vl-map-draw-point-action.cy.ts
+++ b/libs/map/src/components/action/draw-action/draw-point-action/vl-map-draw-point-action.cy.ts
@@ -58,6 +58,29 @@ const mapDrawPointActionSnapping = html`
     </vl-map>
 `;
 
+// Een vl-map-features-layer is een VlMapVectorLayer-subclass zonder vl-map-wfs-layer-tag. Vóór de instanceof-fix werd
+// die door de tag-gebaseerde __snappingLayers genegeerd; nu hoort hij wél als snapping target opgepikt te worden.
+const mapDrawPointActionSnappingVectorSubclassFixture = html`
+    <vl-map id="map-with-draw-point-snap-action">
+        <vl-map-features-layer id="point-layer">
+            <vl-map-draw-point-action
+                id="draw-point-snap-action"
+                default-active
+                snapping
+                snapping-pixel-tolerance="1000"
+            >
+                <vl-map-features-layer id="snap-features-layer">
+                    <vl-map-layer-style
+                        color="rgba(6, 163, 247, 0.4)"
+                        border-size="4"
+                        border-color="rgba(6, 163, 247, 1)"
+                    ></vl-map-layer-style>
+                </vl-map-features-layer>
+            </vl-map-draw-point-action>
+        </vl-map-features-layer>
+    </vl-map>
+`;
+
 describe('cypress-component - map - vl-map-draw-point-action', () => {
     it('a dot draw action is a map action', () => {
         expect(VlMapDrawPointAction.isVlMapAction()).to.be.true;
@@ -101,6 +124,26 @@ describe('cypress-component - map - vl-map-draw-point-action', () => {
                         expect(drawActionOptions.snapping.layer.getSource().sources[1]).to.equal(
                             stilstaandWaterLayer._layer.getSource()
                         );
+                    });
+                });
+            }
+        );
+    });
+
+    it('snapping pikt ook een niet-wfs VlMapVectorLayer subclass op als snapping target', () => {
+        cy.mount(mapDrawPointActionSnappingVectorSubclassFixture);
+        cy.runTestFor2<VlMap, VlMapDrawPointAction>(
+            'vl-map',
+            'vl-map-draw-point-action',
+            (vlMap, vlMapDrawPointAction) => {
+                cy.wrap(vlMap.ready).then(() => {
+                    const drawActionOptions = vlMapDrawPointAction.action.options;
+                    expect(drawActionOptions.snapping.layer instanceof VlCompositeVectorLayer).to.equal(true);
+                    const snappingSources = drawActionOptions.snapping.layer.getSource().sources;
+                    // Strikt: enkel de geneste features-layer, niet de point-layer (ancestor) of andere lagen.
+                    expect(snappingSources.length).to.equal(1);
+                    cy.runTestFor<VlMapFeaturesLayer>(`#snap-features-layer`, (featuresLayer) => {
+                        expect(snappingSources[0]).to.equal(featuresLayer._layer.getSource());
                     });
                 });
             }

--- a/libs/map/src/components/action/draw-action/vl-map-draw-action.ts
+++ b/libs/map/src/components/action/draw-action/vl-map-draw-action.ts
@@ -58,6 +58,6 @@ export class VlMapDrawAction extends VlMapLayerAction {
     }
 
     get __snappingLayers(): any {
-        return Array.from(this.querySelectorAll('vl-map-wfs-layer'));
+        return Array.from(this.querySelectorAll('*')).filter((layer) => layer instanceof VlMapVectorLayer);
     }
 }

--- a/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories-arg.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories-arg.ts
@@ -4,6 +4,8 @@ import { ArgTypes } from '@storybook/web-components-vite';
 
 export const mapWfsLayerArgs = {
     ...mapLayerArgs,
+    cqlFilter: '',
+    geometryName: '',
     layers: '',
     projectionCode: '',
     url: '',
@@ -11,6 +13,36 @@ export const mapWfsLayerArgs = {
 
 export const mapWfsLayerArgTypes: ArgTypes<typeof mapWfsLayerArgs> = {
     ...mapLayerArgTypes,
+    cqlFilter: {
+        name: 'cql-filter',
+        description:
+            'Een CQL-expressie waarmee de features van de WFS-laag server-side gefilterd worden. De waarde wordt als' +
+            ' <code>cql_filter</code> query parameter naar de server gestuurd, gecombineerd met een' +
+            ' <code>BBOX</code>-clausule op de geometry-property:' +
+            ' <code>cql_filter=BBOX(geometry,extent) AND (filter)</code> in plaats van een <code>bbox</code> parameter.' +
+            ' <br><strong>Let op:</strong> <code>cql_filter</code> is een GeoServer-specifieke extensie en wordt niet' +
+            ' door elke WFS-implementatie ondersteund.<br>Dit attribuut is reactief.',
+        type: { name: TYPES.STRING, required: false },
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWfsLayerArgs.cqlFilter },
+        },
+    },
+    geometryName: {
+        name: 'geometry-name',
+        description:
+            'De naam van de geometry-property die in de CQL <code>BBOX(...)</code>-clausule gebruikt wordt. Enkel' +
+            ' relevant samen met <code>cql-filter</code>. Indien niet meegegeven wordt de geometry-property' +
+            ' best-effort gedetecteerd via een <code>DescribeFeatureType</code> call; geef dit attribuut expliciet mee' +
+            ' wanneer die auto-detectie faalt.<br>Dit attribuut is niet reactief.',
+        type: { name: TYPES.STRING, required: false },
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: mapWfsLayerArgs.geometryName },
+        },
+    },
     layers: {
         name: 'layers',
         description: 'De layers van de WFS.<br>Dit attribuut is niet reactief.',

--- a/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories-doc.mdx
+++ b/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories-doc.mdx
@@ -25,6 +25,23 @@ import { VlMapWfsLayer } from '@domg-wc/map';
 <Canvas of={VlMapWfsLayerStories.MapWfsLayerDefault} />
 
 
+## Filteren met de cql-filter
+
+Met het `cql-filter` attribuut filter je de features van de laag server-side. De waarde wordt als `cql_filter` query
+parameter naar de WFS server gestuurd, gecombineerd met een ruimtelijke `BBOX`-clausule:
+`cql_filter=BBOX(geometry,extent) AND (filter)`. Zonder `cql-filter` blijft het gedrag ongewijzigd (een gewone
+`bbox`-parameter).
+
+De `BBOX`-clausule heeft de naam van de geometry-property nodig. Geef die expliciet mee via `geometry-name`, of laat ze
+weg: dan wordt ze best-effort gedetecteerd via een `DescribeFeatureType` call. Faalt die detectie (bv. een
+niet-standaard WFS-server), dan valt de laag veilig terug op een gewone `bbox`-request en verschijnt er een
+`console.warn` - geef in dat geval `geometry-name` expliciet mee.
+
+> **Let op:** `cql_filter` is een GeoServer-specifieke extensie en wordt niet door elke WFS-implementatie ondersteund.
+
+<Canvas of={VlMapWfsLayerStories.MapWfsLayerCqlFilter} />
+
+
 ## Configuratie
 
 <ArgTypes of={VlMapWfsLayerStories.MapWfsLayerDefault} />

--- a/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/stories/vl-map-wfs-layer.stories.ts
@@ -22,11 +22,13 @@ export default {
 
 export const MapWfsLayerDefault = story(
     mapWfsLayerArgs,
-    ({ hidden, layers, maxResolution, minResolution, name, opacity, url }) =>
+    ({ cqlFilter, geometryName, hidden, layers, maxResolution, minResolution, name, opacity, url }) =>
         html`
             <vl-map lambert2008>
                 <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
                 <vl-map-wfs-layer
+                    cql-filter=${cqlFilter}
+                    geometry-name=${geometryName}
                     ?hidden=${hidden}
                     layers=${layers}
                     max-resolution=${maxResolution}
@@ -44,5 +46,36 @@ MapWfsLayerDefault.storyName = 'vl-map-wfs-layer - default';
 MapWfsLayerDefault.args = {
     layers: 'owl_l',
     name: 'Oppervlaktewaterlichamen',
+    url: 'https://geoserver.vmm.be/geoserver/vmm/wfs',
+};
+
+export const MapWfsLayerCqlFilter = story(
+    mapWfsLayerArgs,
+    ({ cqlFilter, geometryName, hidden, layers, maxResolution, minResolution, name, opacity, url }) =>
+        html`
+            <vl-map lambert2008>
+                <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+                <vl-map-wfs-layer
+                    cql-filter=${cqlFilter}
+                    geometry-name=${geometryName}
+                    ?hidden=${hidden}
+                    layers=${layers}
+                    max-resolution=${maxResolution}
+                    min-resolution=${minResolution}
+                    name=${name}
+                    opacity=${opacity}
+                    url=${url}
+                    projection-code="EPSG:31370"
+                >
+                </vl-map-wfs-layer>
+            </vl-map>
+        `
+);
+MapWfsLayerCqlFilter.storyName = 'vl-map-wfs-layer - cql-filter';
+MapWfsLayerCqlFilter.args = {
+    cqlFilter: "bekken_naa = 'IJzerbekken'",
+    geometryName: 'geom',
+    layers: 'owl_l',
+    name: 'Oppervlaktewaterlichamen (gefilterd)',
     url: 'https://geoserver.vmm.be/geoserver/vmm/wfs',
 };

--- a/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/vl-map-wfs-layer.cy.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/vl-map-wfs-layer.cy.ts
@@ -18,6 +18,42 @@ const wfsLayerWithQueryParamsInUrlFixture = html`
     </vl-map>
 `;
 
+const wfsLayerWithCqlFilterAndGeometryNameFixture = html`
+    <vl-map lambert2008>
+        <vl-map-wfs-layer
+            name="foobar"
+            url="http://localhost/wfs"
+            layers="layer1,layer2"
+            cql-filter="WTRLICHC = 'Kanaal'"
+            geometry-name="GEOM"
+        >
+        </vl-map-wfs-layer>
+    </vl-map>
+`;
+
+const wfsLayerWithCqlFilterFixture = html`
+    <vl-map lambert2008>
+        <vl-map-wfs-layer name="foobar" url="http://localhost/wfs" layers="layer1,layer2" cql-filter="WTRLICHC = 'Kanaal'">
+        </vl-map-wfs-layer>
+    </vl-map>
+`;
+
+// Geometrie-property met een niet-triviaal type (MultiSurface) om aan te tonen dat de namespace-gebaseerde detectie
+// werkt voor om het even welk GML-geometrie-type, niet enkel Point.
+const describeFeatureTypeResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml">
+    <xsd:complexType name="layer1Type">
+        <xsd:complexContent>
+            <xsd:extension base="gml:AbstractFeatureType">
+                <xsd:sequence>
+                    <xsd:element name="WTRLICHC" type="xsd:string"/>
+                    <xsd:element name="the_geom" type="gml:MultiSurfacePropertyType"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+</xsd:schema>`;
+
 describe('cypress-component - map - vl-map-wfs-layer', () => {
     it('wfs layer kan toegevoegd worden aan een map met de correcte configuratie', () => {
         cy.intercept('http://localhost/wfs*', {}).as('getWfsLayer');
@@ -48,6 +84,76 @@ describe('cypress-component - map - vl-map-wfs-layer', () => {
             ).to.be.equal(
                 'http://localhost/wfs?foo=bar&service=WFS&request=GetFeature&typename=layer1%2Clayer2&bbox=1.2%2C3.4%2C5.6%2C7.8&srsname=EPSG%3A3812&outputFormat=GML2&version=2.0.0'
             );
+        });
+    });
+
+    it('met cql-filter en expliciete geometry-name bouwt een cql_filter met BBOX-clausule i.p.v. een bbox-parameter', () => {
+        cy.intercept('http://localhost/wfs*', {}).as('getWfsLayer');
+        cy.mount(wfsLayerWithCqlFilterAndGeometryNameFixture);
+        cy.runTestFor<VlMapWfsLayer>('vl-map-wfs-layer', (vlMapWfsLayer) => {
+            const projection = new OlProjection({ code: 'EPSG:31370' });
+            const url = vlMapWfsLayer.layer.getSource().getUrl()([1.2, 3.4, 5.6, 7.8], 123, projection);
+            expect(url.searchParams.has('bbox')).to.be.false;
+            expect(url.searchParams.get('cql_filter')).to.equal("BBOX(GEOM,1.2,3.4,5.6,7.8) AND (WTRLICHC = 'Kanaal')");
+        });
+    });
+
+    it('met cql-filter zonder geometry-name wordt de geometry-property via DescribeFeatureType auto-gedetecteerd, en pas daarna de source aangemaakt', () => {
+        cy.intercept({ url: 'http://localhost/wfs*', query: { request: 'DescribeFeatureType' } }, describeFeatureTypeResponse).as(
+            'describeFeatureType'
+        );
+        cy.intercept({ url: 'http://localhost/wfs*', query: { request: 'GetFeature' } }, {}).as('getWfsLayer');
+        cy.mount(wfsLayerWithCqlFilterFixture);
+        cy.wait('@describeFeatureType');
+        cy.runTestFor<VlMapWfsLayer>('vl-map-wfs-layer', (vlMapWfsLayer) => {
+            const projection = new OlProjection({ code: 'EPSG:31370' });
+            // Race-condition-garantie: de source/layer bestaat pas nadat de geometry-property opgelost is.
+            cy.wrap(null).should(() => {
+                expect(vlMapWfsLayer.layer, 'layer is pas aangemaakt na geometry-detectie').to.exist;
+            });
+            cy.then(() => {
+                const url = vlMapWfsLayer.layer.getSource().getUrl()([1.2, 3.4, 5.6, 7.8], 123, projection);
+                expect(url.searchParams.has('bbox')).to.be.false;
+                expect(url.searchParams.get('cql_filter')).to.equal(
+                    "BBOX(the_geom,1.2,3.4,5.6,7.8) AND (WTRLICHC = 'Kanaal')"
+                );
+            });
+        });
+    });
+
+    it('met cql-filter valt terug op een bbox-request en waarschuwt wanneer DescribeFeatureType faalt', () => {
+        cy.intercept({ url: 'http://localhost/wfs*', query: { request: 'DescribeFeatureType' } }, { statusCode: 500, body: '' }).as(
+            'describeFeatureType'
+        );
+        cy.intercept({ url: 'http://localhost/wfs*', query: { request: 'GetFeature' } }, {}).as('getWfsLayer');
+        cy.window().then((win) => cy.spy(win.console, 'warn').as('consoleWarn'));
+        cy.mount(wfsLayerWithCqlFilterFixture);
+        cy.wait('@describeFeatureType');
+        cy.get('@consoleWarn').should('have.been.calledWithMatch', /geometry-property niet automatisch bepalen/);
+        cy.runTestFor<VlMapWfsLayer>('vl-map-wfs-layer', (vlMapWfsLayer) => {
+            const projection = new OlProjection({ code: 'EPSG:31370' });
+            cy.wrap(null).should(() => {
+                expect(vlMapWfsLayer.layer, 'layer is pas aangemaakt na geometry-detectie').to.exist;
+            });
+            cy.then(() => {
+                const url = vlMapWfsLayer.layer.getSource().getUrl()([1.2, 3.4, 5.6, 7.8], 123, projection);
+                // Veilige terugval: geen ongelimiteerde, filter-loze cql_filter, maar een bbox-begrensd request.
+                expect(url.searchParams.has('cql_filter')).to.be.false;
+                expect(url.searchParams.get('bbox')).to.equal('1.2,3.4,5.6,7.8');
+            });
+        });
+    });
+
+    it('cql-filter is reactief: een wijziging na connect refresht de source en herbouwt de cql_filter-url', () => {
+        cy.intercept('http://localhost/wfs*', {}).as('getWfsLayer');
+        cy.mount(wfsLayerWithCqlFilterAndGeometryNameFixture);
+        cy.runTestFor<VlMapWfsLayer>('vl-map-wfs-layer', (vlMapWfsLayer) => {
+            const projection = new OlProjection({ code: 'EPSG:31370' });
+            const refreshSpy = cy.spy(vlMapWfsLayer.source, 'refresh');
+            vlMapWfsLayer.setAttribute('cql-filter', "WTRLICHC = 'Rivier'");
+            expect(refreshSpy, 'source.refresh wordt aangeroepen bij een cql-filter wijziging').to.have.been.called;
+            const url = vlMapWfsLayer.layer.getSource().getUrl()([1.2, 3.4, 5.6, 7.8], 123, projection);
+            expect(url.searchParams.get('cql_filter')).to.equal("BBOX(GEOM,1.2,3.4,5.6,7.8) AND (WTRLICHC = 'Rivier')");
         });
     });
 

--- a/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/vl-map-wfs-layer.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-wfs-layer/vl-map-wfs-layer.ts
@@ -5,9 +5,24 @@ import { transformExtent } from 'ol/proj';
 import OlVectorSource from 'ol/source/Vector';
 import { VlMapVectorLayer } from '../vl-map-vector-layer';
 
+// De geometry-property in een DescribeFeatureType-schema herken je aan het feit dat zijn type tot de GML-namespace
+// behoort (bv. gml:PointPropertyType, gml:MultiSurfacePropertyType). Matchen op de namespace i.p.v. op de type-naam is
+// robuuster: het werkt voor elk geometrie-type, ook voor minder courante of niet-GeoServer schema's, zolang ze GML
+// gebruiken. WFS 2.0 gebruikt http://www.opengis.net/gml/3.2; het gemeenschappelijke voorvoegsel dekt beide versies.
+const GML_NAMESPACE = 'http://www.opengis.net/gml';
+
 @webComponent('vl-map-wfs-layer')
 export class VlMapWfsLayer extends VlMapVectorLayer {
+    static get _observedAttributes() {
+        return super._observedAttributes.concat(['cql-filter']);
+    }
+
+    private __resolvedGeometryName?: string;
+
     connectedCallback() {
+        if (this.__shouldDetectGeometryName) {
+            return this.__connectAfterGeometryDetection();
+        }
         this._source = this.__createSource();
         this._layer = this._createLayer();
         return super.connectedCallback();
@@ -55,7 +70,15 @@ export class VlMapWfsLayer extends VlMapVectorLayer {
         searchParams.set('service', 'WFS');
         searchParams.set('request', 'GetFeature');
         searchParams.set('typename', this._layers);
-        searchParams.set('bbox', transformedExtent);
+
+        const cqlFilter = this.__cqlFilter;
+        const geometryName = this.__geometryName;
+        if (cqlFilter && geometryName) {
+            searchParams.set('cql_filter', `BBOX(${geometryName},${transformedExtent}) AND (${cqlFilter})`);
+        } else {
+            searchParams.set('bbox', transformedExtent);
+        }
+
         searchParams.set('srsname', this.__layerProjectionCode);
         searchParams.set('outputFormat', this.__wfsOutputFormat);
         searchParams.set('version', this.__wfsVersion);
@@ -76,6 +99,94 @@ export class VlMapWfsLayer extends VlMapVectorLayer {
 
     get __wfsVersion() {
         return '2.0.0';
+    }
+
+    private get __cqlFilter(): string | null {
+        return this.getAttribute('cql-filter');
+    }
+
+    private get __geometryName(): string | undefined {
+        return this.getAttribute('geometry-name') || this.__resolvedGeometryName;
+    }
+
+    private get __shouldDetectGeometryName(): boolean {
+        return !!this.__cqlFilter && !this.getAttribute('geometry-name');
+    }
+
+    private async __connectAfterGeometryDetection(): Promise<void> {
+        this.__resolvedGeometryName = await this.__describeGeometryName();
+        this._source = this.__createSource();
+        this._layer = this._createLayer();
+        return super.connectedCallback();
+    }
+
+    _cqlFilterChangedCallback(_oldValue: string, newValue: string): void {
+        if (!this._source) {
+            return;
+        }
+        if (newValue && !this.getAttribute('geometry-name') && !this.__resolvedGeometryName) {
+            this.__describeGeometryName().then((geometryName) => {
+                this.__resolvedGeometryName = geometryName;
+                this._source.refresh();
+            });
+        } else {
+            this._source.refresh();
+        }
+    }
+
+    private async __describeGeometryName(): Promise<string | undefined> {
+        try {
+            const url = this._url;
+            const { searchParams } = url;
+            searchParams.set('service', 'WFS');
+            searchParams.set('version', this.__wfsVersion);
+            searchParams.set('request', 'DescribeFeatureType');
+            searchParams.set('typename', this._layers);
+
+            const response = await fetch(url.toString());
+            if (!response.ok) {
+                this.__warnGeometryDetectionFailed(`DescribeFeatureType gaf status ${response.status}`);
+                return undefined;
+            }
+
+            const schema = new DOMParser().parseFromString(await response.text(), 'application/xml');
+            if (schema.querySelector('parsererror')) {
+                this.__warnGeometryDetectionFailed('DescribeFeatureType respons kon niet als XML geparset worden');
+                return undefined;
+            }
+
+            const geometryName = this.__findGeometryName(schema);
+            if (!geometryName) {
+                this.__warnGeometryDetectionFailed('geen geometry-property gevonden in het WFS-schema');
+            }
+            return geometryName;
+        } catch (error) {
+            this.__warnGeometryDetectionFailed(error);
+            return undefined;
+        }
+    }
+
+    private __findGeometryName(schema: Document): string | undefined {
+        const elements = Array.from(schema.getElementsByTagNameNS('*', 'element'));
+        const geometryElement = elements.find((element) => {
+            const type = element.getAttribute('type');
+            if (!type) {
+                return false;
+            }
+            const prefix = type.includes(':') ? type.split(':')[0] : null;
+            const namespace = element.lookupNamespaceURI(prefix) ?? '';
+            return namespace.startsWith(GML_NAMESPACE);
+        });
+        return geometryElement?.getAttribute('name') ?? undefined;
+    }
+
+    private __warnGeometryDetectionFailed(reason: unknown): void {
+        console.warn(
+            `vl-map-wfs-layer: kon de geometry-property niet automatisch bepalen voor "${this._layers}" (${reason}). ` +
+                `Het cql-filter wordt niet server-side toegepast (terugval op een bbox-request). ` +
+                `Geef het geometry-name attribuut expliciet mee om dit op te lossen.`,
+            reason instanceof Error ? reason : ''
+        );
     }
 }
 


### PR DESCRIPTION
Kris: code gereviewed en opgekuist (commentaar)
In Storybook kan je de functionaliteit mooi in werking zien in de nieuwe story: http://localhost:8080/?path=/story/map-layer-vector-layer-wfs-layer--map-wfs-layer-cql-filter

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-673
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC355

## Samenvatting
`vl-map-wfs-layer` krijgt een `cql-filter` attribuut waarmee consumers de features van een WFS-laag server-side kunnen filteren, zonder een eigen subclass te hoeven schrijven. Snapping in `vl-map-draw-point-action` werkt voortaan ook voor subclasses van een vector-laag.

## Wijzigingen
- Nieuw reactief `cql-filter` attribuut op `vl-map-wfs-layer`: de waarde wordt als `cql_filter=BBOX(geometry,extent) AND (filter)` naar de WFS-server gestuurd in plaats van een `bbox`-parameter.
- Nieuw optioneel `geometry-name` attribuut; ontbreekt dit, dan wordt de geometry-property best-effort gedetecteerd via een `DescribeFeatureType`-call (namespace-gebaseerd, met afhandeling van parse-fouten).
- De source wordt pas aangemaakt nadat de geometry-property opgelost is, zodat de eerste tile-loads niet ongefilterd vertrekken (geen race condition).
- Faalt de auto-detectie, dan valt de laag veilig terug op een gewone `bbox`-request met een `console.warn`.
- `vl-map-draw-point-action` selecteert zijn snapping layers nu via `instanceof VlMapVectorLayer` in plaats van een `vl-map-wfs-layer` tag-check, zodat ook subclasses opgepikt worden.
- Storybook-story (`cql-filter`), docs en Cypress-tests voor alle paden toegevoegd.

## Backwards compatibility
Breaking change: `vl-map-draw-point-action` neemt nu alle `VlMapVectorLayer`s binnen een draw-action als snapping target (voorheen enkel `vl-map-wfs-layer`) — consumers met meerdere vector-layers in één draw-action moeten verifiëren dat het bredere snapping-gedrag gewenst is. Het `cql-filter` zelf is volledig additief; consumers zonder dat attribuut zien geen gedragsverandering.

## Succescriteria
- [x] `vl-map-wfs-layer` accepteert een `cql-filter` attribute dat als `cql_filter` query parameter naar de WFS-server gaat — geïmplementeerd in `__getWfsUrl`.
- [x] Uitgaande WFS-URL bevat `cql_filter=BBOX({geometryName},{extent}) AND ({user-filter})` i.p.v. `bbox` wanneer `cql-filter` actief is — gedekt door een Cypress-test.
- [x] `geometryName` wordt automatisch bepaald (DescribeFeatureType) of expliciet meegegeven, zonder race condition — source wordt pas na resolve aangemaakt; expliciet getest dat de layer pas daarna bestaat.
- [x] `vl-map-draw-point-action` vindt snapping layers ook voor een subclass van `vl-map-wfs-layer` / `VlMapVectorLayer` — tag-check vervangen door `instanceof`, met een eigen Cypress-test.
- [x] Bestaande consumers zonder `cql-filter` zien geen gedragsverandering — het bbox-pad blijft synchroon en ongewijzigd.
- [x] Storybook-story en Cypress-tests dekken de cql-filter case af — story `vl-map-wfs-layer - cql-filter` + tests voor expliciete naam, auto-detect, degradatie en reactiviteit.
