### PR TITLE
feat: FLUX-696 - vl-map-features-layer - OpenLayers features rechtstreeks toevoegen

### DIFF
--- a/libs/map/src/components/layer/vector-layer/vl-map-features-layer/stories/vl-map-features-layer.stories-doc.mdx
+++ b/libs/map/src/components/layer/vector-layer/vl-map-features-layer/stories/vl-map-features-layer.stories-doc.mdx
@@ -26,6 +26,28 @@ import { VlMapFeaturesLayer } from '@domg-wc/map';
 <Canvas of={VlMapFeaturesLayerStories.MapFeaturesLayerDefault} />
 
 
+## OpenLayers Feature-objecten rechtstreeks toevoegen
+
+Naast de GeoJSON-flows (`features`-attribuut, `addFeature`, `addFeatureCollection`) kan je ook OpenLayers
+`Feature`-objecten rechtstreeks op de laag zetten met `addFeatures(features)` (toevoegen) en `setFeatures(features)`
+(alles vervangen). Properties gezet via `feature.set(...)` en `feature.setId(...)` blijven daarbij behouden - er
+gebeurt geen GeoJSON-serialisatie.
+
+Let op: anders dan de GeoJSON-flows transformeren deze methodes de geometrie niet. De features moeten dus al in de
+kaartprojectie staan. Net als `addFeature` falen ze stil wanneer ze vóór `connectedCallback` worden aangeroepen.
+
+```js
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+
+const feature = new Feature({ geometry: new Point([x, y]) });
+feature.setId(1);
+feature.set('emissiebron', emissiebron);
+
+layer.setFeatures([feature]);
+```
+
+
 ## Configuratie
 
 <ArgTypes of={VlMapFeaturesLayerStories.MapFeaturesLayerDefault} />

--- a/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.cy.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.cy.ts
@@ -336,6 +336,84 @@ describe('cypress-component - map - vl-map-features-layer', () => {
         });
     });
 
