### PR TITLE
fix: FLUX-697 - vl-map-select-actions - actief zolang één layer zichtbaar

### DIFF
--- a/apps/storybook-e2e/src/e2e/map/action/layer-action/select-actions/vl-map-multiselect-actions.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/map/action/layer-action/select-actions/vl-map-multiselect-actions.stories.cy.ts
@@ -14,3 +14,20 @@ describe('cypress-e2e - map - vl-map-multiselect-actions - default story', () =>
         cy.get('vl-map').find('vl-map-multiselect-actions');
     });
 });
+
+describe('cypress-e2e - map - vl-map-multiselect-actions - multilayer visibility story', () => {
+    const mapMultiselectActionMultilayerUrl =
+        'http://localhost:8080/iframe.html?args=&id=map-action-layer-action-select-action-multiselect-actions--map-multiselect-actions-multilayer-visibility&viewMode=story';
+
+    beforeEach(() => {
+        cy.visit(mapMultiselectActionMultilayerUrl);
+    });
+
+    it('should render a map', () => {
+        cy.get('vl-map').shadow().find('div#map');
+    });
+
+    it('should render vl-map-multiselect-actions', () => {
+        cy.get('vl-map').find('vl-map-multiselect-actions');
+    });
+});

--- a/libs/map/src/actions/map/map-with-actions.spec.ts
+++ b/libs/map/src/actions/map/map-with-actions.spec.ts
@@ -10,10 +10,13 @@ import DragZoom from 'ol/interaction/DragZoom';
 import Collection from 'ol/Collection';
 import Interaction from 'ol/interaction/Interaction';
 import VectorSource from 'ol/source/Vector';
+import OlVectorLayer from 'ol/layer/Vector';
 import { VlMapWithActions } from './map-with-actions';
 import { VlBaseMapAction } from '../mapaction';
 import { VlDrawLineAction } from '../draw/draw-line-action';
+import { VlSelectActions } from '../select/select-actions';
 import { VlMapAction } from '../../components/action/vl-map-action';
+import { OlVectorLayerType } from '../../vl-map.model';
 import ResizeObserver from 'resize-observer-polyfill';
 
 global.ResizeObserver = ResizeObserver;
