### PR TITLE
fix: FLUX-295 - vl-typography - observer heraangemaakt na verplaatsen in DOM

### DIFF
--- a/libs/components/src/block/typography/vl-typography.component.cy.ts
+++ b/libs/components/src/block/typography/vl-typography.component.cy.ts
@@ -1,0 +1,99 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { html } from 'lit';
+import { VlTypography } from './vl-typography.component';
+
+registerWebComponents([VlTypography]);
+
+describe('cypress-component - block components - vl-typography', () => {
+    it('should mount', () => {
+        cy.mount(html`<vl-typography><p>tekst</p></vl-typography>`);
+
+        cy.get('vl-typography').shadow();
+    });
+
+    it('should be accessible', () => {
+        cy.mount(html`<vl-typography><p>tekst</p></vl-typography>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-typography');
+    });
+
+    it('should render the light DOM content in the shadow DOM', () => {
+        cy.mount(html`<vl-typography><p>initial text</p></vl-typography>`);
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'initial text');
+    });
+
+    it('should replace template parameters', () => {
+        cy.mount(html`
+            <vl-typography parameters='{"name": "Jos"}'><p>Hello &#36;{parameter.name}</p></vl-typography>
+        `);
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'Hello Jos');
+    });
+
+    it('should update the shadow DOM when the light DOM changes', () => {
+        cy.mount(html`<vl-typography><p>initial text</p></vl-typography>`);
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'initial text');
+
+        cy.get('vl-typography').then(($typography) => {
+            $typography[0].innerHTML = '<p>updated text</p>';
+        });
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'updated text');
+    });
+
+    it('should update the shadow DOM when the light DOM changes after the component was moved in the DOM', () => {
+        cy.mount(html`
+            <div id="first"><vl-typography><p>initial text</p></vl-typography></div>
+            <div id="second"></div>
+        `);
+
+        cy.get('vl-typography').then(($typography) => {
+            const typography = $typography[0];
+            typography.ownerDocument.getElementById('second')?.appendChild(typography);
+        });
+        cy.get('#second vl-typography').shadow().find('#content p').should('contain.text', 'initial text');
+
+        cy.get('vl-typography').then(($typography) => {
+            $typography[0].innerHTML = '<p>updated text</p>';
+        });
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'updated text');
+    });
+
+    it('should process a light DOM mutation only once after the component was moved multiple times', () => {
+        cy.mount(html`
+            <div id="first"></div>
+            <div id="second"><vl-typography><p>initial text</p></vl-typography></div>
+        `);
+
+        cy.get('vl-typography').then(($typography) => {
+            const typography = $typography[0];
+            const document = typography.ownerDocument;
+            document.getElementById('first')?.appendChild(typography);
+            document.getElementById('second')?.appendChild(typography);
+            cy.spy(typography as any, '__processSlotElements').as('processSlotElements');
+            typography.innerHTML = '<p>updated text</p>';
+        });
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'updated text');
+        cy.get('@processSlotElements').should('have.been.calledOnce');
+    });
+
+    it('should render content that was changed while the component was detached from the DOM', () => {
+        cy.mount(html`
+            <div id="first"><vl-typography><p>initial text</p></vl-typography></div>
+            <div id="second"></div>
+        `);
+
+        cy.get('vl-typography').then(($typography) => {
+            const typography = $typography[0];
+            typography.remove();
+            typography.innerHTML = '<p>updated text</p>';
+            typography.ownerDocument.getElementById('second')?.appendChild(typography);
+        });
+
+        cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'updated text');
+    });
+});

--- a/libs/components/src/block/typography/vl-typography.component.ts
+++ b/libs/components/src/block/typography/vl-typography.component.ts
@@ -24,8 +24,6 @@ export class VlTypography extends BaseHTMLElement {
             titlesStyle.styleSheet!,
         ];
         super(html, styleSheets);
-
-        this._observer = this.__observeSlotElements(() => this.__processSlotElements());
     }
 
     static get _observedAttributes() {
@@ -49,11 +47,15 @@ export class VlTypography extends BaseHTMLElement {
     connectedCallback() {
         super.connectedCallback();
 
+        if (!this._observer) {
+            this._observer = this.__observeSlotElements(() => this.__processSlotElements());
+        }
         this.__processSlotElements();
     }
 
     disconnectedCallback() {
         this._observer?.disconnect();
+        this._observer = undefined;
     }
 
     _parametersChangedCallback() {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-295
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC366

De wijziging is zoals voorgesteld in het ticket. Er waren nog geen component testen die zijn toegevoegd.

Dit is nog een component conform de oude opzet, die moet eens herschreven worden. Zeker die css moet anders (niet meer van DV), e2e testen moeten weggewerkt worden -> allemaal out-of-scope voor dit ticket.


## Samenvatting
Wijzigingen aan de light-DOM-inhoud van `vl-typography` worden opnieuw gerenderd nadat de component verplaatst werd in de DOM. Voorheen stopte de component met updaten zodra hij eenmaal losgekoppeld en opnieuw toegevoegd was.

## Wijzigingen
- Na het verplaatsen van `<vl-typography>` (detach + re-attach) worden `innerHTML`-wijzigingen weer verwerkt in de shadow DOM.
- Inhoud die wijzigde terwijl de component losgekoppeld was, wordt bij het opnieuw toevoegen alsnog gesynchroniseerd.
- Herhaald verplaatsen veroorzaakt geen dubbele verwerking van mutaties.
- Bij het loskoppelen wordt de interne observer netjes opgeruimd (geen memory leak).
- Nieuwe Cypress component-testspec voor `vl-typography` dekt deze scenario's plus het bestaande gedrag (initiële rendering, light-DOM-mutaties, `parameters`-substitutie, accessibility).

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Na verplaatsen in de DOM (detach + re-attach) worden wijzigingen aan de light-DOM `innerHTML` opnieuw verwerkt — observer wordt heraangemaakt bij reconnect; gedekt door test.
- [x] Bij `disconnectedCallback` wordt de observer netjes ge-disconnect en de referentie gereset — verse observer bij elke reconnect, geen leak.
- [x] Herhaald verplaatsen blijft correct werken zonder dubbele observers — guard bij aanmaak; spy-test verifieert exact één verwerking per mutatie.
- [x] Bestaand gedrag (`parameters`-substitutie, initiële rendering) blijft ongewijzigd — expliciet getest; geen API-wijziging.
- [x] Een test dekt "verplaats component, wijzig daarna innerHTML, verwacht update" — nieuwe Cypress component-spec (8 tests), incl. het scenario "mutatie tijdens detached state".
