### PR TITLE
ON HOLD - fix: FLUX-723 - vl-input-field - badInput i.p.v. valueMissing bij komma-invoer

### DIFF
--- a/apps/storybook/docs/f_patronen/formulier/2_validatie/formulier-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/2_validatie/formulier-validatie.mdx
@@ -33,6 +33,12 @@ controleert.
 Hieronder een overzicht van de gebruikte attributen van [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState#instance_properties) met hun betekenis en bijhorende
 [validation attributen](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation#validation-related_attributes):
 
+- `badInput`: als de browser de ingevoerde tekst niet kan omzetten naar een waarde, bv. "12,3" in een
+   `vl-input-field` met `type="number"` in een browser die de komma niet als decimaalteken aanvaardt (Safari, Firefox).
+   Het veld toont dan zichtbaar tekst, maar de native waarde is leeg. Voorzie hiervoor een `vl-form-message` met
+   `state="badInput"` (bv. "Gelieve een geldig getal in te vullen, gebruik een punt als decimaalteken."), anders krijgt
+   de gebruiker enkel de foutstijl zonder boodschap. Zolang `badInput` actief is, wordt `valueMissing` niet
+   gerapporteerd.
 - `customError`: als je custom validatie instelt, [zie hier](/docs/patronen-formulier-aangepaste-validatie--documentatie) hoe je zelf een custom validator schrijft.
 - `patternMismatch`: als de waarde niet overeenkomt met het patroon dat is ingesteld door het `pattern` attribuut.
 - `rangeOverflow`: als de waarde hoger is dan de waarde die is gespecifieerd door het `max` attribuut.

--- a/libs/components/src/form/input-field/validators.ts
+++ b/libs/components/src/form/input-field/validators.ts
@@ -1,4 +1,31 @@
-import { Validator } from '@open-wc/form-control';
+import { FormValue, requiredValidator, SyncValidator, Validator } from '@open-wc/form-control';
+
+type FormControlWithValidationTarget = HTMLElement & { validationTarget: HTMLInputElement | undefined | null };
+
+// Vóór de eerste render is validationTarget nog null; dan is er per definitie geen badInput.
+const hasNativeBadInput = (instance: FormControlWithValidationTarget): boolean =>
+    !!instance.validationTarget?.validity.badInput;
+
+export const badInputValidator: Validator = {
+    key: 'badInput',
+    message: 'Please enter a valid value.',
+    isValid(instance: FormControlWithValidationTarget): boolean {
+        return !hasNativeBadInput(instance);
+    },
+};
+
+export const badInputAwareRequiredValidator: Validator = {
+    ...requiredValidator,
+    isValid(instance: FormControlWithValidationTarget, value: FormValue): boolean {
+        // Bij badInput geeft de native input een lege value terug terwijl er zichtbaar tekst
+        // staat — valueMissing zou dan misleidend zijn, badInput dekt die toestand.
+        if (hasNativeBadInput(instance)) {
+            return true;
+        }
+
+        return (requiredValidator as SyncValidator).isValid(instance, value);
+    },
+};
 
 export const minValueValidator: Validator = {
     attribute: 'min',

--- a/libs/components/src/form/input-field/vl-input-field.component.cy.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.cy.ts
@@ -309,6 +309,117 @@ describe('cypress-component - form components - vl-input-field', () => {
     });
 });
 
+describe('cypress-component - form components - vl-input-field - badInput', () => {
+    // Programmatic value-assignment (zoals cy.type op een number-input) zet nooit badInput op de
+    // native input; alleen échte toetsenbordinvoer doet dat (bv. "12,3" in Safari). Het
+    // Safari-gedrag wordt daarom gesimuleerd door de native validity te stubben: lege value,
+    // badInput true, gevolgd door een echt input-event.
+    const simulateNativeBadInput = (input: HTMLInputElement) => {
+        Object.defineProperty(input, 'validity', {
+            configurable: true,
+            value: { badInput: true, valid: false },
+        });
+        input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    };
+
+    const restoreNativeValidity = (input: HTMLInputElement) => {
+        Reflect.deleteProperty(input, 'validity');
+    };
+
+    const mountNumberForm = () =>
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-input-field id="aantal" name="aantal" type="number" required></vl-input-field>
+                <vl-form-message for="aantal" state="valueMissing">Gelieve een aantal in te vullen.</vl-form-message>
+                <vl-form-message for="aantal" state="badInput">Gelieve een geldig getal in te vullen.</vl-form-message>
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+    it('should report badInput instead of valueMissing, also without a value change (badInput op een leeg veld)', () => {
+        mountNumberForm();
+
+        // De value blijft '' vóór en na het input-event: dit dekt expliciet de hervalidatie
+        // wanneer Lit geen update triggert.
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .then(($input) => simulateNativeBadInput($input[0] as HTMLInputElement));
+        cy.get('vl-input-field').should(($el) => {
+            const component = $el.get(0) as VlInputFieldComponent;
+            expect(component.validity.badInput).to.be.true;
+            expect(component.validity.valueMissing).to.be.false;
+            expect(component.validity.valid).to.be.false;
+        });
+    });
+
+    it('should report badInput when unparsable input clears the native value (Safari komma-scenario)', () => {
+        mountNumberForm();
+
+        cy.get('vl-input-field').shadow().find('input').type('12');
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .then(($input) => {
+                const input = $input[0] as HTMLInputElement;
+                input.value = '';
+                simulateNativeBadInput(input);
+            });
+        // .should(fn) retryt tot de asynchrone Lit-update en hervalidatie verwerkt zijn.
+        cy.get('vl-input-field').should(($el) => {
+            const component = $el.get(0) as VlInputFieldComponent;
+            expect(component.validity.badInput).to.be.true;
+            expect(component.validity.valueMissing).to.be.false;
+        });
+    });
+
+    it('should show the badInput message and not the valueMissing message on submit', () => {
+        mountNumberForm();
+
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .then(($input) => simulateNativeBadInput($input[0] as HTMLInputElement));
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="badInput"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .should('have.attr', 'aria-description', 'Gelieve een geldig getal in te vullen.');
+    });
+
+    it('should still report valueMissing for an empty required field', () => {
+        mountNumberForm();
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="badInput"]').should('not.have.attr', 'show');
+    });
+
+    it('should recover once the input becomes parsable', () => {
+        mountNumberForm();
+
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .then(($input) => simulateNativeBadInput($input[0] as HTMLInputElement));
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="badInput"]').should('have.attr', 'show');
+
+        cy.get('vl-input-field')
+            .shadow()
+            .find('input')
+            .then(($input) => restoreNativeValidity($input[0] as HTMLInputElement));
+        cy.get('vl-input-field').shadow().find('input').type('12');
+        cy.get('vl-form-message[state="badInput"]').should('not.have.attr', 'show');
+        cy.get('vl-input-field').should(($el) => {
+            const component = $el.get(0) as VlInputFieldComponent;
+            expect(component.validity.valid).to.be.true;
+        });
+    });
+});
+
 describe('cypress-component - form components - vl-input-field - success message', () => {
     // De aanwezigheid van een vl-form-message met state="valid" is de opt-in voor de auto-success.
     const mountInForm = (withSuccessMessage = true) =>

--- a/libs/components/src/form/input-field/vl-input-field.component.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.ts
@@ -5,7 +5,13 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { FormControl } from '../form-control';
-import { maxValueValidator, minValueValidator, patternValidator } from './validators';
+import {
+    badInputAwareRequiredValidator,
+    badInputValidator,
+    maxValueValidator,
+    minValueValidator,
+    patternValidator,
+} from './validators';
 import { inputFieldStyles } from './vl-input-field.css';
 import { inputFieldDefaults } from './vl-input-field.defaults';
 
@@ -35,7 +41,11 @@ export class VlInputFieldComponent extends FormControl {
     protected dispatchInput = false;
 
     static formControlValidators = [
-        ...FormControl.formControlValidators,
+        // De standaard requiredValidator wordt vervangen door een badInput-bewuste variant,
+        // anders rapporteert een number-veld met onparsebare invoer (lege native value) valueMissing.
+        ...FormControl.formControlValidators.filter((validator) => validator.key !== 'valueMissing'),
+        badInputAwareRequiredValidator,
+        badInputValidator,
         minLengthValidator,
         maxLengthValidator,
         minValueValidator,
@@ -143,7 +153,14 @@ export class VlInputFieldComponent extends FormControl {
 
     protected onInput(event: Event & { target: HTMLInputElement }) {
         this.dispatchInput = true;
-        this.value = event?.target?.value;
+
+        const value = event?.target?.value ?? '';
+        if (value === this.value) {
+            // Een number-input met onparsebare invoer houdt een lege value maar wisselt wel van
+            // badInput-toestand; zonder value-wijziging triggert Lit geen update, dus hervalideer expliciet.
+            this.setValue(value);
+        }
+        this.value = value;
     }
 
     protected onUpdated(changedProperties: Map<string, unknown>) {


### PR DESCRIPTION
Navraag via het ticket gedaan:
- ik kan dit probleem niet reproduceren in Storybook
- deze PR lost hun feitelijk probleem niet op
- deze component lijkt niet de juiste voor wat ze functioneel willen

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-723
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC367

## Samenvatting
Een verplicht `vl-input-field` met `type="number"` toont niet langer de `valueMissing`-melding ("verplicht") wanneer er zichtbaar tekst in het veld staat die de browser niet als getal kan parsen, zoals een decimale komma ("12,3") in Safari/Firefox. De component rapporteert in dat geval de validity-state `badInput`, zodat de consumer een passende boodschap kan tonen.

## Wijzigingen
- `vl-input-field` rapporteert voortaan `validity.badInput` wanneer de native input onparsebare invoer heeft (lege native waarde terwijl er zichtbaar tekst staat).
- Zolang `badInput` actief is, wordt `valueMissing` onderdrukt — een required number-veld toont dus geen misleidende "verplicht"-melding meer bij komma-invoer.
- Een `vl-form-message` met `state="badInput"` toont nu de bijhorende boodschap; bestaand gedrag voor lege velden, range- en pattern-validatie blijft ongewijzigd.
- Documentatie (`formulier-validatie.mdx`) beschrijft de `badInput`-state en raadt aan een `state="badInput"`-message te voorzien.

## Backwards compatibility
Additieve wijziging: nieuwe `badInput` validity-state en bijhorende `vl-form-message state="badInput"`. Velden die voorheen (foutief) `valueMissing` toonden bij komma-invoer tonen nu `badInput`; consumers zonder een `badInput`- of algemene message zien enkel de foutstijl zonder tekst — voorzie daarom een `state="badInput"`-message. Geen breaking API-wijziging.

## Succescriteria
- [x] Geen `valueMissing`-melding bij zichtbaar onparsebare tekst — `badInputAwareRequiredValidator` geeft valid terug zolang de native input `badInput` rapporteert.
- [x] Component rapporteert `badInput` in haar `validity`, consumeerbaar via `<vl-form-message state="badInput">` — `badInputValidator` + bestaande `showFormMessage()`-flow (incl. `aria-description`).
- [x] Bestaand gedrag voor lege velden, range- en pattern-validatie ongewijzigd — required-pad delegeert naar de upstream `requiredValidator`; alle bestaande input-field- en masked-tests blijven groen.
- [x] Cypress-test die het scenario afdekt (native `badInput === true` → invalid met state `badInput`, niet `valueMissing`) — aanwezig, plus recovery-, leeg-veld- en aria-description-tests.