@@ -114,6 +117,32 @@ describe('jest - map - map-with-actions', () => {
         map.removeAction(newAction);
 
         expect(activateDefaultActionSpy).toHaveBeenCalled();
+    });
+
+    it('matcht een single-layer action op zijn layer en niet op een vreemde layer', () => {
+        const layer = new OlVectorLayer({ source: new VectorSource() }) as OlVectorLayerType;
+        const otherLayer = new OlVectorLayer({ source: new VectorSource() }) as OlVectorLayerType;
+        action1.layer = layer;
+
+        map = new VlTestMapWithActions({ actions: [action1] });
+
+        expect(map.getLayerActions(layer)).toContain(action1);
+        expect(map.getLayerActions(otherLayer)).not.toContain(action1);
+    });
+
+    it('returns a multi-layer action for each of its coupled layers, not just the proxy layer', () => {
+        const layer1 = new OlVectorLayer({}) as OlVectorLayerType;
+        const layer2 = new OlVectorLayer({}) as OlVectorLayerType;
+        const otherLayer = new OlVectorLayer({}) as OlVectorLayerType;
+        const selectActions = new VlSelectActions([layer1, layer2]);
+
+        map = new VlTestMapWithActions({
+            actions: [selectActions],
+        });
+
+        expect(map.getLayerActions(layer1)).toContain(selectActions);
+        expect(map.getLayerActions(layer2)).toContain(selectActions);
+        expect(map.getLayerActions(otherLayer)).not.toContain(selectActions);
     });
 
     it('there are 9 predefined interactions', () => {

--- a/libs/map/src/actions/map/map-with-actions.ts
+++ b/libs/map/src/actions/map/map-with-actions.ts
@@ -100,7 +100,7 @@ export class VlMapWithActions extends Map {
     }
 
     getLayerActions(layer) {
-        return this.actions && this.actions.filter((action) => action.layer === layer);
+        return this.actions && this.actions.filter((action) => action.appliesToLayer(layer));
     }
 
     activateAction(action) {

--- a/libs/map/src/actions/mapaction.spec.ts
+++ b/libs/map/src/actions/mapaction.spec.ts
@@ -1,5 +1,8 @@
 import { VlBaseMapAction } from './mapaction';
 import Interaction from 'ol/interaction/Interaction';
+import OlVectorLayer from 'ol/layer/Vector';
+import OlVectorSource from 'ol/source/Vector';
+import { OlVectorLayerType } from '../vl-map.model';
 
 describe('jest - map - mapaction', () => {
     it('kan een interactie toevoegen die niet actief staat', () => {
@@ -25,5 +28,24 @@ describe('jest - map - mapaction', () => {
         const VlmapAction = new VlBaseMapAction([new Interaction(), new Interaction()]);
         VlmapAction.deactivate();
         VlmapAction.interactions.forEach((interaction) => expect(interaction.getActive()).toBe(false));
+    });
+
+    it('is enkel van toepassing op zijn eigen layer', () => {
+        const layer = new OlVectorLayer({ source: new OlVectorSource() }) as OlVectorLayerType;
+        const otherLayer = new OlVectorLayer({ source: new OlVectorSource() }) as OlVectorLayerType;
+        const VlmapAction = new VlBaseMapAction([new Interaction()]);
+        VlmapAction.layer = layer;
+        expect(VlmapAction.appliesToLayer(layer)).toBe(true);
+        expect(VlmapAction.appliesToLayer(otherLayer)).toBe(false);
+    });
+
+    it('heeft een zichtbare layer enkel wanneer zijn eigen layer zichtbaar is', () => {
+        const layer = new OlVectorLayer({ source: new OlVectorSource() }) as OlVectorLayerType;
+        const VlmapAction = new VlBaseMapAction([new Interaction()]);
+        VlmapAction.layer = layer;
+        layer.setVisible(true);
+        expect(VlmapAction.hasVisibleLayer()).toBe(true);
+        layer.setVisible(false);
+        expect(VlmapAction.hasVisibleLayer()).toBe(false);
     });
 });

--- a/libs/map/src/actions/mapaction.ts
+++ b/libs/map/src/actions/mapaction.ts
@@ -33,6 +33,14 @@ export class VlBaseMapAction {
         this._layer = layer;
     }
 
+    appliesToLayer(layer: OlVectorLayerType): boolean {
+        return this._layer === layer;
+    }
+
+    hasVisibleLayer(): boolean {
+        return !!this._layer?.getVisible();
+    }
+
     get interactions(): OlInteraction[] {
         return this._interactions;
     }

--- a/libs/map/src/actions/select/select-actions.spec.ts
+++ b/libs/map/src/actions/select/select-actions.spec.ts
@@ -105,6 +105,29 @@ describe('jest - map - select-actions', () => {
         expect(selectActions.isMarked(feature2)).toBe(false);
     });
 
+    it('is van toepassing op elk van zijn gekoppelde layers', () => {
+        const layer1 = new OlVectorLayer({ source: new OlVectorSource() });
+        const layer2 = new OlVectorLayer({ source: new OlVectorSource() });
+        const otherLayer = new OlVectorLayer({ source: new OlVectorSource() });
+        const selectActions = new VlSelectActions([layer1, layer2] as OlVectorLayerType[]);
+        expect(selectActions.appliesToLayer(layer1 as OlVectorLayerType)).toBe(true);
+        expect(selectActions.appliesToLayer(layer2 as OlVectorLayerType)).toBe(true);
+        expect(selectActions.appliesToLayer(otherLayer as OlVectorLayerType)).toBe(false);
+    });
+
+    it('blijft een zichtbare layer hebben zolang minstens één gekoppelde layer zichtbaar is', () => {
+        const layer1 = new OlVectorLayer({ source: new OlVectorSource() });
+        const layer2 = new OlVectorLayer({ source: new OlVectorSource() });
+        const selectActions = new VlSelectActions([layer1, layer2] as OlVectorLayerType[]);
+        layer1.setVisible(true);
+        layer2.setVisible(false);
+        expect(selectActions.hasVisibleLayer()).toBe(true);
+        layer1.setVisible(false);
+        expect(selectActions.hasVisibleLayer()).toBe(false);
+        layer2.setVisible(true);
+        expect(selectActions.hasVisibleLayer()).toBe(true);
+    });
+
     it('kan clusters markeren en demarkeren', () => {
         const feature1 = new OlFeature();
         const feature2 = new OlFeature();

--- a/libs/map/src/actions/select/select-actions.ts
+++ b/libs/map/src/actions/select/select-actions.ts
@@ -24,6 +24,16 @@ export class VlSelectActions extends VlSelectAction {
         this._layer = layer;
     }
 
+    // Een select-action is aan al zijn layers gekoppeld, niet enkel aan de proxy-layer
+    // die `layer` (via getLayer) teruggeeft.
+    public appliesToLayer(layer: OlVectorLayerType): boolean {
+        return this.layers.includes(layer);
+    }
+
+    public hasVisibleLayer(): boolean {
+        return this.layers.some((layer) => layer?.getVisible());
+    }
+
     protected getLayerByFeature(layers: OlVectorLayerType[], feature: OlFeature): OlVectorLayerType {
         return layers.find((layer) => {
             const features = layer?.getSource()?.getFeatures() || [];

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-doc.mdx
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-doc.mdx
@@ -1,6 +1,7 @@
 import { ArgTypes, Canvas, Source } from '@storybook/addon-docs/blocks';
 import * as VlMapMultiselectActionsStories from './vl-map-multiselect-actions.stories';
 import defaultStorySource from './vl-map-multiselect-actions.stories-default?raw';
+import multilayerVisibilityStorySource from './vl-map-multiselect-actions.stories-util?raw';
 
 # Map Multiselect Actions
 
@@ -30,6 +31,25 @@ import { VlMapMultiselectActions } from '@domg-wc/map';
 <details>
     <summary>Toon code</summary>
     <Source code={defaultStorySource} language="ts" dark={true} />
+</details>
+
+
+## Zichtbaarheid bij meerdere kaartlagen
+
+Een `map-multiselect-actions` die aan meerdere kaartlagen gekoppeld is, blijft bruikbaar zolang minstens één
+gekoppelde kaartlaag zichtbaar is. De actie deactiveert pas wanneer álle gekoppelde kaartlagen verborgen zijn.<br/>
+Gebruik de layer-switcher in de side-sheet om `layer-1` en `layer-2` te tonen of te verbergen en het gedrag te testen:
+
+- Verberg één kaartlaag → de selectie-actie blijft actief (selecteren in de zichtbare laag werkt nog).
+- Verberg beide kaartlagen → de selectie-actie deactiveert.
+- Maak opnieuw één kaartlaag zichtbaar → de selectie-actie wordt terug actief.
+
+<Canvas of={VlMapMultiselectActionsStories.MapMultiselectActionsMultilayerVisibility} />
+
+
+<details>
+    <summary>Toon code</summary>
+    <Source code={multilayerVisibilityStorySource} language="ts" dark={true} />
 </details>
 
 

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-util.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories-util.ts
@@ -1,0 +1,49 @@
+import { html } from 'lit';
+
+const featuresLayer1 = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: 1,
+            geometry: {
+                type: 'Point',
+                coordinates: [146055.0, 196908.0],
+            },
+        },
+    ],
+};
+
+const featuresLayer2 = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: 2,
+            geometry: {
+                type: 'Point',
+                coordinates: [149055.0, 199908.0],
+            },
+        },
+    ],
+};
+
+// De select-action is aan beide layers gekoppeld.
+const layers = ['layer-1', 'layer-2'];
+
+export const component = (active: boolean, defaultActive: boolean) => html`
+    <vl-map lambert2008>
+        <vl-map-side-sheet>
+            <vl-map-layer-switcher title="Kaartlagen" .layers=${layers}></vl-map-layer-switcher>
+        </vl-map-side-sheet>
+        <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+        <vl-map-features-layer .features=${featuresLayer1} name="layer-1" projection-code="EPSG:31370">
+            <vl-map-layer-circle-style color="rgba(0, 255, 21, 1)" border-color="#000000"></vl-map-layer-circle-style>
+        </vl-map-features-layer>
+        <vl-map-features-layer .features=${featuresLayer2} name="layer-2" projection-code="EPSG:31370">
+            <vl-map-layer-circle-style color="rgba(255, 230, 21, 1)" border-color="#000000"></vl-map-layer-circle-style>
+        </vl-map-features-layer>
+        <vl-map-multiselect-actions .active=${active} .layers=${layers} ?default-active=${defaultActive}>
+        </vl-map-multiselect-actions>
+    </vl-map>
+`;

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/stories/vl-map-multiselect-actions.stories.ts
@@ -3,11 +3,14 @@ import { Meta } from '@storybook/web-components-vite';
 import '../../../../../../vl-map';
 import '../../../../../baselayer/vl-map-base-layer-grb-gray/vl-map-base-layer-grb-gray';
 import '../../../../../layer-style/vl-map-layer-circle-style/vl-map-layer-circle-style';
+import '../../../../../layer-switcher/vl-map-layer-switcher';
 import '../../../../../layer/vector-layer/vl-map-features-layer/vl-map-features-layer';
+import '../../../../../side-sheet/vl-map-side-sheet';
 import '../../select-actions/vl-map-select-actions';
 import '../vl-map-multiselect-actions';
 import { mapMultiselectActionsArgs, mapMultiselectActionsArgTypes } from './vl-map-multiselect-actions.stories-arg';
 import { component as defaultComponent } from './vl-map-multiselect-actions.stories-default';
+import { component as multilayerVisibilityComponent } from './vl-map-multiselect-actions.stories-util';
 import mapMultiselectActionsDoc from './vl-map-multiselect-actions.stories-doc.mdx';
 
 export default {
@@ -29,4 +32,16 @@ export const MapMultiselectActionsDefault = story(mapMultiselectActionsArgs, ({ 
 MapMultiselectActionsDefault.storyName = 'vl-map-multiselect-actions - default';
 MapMultiselectActionsDefault.args = {
     active: true,
+};
+
+export const MapMultiselectActionsMultilayerVisibility = story(
+    mapMultiselectActionsArgs,
+    ({ active, defaultActive }) => {
+        return multilayerVisibilityComponent(active, defaultActive);
+    }
+);
+MapMultiselectActionsMultilayerVisibility.storyName = 'vl-map-multiselect-actions - multilayer visibility';
+MapMultiselectActionsMultilayerVisibility.args = {
+    active: true,
+    defaultActive: true,
 };

--- a/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.cy.ts
+++ b/libs/map/src/components/action/layer-action/select-action/multiselect-actions/vl-map-multiselect-actions.cy.ts
@@ -75,6 +75,31 @@ describe('cypress-component - map - vl-map-multiselect-actions', () => {
         cy.checkA11y('vl-map-multiselect-actions');
     });
 
+    it('should stay active while at least one coupled layer is visible and deactivate only when all are hidden', () => {
+        cy.get('vl-map').should('exist');
+        cy.get('vl-map-multiselect-actions').should('exist');
+        cy.wait(1000);
+
+        cy.document().then((doc) => {
+            const vlMap = doc.querySelector('vl-map') as VlMap;
+            const multiselectActions = doc.querySelector('vl-map-multiselect-actions') as VlMapMultiselectActions;
+            const layerElements = Array.from(
+                doc.querySelectorAll('vl-map-features-layer')
+            ) as VlMapFeaturesLayer[];
+
+            expect(vlMap.activeAction).to.equal(multiselectActions.action);
+
+            layerElements[0].visible = false;
+            expect(vlMap.activeAction).to.equal(multiselectActions.action);
+
+            layerElements[1].visible = false;
+            expect(vlMap.activeAction).to.not.equal(multiselectActions.action);
+
+            layerElements[0].visible = true;
+            expect(vlMap.activeAction).to.equal(multiselectActions.action);
+        });
+    });
+
     it('should fire the onSelect event', () => {
         cy.window().then((win) => {
             // @ts-ignore

--- a/libs/map/src/components/action/vl-map-action.ts
+++ b/libs/map/src/components/action/vl-map-action.ts
@@ -74,8 +74,9 @@ export class VlMapAction extends BaseHTMLElement {
     }
 
     activate(): void {
-        // Do not activate action if its layer is invisible
-        if (this.action && this.action.layer.get('visible')) {
+        // Een multi-layer action blijft activeerbaar zolang minstens één gekoppelde layer
+        // zichtbaar is; baseer dit dus niet op de ene proxy-layer.
+        if (this.action && this.action.hasVisibleLayer()) {
             this._mapElement.changeActiveAction(this.action);
         }
     }
@@ -85,7 +86,7 @@ export class VlMapAction extends BaseHTMLElement {
         if (this.action && this.action === this._mapElement.activeAction) {
             const actionIsNotDefault = this.action !== this._mapElement.defaultAction;
             const layerIsVisible =
-                this._mapElement.defaultAction && this._mapElement.defaultAction.layer.get('visible');
+                this._mapElement.defaultAction && this._mapElement.defaultAction.hasVisibleLayer();
             this._mapElement.changeActiveAction(actionIsNotDefault && layerIsVisible && this._mapElement.defaultAction);
         }
     }

--- a/libs/map/src/vl-map.ts
+++ b/libs/map/src/vl-map.ts
@@ -288,7 +288,10 @@ export class VlMap extends BaseHTMLElement {
 
         if (actions) {
             actions.forEach((action) => {
-                if (layerElement.visible) {
+                // Een action kan aan meerdere layers gekoppeld zijn; baseer (de)activatie op
+                // de zichtbaarheid van al die layers, niet op de ene layer die net wijzigde.
+                const hasVisibleLayer = action.hasVisibleLayer();
+                if (hasVisibleLayer) {
                     // Activate default active action on layer if applicable
                     if (!this.activeAction && action === this.defaultAction) {
                         action.element.activate();
@@ -306,7 +309,7 @@ export class VlMap extends BaseHTMLElement {
                 // Enable or disable the control of the action
                 const actionControl = action.getControl();
                 if (actionControl) {
-                    actionControl.get('element').setDisabled(!layerElement.visible);
+                    actionControl.get('element').setDisabled(!hasVisibleLayer);
                 }
             });
         }


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-697
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC359

Je kan dit testen via de nieuwe story: http://localhost:8080/?path=/story/map-action-layer-action-select-action-multiselect-actions--map-multiselect-actions-multilayer-visibility
Als je die story in de oude versie steekt zal je zien dat dat niet logisch werkte, je kwam vast te zitten, de verborgen layer met selectie blokkeerde een nieuwe selectie op de zichtbare layer.

## Samenvatting
Een `vl-map-select-actions` die aan meerdere layers gekoppeld is, blijft nu actief en bruikbaar zolang minstens één gekoppelde layer zichtbaar is, en deactiveert pas wanneer alle gekoppelde layers verborgen zijn. Voorheen verloren consumers met multi-layer selectie hun selectie-actie zodra één layer werd verborgen of getoond.

## Wijzigingen
- Multi-layer select-actions blijven actief zolang ≥1 gekoppelde layer zichtbaar is; deactiveren gebeurt pas wanneer alle gekoppelde layers verborgen zijn.
- Heractivatie en het enablen/disablen van de action-control steunen nu op alle gekoppelde layers, niet langer op de ene gewijzigde layer.
- Visibility-events van een niet-proxy-layer koppelen correct door naar de juiste action.
- Single-layer actions behouden hun bestaande gedrag.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. Single-layer actions (`vl-map-select-action`, `vl-map-layer-action`) houden identieke semantiek.

## Succescriteria
- [x] Een `vl-map-select-actions` met meerdere layers blijft actief zolang ≥1 gekoppelde layer zichtbaar is.
- [x] De action deactiveert pas wanneer alle gekoppelde layers verborgen zijn.
- [x] Heractivatie en het enablen/disablen van de control baseren op alle gekoppelde layers.
- [x] Bestaand gedrag voor single-layer actions blijft ongewijzigd — gedekt door regressietests.
- [x] Visibility-events voor een niet-proxy-layer worden correct doorgekoppeld.
