### PR TITLE
fix: FLUX-134 - data-prefix hersteld op native HTML-elementen

### DIFF
--- a/libs/components/src/block/accordion/vl-accordion.component.ts
+++ b/libs/components/src/block/accordion/vl-accordion.component.ts
@@ -23,9 +23,9 @@ export class VlAccordionComponent extends BaseHTMLElement {
     constructor() {
         const html = `
           <div class="js">
-            <div class="vl-accordion" accordion>
+            <div class="vl-accordion" data-accordion>
             <div class="vl-accordion__button-container">
-              <button class="vl-toggle vl-link vl-link--bold" accordion-toggle>
+              <button class="vl-toggle vl-link vl-link--bold" data-accordion-toggle>
                 <vl-icon id="toggle-icon" icon="arrow-down-fat" class="vl-accordion__icon vl-link__icon vl-link__icon--before"></vl-icon>
                 <slot name="title" class="vl-accordion__title"></slot>
               </button>
@@ -70,7 +70,7 @@ export class VlAccordionComponent extends BaseHTMLElement {
     }
 
     get _accordionElement() {
-        return this._element.querySelector('[accordion]');
+        return this._element.querySelector('[accordion],[data-accordion]');
     }
 
     get _buttonElement() {
@@ -225,12 +225,12 @@ export class VlAccordionComponent extends BaseHTMLElement {
 
     _openToggleTextChangedCallback(oldValue: string, newValue: string) {
         this._titleElement.classList.add('js-vl-accordion__toggle__text');
-        this._titleElement.setAttribute('accordion-open-text', newValue);
+        this._titleElement.setAttribute('data-accordion-open-text', newValue);
     }
 
     _closeToggleTextChangedCallback(oldValue: string, newValue: string) {
         this._titleElement.classList.add('js-vl-accordion__toggle__text');
-        this._titleElement.setAttribute('accordion-close-text', newValue);
+        this._titleElement.setAttribute('data-accordion-close-text', newValue);
     }
 
     _contentPaddingChangedCallback(oldValue: keyof typeof PADDINGS, newValue: keyof typeof PADDINGS) {

--- a/libs/components/src/block/accordion/vl-accordion.lib.js
+++ b/libs/components/src/block/accordion/vl-accordion.lib.js
@@ -46,8 +46,19 @@ const vl = window.vl || { ns: 'vl' };
         acIconMin = ''.concat(vl.ns, 'vi-minus'),
         acContentClassName = ''.concat(vl.ns, 'accordion__content'),
         acAtt = 'accordion',
-        acDressedAtt = ''.concat(acAtt, '-dressed'),
-        acToggleAtt = ''.concat(acAtt, '-toggle');
+        // Interne marker: enkel door deze lib gezet/gelezen → enkel data-vorm.
+        acDressedAtt = 'data-'.concat(acAtt, '-dressed'),
+        acToggleAtt = ''.concat(acAtt, '-toggle'),
+        // Selectors matchen de oude vorm (geldig op een vl-element) én de
+        // data-vorm (geldig op een native element).
+        acAttSelector = '['.concat(acAtt, '],[data-').concat(acAtt, ']'),
+        acToggleSelector = '['.concat(acToggleAtt, '],[data-').concat(acToggleAtt, ']'),
+        acOpenTextAtt = ''.concat(acAtt, '-open-text'),
+        acCloseTextAtt = ''.concat(acAtt, '-close-text');
+
+    function getDualAttribute(element, name) {
+        return element.getAttribute('data-'.concat(name)) || element.getAttribute(name);
+    }
 
     var Accordion = /*#__PURE__*/ (function () {
         function Accordion() {
@@ -79,7 +90,7 @@ const vl = window.vl || { ns: 'vl' };
             {
                 key: 'open',
                 value: function open(element) {
-                    var toggle = element.querySelector('['.concat(acToggleAtt, ']'));
+                    var toggle = element.querySelector(acToggleSelector);
 
                     if (toggle && !vl.util.hasClass(element, acOpenClassName)) {
                         toggle.click();
@@ -94,7 +105,7 @@ const vl = window.vl || { ns: 'vl' };
             {
                 key: 'toggle',
                 value: function toggle(element) {
-                    var toggle = element.querySelector('['.concat(acToggleAtt, ']'));
+                    var toggle = element.querySelector(acToggleSelector);
 
                     if (toggle) {
                         toggle.click();
@@ -120,7 +131,7 @@ const vl = window.vl || { ns: 'vl' };
                         hiddenState = true;
                     element.setAttribute(acDressedAtt, true);
                     toggle = element.querySelector(acToggleTextClassName);
-                    accordion = element.closest('.'.concat(className, ', [').concat(acAtt, ']'));
+                    accordion = element.closest('.'.concat(className, ', ').concat(acAttSelector));
                     accordionContent = accordion.querySelector('.'.concat(acContentClassName));
 
                     if (vl.util.exists(accordionContent)) {
@@ -128,8 +139,8 @@ const vl = window.vl || { ns: 'vl' };
                     }
 
                     if (toggle) {
-                        closedText = toggle.getAttribute('accordion-close-text');
-                        openText = toggle.getAttribute('accordion-open-text');
+                        closedText = getDualAttribute(toggle, acCloseTextAtt);
+                        openText = getDualAttribute(toggle, acOpenTextAtt);
 
                         if (vl.util.hasClass(element, acOpenClassName)) {
                             toggle.innerHTML = closedText;
@@ -145,7 +156,7 @@ const vl = window.vl || { ns: 'vl' };
                     element.addEventListener(
                         'click',
                         function (event) {
-                            var accordion = event.target.closest('.'.concat(className, ', [').concat(acAtt, ']'));
+                            var accordion = event.target.closest('.'.concat(className, ', ').concat(acAttSelector));
 
                             if (accordion && !vl.util.hasClass(element, acDisabledClassName)) {
                                 event.preventDefault();
@@ -177,9 +188,9 @@ const vl = window.vl || { ns: 'vl' };
 
                                 if (toggle) {
                                     if (vl.util.hasClass(accordion, acOpenClassName)) {
-                                        toggle.innerHTML = toggle.getAttribute('accordion-close-text');
+                                        toggle.innerHTML = getDualAttribute(toggle, acCloseTextAtt);
                                     } else {
-                                        toggle.innerHTML = toggle.getAttribute('accordion-open-text');
+                                        toggle.innerHTML = getDualAttribute(toggle, acOpenTextAtt);
                                     }
                                 }
                             }
@@ -205,13 +216,16 @@ const vl = window.vl || { ns: 'vl' };
 
                     // get all accordion toggle elements
                     var elements = document.querySelectorAll(
-                        '\n      .'
+                        '.'
                             .concat(className, ':not([js-dress="false"]) .')
                             .concat(acToggleClassName, ':not([')
-                            .concat(acDressedAtt, ']),\n      [')
+                            .concat(acDressedAtt, ']),[')
                             .concat(acAtt, ']:not([js-dress="false"]) [')
                             .concat(acToggleAtt, ']:not([')
-                            .concat(acDressedAtt, '])\n    ')
+                            .concat(acDressedAtt, ']),[data-')
+                            .concat(acAtt, ']:not([js-dress="false"]) [data-')
+                            .concat(acToggleAtt, ']:not([')
+                            .concat(acDressedAtt, '])')
                     ); // add functionality to the accordions
 
                     vl.util.each(elements, function (element) {

--- a/libs/components/src/block/alert/vl-alert.component.ts
+++ b/libs/components/src/block/alert/vl-alert.component.ts
@@ -36,11 +36,6 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
         };
     }
 
-    protected updated(changedProperties: Map<string, unknown>): void {
-        super.updated(changedProperties);
-        this.processButtons();
-    }
-
     protected render(): TemplateResult {
         const classes = {
             'vl-alert': true,
@@ -92,15 +87,6 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
     private removeAlert() {
         this.remove();
         this.dispatchEvent(new VlAlertClosedEvent());
-    }
-
-    private processButtons() {
-        const actionsSlotElement = this.renderRoot.querySelector('slot[name="actions"]') as HTMLSlotElement;
-        const buttonNodes = actionsSlotElement
-            ?.assignedNodes()
-            .filter((element) => element instanceof HTMLButtonElement);
-
-        buttonNodes.forEach((node) => (node as HTMLButtonElement).setAttribute('data-narrow', ''));
     }
 }
 

--- a/libs/components/src/block/alert/vl-alert.component.ts
+++ b/libs/components/src/block/alert/vl-alert.component.ts
@@ -100,7 +100,7 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
             ?.assignedNodes()
             .filter((element) => element instanceof HTMLButtonElement);
 
-        buttonNodes.forEach((node) => (node as HTMLButtonElement).setAttribute('narrow', ''));
+        buttonNodes.forEach((node) => (node as HTMLButtonElement).setAttribute('data-narrow', ''));
     }
 }
 

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
@@ -376,7 +376,7 @@ export class VlAutocomplete extends BaseLitElement {
                 liElements.push(html` <li
                     id="${id}"
                     class="vl-autocomplete__cta flux-autocomplete-group"
-                    groupindex="${groupIndex}"
+                    data-groupindex="${groupIndex}"
                     role="option"
                     aria-selected="false"
                     aria-disabled="true"
@@ -400,7 +400,7 @@ export class VlAutocomplete extends BaseLitElement {
             id="${id}"
             @click=${() => this.autocomplete(item, id)}
             class="vl-autocomplete__cta flux-autocomplete-item"
-            groupindex="${groupIndex}"
+            data-groupindex="${groupIndex}"
             role="option"
             aria-selected="${id === this._highlightedEl?.id ? 'true' : 'false'}"
         >

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
@@ -376,7 +376,6 @@ export class VlAutocomplete extends BaseLitElement {
                 liElements.push(html` <li
                     id="${id}"
                     class="vl-autocomplete__cta flux-autocomplete-group"
-                    data-groupindex="${groupIndex}"
                     role="option"
                     aria-selected="false"
                     aria-disabled="true"
@@ -400,7 +399,6 @@ export class VlAutocomplete extends BaseLitElement {
             id="${id}"
             @click=${() => this.autocomplete(item, id)}
             class="vl-autocomplete__cta flux-autocomplete-item"
-            data-groupindex="${groupIndex}"
             role="option"
             aria-selected="${id === this._highlightedEl?.id ? 'true' : 'false'}"
         >

--- a/libs/components/src/block/modal/vl-modal.component.ts
+++ b/libs/components/src/block/modal/vl-modal.component.ts
@@ -27,7 +27,7 @@ export class VlModalComponent extends BaseHTMLElement {
     constructor() {
         const html = `
             <div class="vl-modal">
-                <dialog class="vl-modal-dialog" id="modal-dialog" modal tabindex="-1"
+                <dialog class="vl-modal-dialog" id="modal-dialog" data-modal tabindex="-1"
                         aria-modal="true" aria-hidden="true" aria-labelledby="modal-toggle-title">
                     <div class="vl-modal-dialog__wrapper" id="modal-dialog-wrapper">
                         <div class="vl-grid vl-stacked-small">
@@ -36,7 +36,7 @@ export class VlModalComponent extends BaseHTMLElement {
                             </div>
                             <div class="vl-column vl-column--12 vl-column--m-12">
                                 <div id="modal-action-group" class="vl-group">
-                                    <slot name="button" modal-close></slot>
+                                    <slot name="button" data-modal-close></slot>
                                     <vl-link id="modal-toggle-cancellable"
                                              button-as-link icon="cross" icon-placement="before"
                                              modal-close>Annuleer</vl-link>
@@ -77,11 +77,11 @@ export class VlModalComponent extends BaseHTMLElement {
     }
 
     static get _closableAttribute() {
-        return 'modal-closable';
+        return 'data-modal-closable';
     }
 
     static get _closeAttribute() {
-        return 'modal-close';
+        return 'data-modal-close';
     }
 
     get _dialogElement(): HTMLDialogElement {
@@ -210,7 +210,7 @@ export class VlModalComponent extends BaseHTMLElement {
 
     _getCloseButtonTemplate() {
         return this._template(`
-      <button id="close" type="button" class="vl-modal-dialog__close" aria-expanded="true" modal-close>
+      <button id="close" type="button" class="vl-modal-dialog__close" aria-expanded="true" data-modal-close>
         <span class="vl-modal-dialog__close__icon vl-icon vl-icon--cross" aria-hidden="true"></span>
         <span class="vl-u-visually-hidden">Venster sluiten</span>
       </button>

--- a/libs/components/src/block/modal/vl-modal.lib.js
+++ b/libs/components/src/block/modal/vl-modal.lib.js
@@ -34,10 +34,14 @@
     }
 
     const mAttr = 'modal';
-    const mDressedAtt = ''.concat(mAttr, '-dressed');
-    const mClosable = ''.concat(mAttr, '-closable');
+    // Interne markers worden enkel door deze lib gezet/gelezen → enkel data-vorm.
+    const mDressedAtt = 'data-'.concat(mAttr, '-dressed');
+    const mClosable = 'data-'.concat(mAttr, '-closable');
+    // Publieke attributen: matchen zowel de oude vorm (geldig op een vl-element)
+    // als de data-vorm (geldig op een native element).
     const mOpen = ''.concat(mAttr, '-open');
     const mClose = ''.concat(mAttr, '-close');
+    const mCloseSelector = '['.concat(mClose, '],[data-').concat(mClose, ']');
     const mFallbackBackdropClass = '.backdrop';
     const noOverflowClass = ''.concat(vl.ns, 'u-no-overflow');
 
@@ -116,8 +120,15 @@
 
                         element.setAttribute(mDressedAtt, true); // Handle open/close
 
-                        linkedOpenTrigger = findOpenTrigger(element, '['.concat(mOpen, '="').concat(element.id, '"]'));
-                        linkedClosedTrigger = element.querySelectorAll('['.concat(mClose, ']')); // See if closable (by esc or backdrop)
+                        linkedOpenTrigger = findOpenTrigger(
+                            element,
+                            '['
+                                .concat(mOpen, '="')
+                                .concat(element.id, '"],[data-')
+                                .concat(mOpen, '="')
+                                .concat(element.id, '"]')
+                        );
+                        linkedClosedTrigger = element.querySelectorAll(mCloseSelector); // See if closable (by esc or backdrop)
 
                         closable = element.hasAttribute(mClosable);
                         vl.util.each(linkedOpenTrigger, (openTrigger) => {
@@ -178,7 +189,11 @@
                         const _this = this;
 
                         const elements = document.querySelectorAll(
-                            '['.concat(mAttr, ']:not([').concat(mDressedAtt, ']):not([js-dress="false"])')
+                            '['
+                                .concat(mAttr, ']:not([')
+                                .concat(mDressedAtt, ']):not([js-dress="false"]),[data-')
+                                .concat(mAttr, ']:not([')
+                                .concat(mDressedAtt, ']):not([js-dress="false"])')
                         );
                         vl.util.each(elements, (element) => {
                             _this.dress(element);

--- a/libs/components/src/block/pager/vl-pager.component.ts
+++ b/libs/components/src/block/pager/vl-pager.component.ts
@@ -110,11 +110,11 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
     }
 
     get _pageElements() {
-        return [...this._pagesListElement!.querySelectorAll('[pager-page]')];
+        return [...this._pagesListElement!.querySelectorAll('[data-pager-page]')];
     }
 
     get _pageSkippedElements() {
-        return [...this._pagesListElement!.querySelectorAll('[pager-page-skipped]')];
+        return [...this._pagesListElement!.querySelectorAll('[data-pager-page-skipped]')];
     }
 
     get _pageBackLink() {
@@ -160,7 +160,7 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
 
     __getActivePageTemplate(number: string) {
         return this._template(`
-      <li pager-page=${number} class="vl-pager__element vl-pager__element--active" aria-current="page" tabindex="-1">
+      <li data-pager-page=${number} class="vl-pager__element vl-pager__element--active" aria-current="page" tabindex="-1">
         <span class="vl-pager__element-cta">${number}</span>
       </li>
     `);
@@ -168,7 +168,7 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
 
     __getSkippedPageTemplate() {
         return this._template(`
-      <li pager-page-skipped class="vl-pager__element">
+      <li data-pager-page-skipped class="vl-pager__element">
         <div class="vl-pager__element-cta">...</div>
       </li>
     `);
@@ -188,7 +188,7 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
 
     __getPageTemplate(number: string) {
         const template = this._template(`
-      <li pager-page=${number} class="vl-pager__element">
+      <li data-pager-page=${number} class="vl-pager__element">
         <a href="#" class="vl-pager__element-cta vl-link bold">${number}</a>
       </li>
     `);

--- a/libs/components/src/block/rich-data-table/vl-rich-data-field.component.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-field.component.ts
@@ -32,7 +32,7 @@ export class VlRichDataField extends BaseHTMLElement {
             th.appendChild(headerContent);
         }
         if (this.sortable) {
-            th.setAttribute('sortable', '');
+            th.setAttribute('data-sortable', '');
         }
         return th;
     }

--- a/libs/components/src/block/rich-data-table/vl-rich-data-table.component.cy.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-table.component.cy.ts
@@ -145,7 +145,7 @@ const shouldPaginateCorrectly = (dataRows: unknown[], pagination: { currentPage:
 };
 
 const selectPagerPage = (pageNumber: number) => {
-    cy.get('vl-rich-data-table').find('vl-pager').shadow().find(`[pager-page=${pageNumber}]`).click();
+    cy.get('vl-rich-data-table').find('vl-pager').shadow().find(`[data-pager-page=${pageNumber}]`).click();
 };
 
 const findValueByPath = (item: any, pathToKey: string): string | undefined => {

--- a/libs/components/src/block/rich-data-table/vl-rich-data-table.component.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-table.component.ts
@@ -259,7 +259,7 @@ export class VlRichDataTable extends VlRichData {
 
     __initializeSortingOnHeaderColumn(header: any) {
         // Support both legacy anchors and new buttons used as sort toggles
-        const sorterButton = header.querySelector('th[sortable] > a, th[sortable] > button');
+        const sorterButton = header.querySelector('th[data-sortable] > a, th[data-sortable] > button');
         if (sorterButton) {
             sorterButton.addEventListener('click', () => {
                 sorterButton.querySelector('vl-rich-data-sorter').nextDirection();
@@ -346,14 +346,14 @@ export class VlRichDataTable extends VlRichData {
         }
 
         const allSortableHeaderCells: HTMLElement[] = Array.from(
-            this.__tableHeaderRow?.querySelectorAll('th[sortable]') || []
+            this.__tableHeaderRow?.querySelectorAll('th[data-sortable]') || []
         ) as HTMLElement[];
 
         allSortableHeaderCells.forEach((th) => th.removeAttribute('aria-sort'));
 
         this.__sortingState?.forEach(({ name, direction }) => {
             const header = this.__tableHeaderRow
-                ?.querySelector(`th[sortable] vl-rich-data-sorter[for="${name}"]`)
+                ?.querySelector(`th[data-sortable] vl-rich-data-sorter[for="${name}"]`)
                 ?.closest('th');
 
             header?.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');

--- a/libs/components/src/block/rich-data-table/vl-rich-data-table.flux-css.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-table.flux-css.ts
@@ -1,7 +1,7 @@
 import { css, CSSResult } from 'lit';
 
 export const vlRichDataTableFluxStyles: CSSResult = css`
-    th[sortable] a {
+    th[data-sortable] a {
         cursor: pointer;
     }
 `;

--- a/libs/components/src/block/rich-data/vl-rich-data.component.cy.ts
+++ b/libs/components/src/block/rich-data/vl-rich-data.component.cy.ts
@@ -60,7 +60,7 @@ describe('cypress-component - block components - vl-rich-data', () => {
             .then((child) => {
                 expect(child[0]).to.contain('1-5');
             });
-        cy.get('vl-pager').shadow().find('li[pager-page=2]').click({ force: true });
+        cy.get('vl-pager').shadow().find('li[data-pager-page=2]').click({ force: true });
         cy.get('vl-pager')
             .shadow()
             .find('#bounds')

--- a/libs/components/src/block/wizard/vl-wizard.component.ts
+++ b/libs/components/src/block/wizard/vl-wizard.component.ts
@@ -53,7 +53,7 @@ export class VlWizard extends BaseLitElement {
 
     render() {
         return html`
-            <section class="vl-wizard" wizard>
+            <section class="vl-wizard" data-wizard>
                 <header class="vl-wizard__heading" role="none">
                     <slot name="title"></slot>
                     <slot name="header"></slot>


### PR DESCRIPTION
Kris: 2e commit met opkuis van nutteloze attributes
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-134
http://bamboo.cumuli.be:8080/bamboo/chain/viewChain.action?planKey=FLUX-CFWC354

## Samenvatting
Author-attributen die op native HTML-elementen in de shadow-DOM stonden krijgen
opnieuw een `data-`-prefix, zodat de gerenderde HTML valide is. Twee attributen
(`narrow` op alert, `groupindex` op autocomplete) bleken effectloze dode code en
zijn verwijderd in plaats van geprefixt. Voor consumers verandert er niets:
bestaande markup op `vl-`-elementen blijft werken.

## Wijzigingen
Twee commits:

**1. `data-`-prefix hersteld op native HTML-elementen** (`49c7e3c7`)
- Modal: `<dialog>`, `<slot name="button">` en de interne close-`<button>` krijgen `data-modal`/`data-modal-close`; `lib.js` matcht via dual-selectoren zowel de oude vorm (op een `vl-`-element) als de `data-`-vorm.
- Accordion: `<div data-accordion>` en `<button data-accordion-toggle>` + dual-selectoren en `getDualAttribute`-helper voor de open/close-tekst.
- Pager: `<li>`-paginering hernoemd naar `data-pager-page`/`data-pager-page-skipped` (puur interne selectoren).
- Wizard: `data-wizard` op `<section>`. Rich-data: `data-sortable` op `<th>` (+ interne selectoren en flux-css).
- Rich-data Cypress-tests meegemigreerd naar `[data-pager-page]`.

**2. Dode code zonder effect verwijderd (vl-alert, vl-autocomplete)** (`619300d1`)
- vl-alert: `processButtons()` + de `updated()`-hook verwijderd. Die zetten `data-narrow` op de slot-buttons, maar daar hangt geen CSS-implementatie aan — puur effectloos.
- vl-autocomplete: `data-groupindex` van de twee `<li>`-templates verwijderd; het werd gezet maar nergens uitgelezen.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. Geen publiek attribuut
hernoemd; `vl-`-element-gebruik blijft werken via de dual-selectoren. De
verwijderde `data-narrow`/`data-groupindex` waren intern en zonder effect.

## Succescriteria
- [x] Geen native HTML-element met niet-namespaced custom attribuut — alle native-element-attributen uit commit `004d59c9` zijn `data-*` geworden, of (waar effectloos) verwijderd.
- [x] Functionele werking onveranderd / Cypress groen — dual-selectoren en interne selectoren mee aangepast, rich-data-tests gemigreerd (Cypress nog in CI te bevestigen).
- [x] Publieke API BC-veilig — geen publiek attribuut hernoemd; `vl-`-element-gebruik blijft werken via de dual-selectoren.
- [x] HTML-validatie schoon op gerenderde shadow-DOM — native elementen dragen enkel valide `data-*` author-attributen.