+    it('kan programmatorisch OpenLayers Feature-objecten toevoegen met behoud van object-properties', () => {
+        cy.mount(mapFixture);
+        cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {
+            cy.wrap(vlMap.ready).then(() => {
+                expect(vlMapFeaturesLayer.layer.getSource().getFeatures()).to.be.lengthOf(1);
+
+                const reference = { naam: 'emissiebron' };
+                const feature = new OlFeature({ geometry: new OlPoint([647051, 697907]) });
+                feature.setId(2);
+                feature.set('emissiebron', reference);
+
+                vlMapFeaturesLayer.addFeatures([feature]);
+
+                expect(vlMapFeaturesLayer.layer.getSource().getFeatures()).to.be.lengthOf(2);
+                const added = vlMapFeaturesLayer.getFeature(2);
+                expect(added).to.exist;
+                expect(added.get('emissiebron')).to.equal(reference);
+            });
+        });
+    });
+
+    it('kan programmatorisch OpenLayers Feature-objecten toevoegen aan een laag met cluster', () => {
+        cy.mount(mapClusterFixture);
+        cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {
+            cy.wrap(vlMap.ready).then(() => {
+                expect(vlMapFeaturesLayer.source.getSource().getFeatures()).to.be.lengthOf(1);
+
+                const feature = new OlFeature({ geometry: new OlPoint([647051, 697907]) });
+                feature.setId(2);
+
+                vlMapFeaturesLayer.addFeatures([feature]);
+
+                expect(vlMapFeaturesLayer.source.getSource().getFeatures()).to.be.lengthOf(2);
+                expect(vlMapFeaturesLayer.getFeature(1)).to.exist;
+                expect(vlMapFeaturesLayer.getFeature(2)).to.exist;
+            });
+        });
+    });
+
+    it('kan programmatorisch alle features vervangen door OpenLayers Feature-objecten', () => {
+        cy.mount(mapFixture);
+        cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {
+            cy.wrap(vlMap.ready).then(() => {
+                expect(vlMapFeaturesLayer.layer.getSource().getFeatures()).to.be.lengthOf(1);
+                expect(vlMapFeaturesLayer.getFeature(1)).to.exist;
+
+                const feature2 = new OlFeature({ geometry: new OlPoint([647051, 697907]) });
+                const feature3 = new OlFeature({ geometry: new OlPoint([657050, 707908]) });
+                feature2.setId(2);
+                feature3.setId(3);
+
+                vlMapFeaturesLayer.setFeatures([feature2, feature3]);
+
+                expect(vlMapFeaturesLayer.layer.getSource().getFeatures()).to.be.lengthOf(2);
+                expect(vlMapFeaturesLayer.getFeature(1)).to.be.undefined;
+                expect(vlMapFeaturesLayer.getFeature(2)).to.exist;
+                expect(vlMapFeaturesLayer.getFeature(3)).to.exist;
+            });
+        });
+    });
+
+    it('wanneer programmatorisch OpenLayers Feature-objecten aan een laag met auto zoom toegevoegd worden zal de map daar naartoe zoomen', () => {
+        cy.mount(mapAutoExtentFixture);
+        cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {
+            cy.wrap(vlMap.ready).then(() => {
+                cy.spy(vlMapFeaturesLayer, 'rerender').as('rerender');
+
+                const feature = new OlFeature({ geometry: new OlPoint([646051.3938802485, 697907.7169700935]) });
+                feature.setId(3);
+
+                vlMapFeaturesLayer.setFeatures([feature]);
+
+                cy.get('@rerender').should('have.been.called');
+                expect(vlMap.map.getView().getCenter()).to.deep.equal([646051.3938802485, 697907.7169700935]);
+            });
+        });
+    });
+
     it('kan programmatorisch feature collection toevoegen', () => {
         cy.mount(mapFixture);
         cy.runTestFor2<VlMap, VlMapFeaturesLayer>('vl-map', 'vl-map-features-layer', (vlMap, vlMapFeaturesLayer) => {

--- a/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.ts
+++ b/libs/map/src/components/layer/vector-layer/vl-map-features-layer/vl-map-features-layer.ts
@@ -1,4 +1,5 @@
 import { webComponent } from '@domg-wc/common';
+import OlFeature from 'ol/Feature';
 import { isEmpty as isEmptyExtent } from 'ol/extent';
 import OlGeoJSON from 'ol/format/GeoJSON';
 import OlPoint from 'ol/geom/Point';
@@ -125,9 +126,10 @@ export class VlMapFeaturesLayer extends VlMapVectorLayer {
     }
 
     /**
-     * Verwijdert alle features van de laag
+     * Verwijdert alle features van de laag, ongeacht hoe ze toegevoegd werden
+     * (GeoJSON of rechtstreekse OpenLayers Feature-objecten).
      */
-    clearFeatures() {
+    clearFeatures () {
         if (this.__featuresSource) {
             this.__featuresSource.clear();
             this._featuresChanged();
@@ -135,9 +137,11 @@ export class VlMapFeaturesLayer extends VlMapVectorLayer {
     }
 
     /**
-     * Voegt een feature toe aan de kaartlaag via geojson
+     * Voegt één feature toe aan de kaartlaag via GeoJSON. De GeoJSON wordt ge-parsed en de geometrie
+     * wordt van de laag- naar de kaartprojectie getransformeerd.
+     * Gebruik {@link addFeatures} om bestaande OpenLayers Feature-objecten rechtstreeks toe te voegen.
      *
-     * @param {string} feature
+     * @param {string} feature - GeoJSON van één feature.
      */
     addFeature(feature) {
         if (this.__featuresSource) {
@@ -147,13 +151,44 @@ export class VlMapFeaturesLayer extends VlMapVectorLayer {
     }
 
     /**
-     * Voegt een featurecollection toe aan de kaartlaag via geojson
+     * Voegt meerdere features toe aan de kaartlaag via een GeoJSON FeatureCollection. De GeoJSON wordt
+     * ge-parsed en de geometrieën worden van de laag- naar de kaartprojectie getransformeerd.
+     * Gebruik {@link addFeatures} om bestaande OpenLayers Feature-objecten rechtstreeks toe te voegen.
      *
-     * @param {string} featureCollection
+     * @param {string} featureCollection - GeoJSON FeatureCollection.
      */
     addFeatureCollection(featureCollection) {
         if (this.__featuresSource) {
             this.__featuresSource.addFeatures(this._geoJSON.readFeatures(featureCollection, this.__readOptions));
+            this._featuresChanged();
+        }
+    }
+
+    /**
+     * Voegt OpenLayers Feature-objecten rechtstreeks toe aan de kaartlaag, zonder GeoJSON-serialisatie.
+     * Properties gezet via feature.set(...) en feature.setId(...) blijven behouden. De geometrieën worden
+     * niet getransformeerd: ze moeten al in de kaartprojectie staan (anders dan de GeoJSON-flows).
+     *
+     * @param {OlFeature[]} features
+     */
+    addFeatures(features: OlFeature[]) {
+        if (this.__featuresSource) {
+            this.__featuresSource.addFeatures(features);
+            this._featuresChanged();
+        }
+    }
+
+    /**
+     * Vervangt alle features op de kaartlaag door de meegegeven OpenLayers Feature-objecten, zonder
+     * GeoJSON-serialisatie. Properties gezet via feature.set(...) en feature.setId(...) blijven behouden.
+     * De geometrieën worden niet getransformeerd: ze moeten al in de kaartprojectie staan.
+     *
+     * @param {OlFeature[]} features
+     */
+    setFeatures(features: OlFeature[]) {
+        if (this.__featuresSource) {
+            this.__featuresSource.clear();
+            this.__featuresSource.addFeatures(features);
             this._featuresChanged();
         }
     }


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-696
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC368

## Samenvatting
`vl-map-features-layer` krijgt twee nieuwe publieke methodes om OpenLayers `Feature`-objecten rechtstreeks op de laag te zetten, zonder GeoJSON-roundtrip. Properties gezet via `feature.set(...)` (zoals object-referenties) en id's via `feature.setId(...)` blijven daardoor behouden — de workaround via de private `__featuresSource` is niet langer nodig.

## Wijzigingen
- Nieuwe publieke methode `addFeatures(features)`: voegt OL `Feature`-objecten toe aan de laag zonder serialisatie.
- Nieuwe publieke methode `setFeatures(features)`: vervangt alle features op de laag in één call (clear + bulk add).
- Beide methodes werken met en zonder `cluster`-modus (features belanden op de onderliggende vector source) en triggeren auto-extent + rerender identiek aan de bestaande GeoJSON-flows.
- Storybook-documentatie uitgebreid met de directe OL-feature-flow, inclusief een copy-paste-baar voorbeeld en het projectie-contract (geometrieën moeten al in de kaartprojectie staan; geen projectie-transformatie).
- Vier nieuwe Cypress component-tests: behoud van object-properties, cluster-modus, vervangen via `setFeatures`, en auto-extent/rerender met center-assertie.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Publieke methode om OL `Feature`-objecten toe te voegen zonder GeoJSON-serialisatie; properties via `feature.set(...)` en `feature.setId(...)` blijven behouden — `addFeatures()`/`setFeatures()` gaan rechtstreeks via de vector source; getest met identity-check op een object-referentie.
- [x] Bestaande workaround vervangbaar door één publieke call — `setFeatures()` doet exact clear + add + `_featuresChanged()`.
- [x] Auto-extent en rerender identiek aan de bestaande GeoJSON-flows — beide methodes ronden af via `_featuresChanged()`; getest met rerender-spy en center-assertie op de map view.
- [x] Werkt met en zonder `cluster`-attribute — features belanden via `__featuresSource` op de onderliggende source; getest met cluster-fixture.
- [x] Bestaande API (`features` getter/setter, `addFeature`, `addFeatureCollection`) blijft ongewijzigd — diff is volledig additief; alle 19 bestaande specs blijven groen.
