### PR TITLE
fix: FLUX-720 - vl-select - reset value bij slot-mutatie zonder selectie

### DIFF
--- a/libs/components/src/form/select/vl-select.component.cy.ts
+++ b/libs/components/src/form/select/vl-select.component.cy.ts
@@ -409,6 +409,32 @@ describe('vl-select - options', () => {
                         .not.to.be.undefined
             );
     });
+
+    it('should reset value to empty when slotted options change to a set without a selection', () => {
+        cy.mount(
+            html`<vl-select placeholder="Selecteer">
+                <option value="hasselt">Hasselt</option>
+                <option value="turnhout" selected>Turnhout</option>
+            </vl-select>`
+        );
+
+        cy.get('vl-select').should(($vlSelect) => {
+            expect($vlSelect[0].value).to.equal('turnhout');
+        });
+
+        cy.get('vl-select').then(($vlSelect) => {
+            $vlSelect[0].innerHTML = `
+                <option value="hasselt">Hasselt</option>
+                <option value="turnhout">Turnhout</option>
+            `;
+        });
+
+        cy.get('vl-select').should(($vlSelect) => {
+            expect($vlSelect[0].value).to.equal('');
+        });
+
+        cy.get('vl-select').shadow().find('option:selected').should('contain', 'Selecteer');
+    });
 });
 
 describe('vl-select - in form', () => {

--- a/libs/components/src/form/select/vl-select.component.ts
+++ b/libs/components/src/form/select/vl-select.component.ts
@@ -198,9 +198,15 @@ export class VlSelectComponent extends FormControl {
 
     private onSlotChange() {
         this.parseSlottedOptions();
-        const selected = this.getSelectedOption();
-        if (selected) this.value = selected.value;
+        this.syncValueWithOptions();
         this.requestUpdate();
+    }
+
+    private syncValueWithOptions() {
+        if (this.getAllOptions().length > 0) {
+            // Reset naar '' wanneer er opties zijn maar geen selectie (placeholder), zonder de value te wissen
+            this.value = this.getSelectedOption()?.value || '';
+        }
     }
 
     private getSelectedOption(): SelectOption | undefined {
@@ -225,10 +231,16 @@ export class VlSelectComponent extends FormControl {
     }
 
     private setupSlotObserver() {
-        this.slotObserver = new MutationObserver(() => {
+        this.slotObserver = new MutationObserver((mutations) => {
+            const optionsChanged = mutations.some(
+                (mutation) => mutation.type === 'childList' || mutation.target !== this
+            );
+            if (!optionsChanged) {
+                return;
+            }
+
             this.parseSlottedOptions();
-            const selected = this.getSelectedOption();
-            if (selected) this.value = selected.value;
+            this.syncValueWithOptions();
             this.requestUpdate();
         });
 


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-720
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC362 ✅ 

`vl-select` reset z'n value nu correct na een optie-wijziging: zodra er opties zijn maar geen enkele selected is, wordt value op '' gezet (placeholder) i.p.v. de oude waarde te behouden. De MutationObserver negeert daarbij host-attribuut-wijzigingen (bv. value via setFormData) zodat een extern gezette waarde niet ongewenst gewist wordt.