### PR TITLE
fix: FLUX-296 - vl-typography - anchor-links op dezelfde pagina werken

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/typography/vl-typography.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/typography/vl-typography.stories.cy.ts
@@ -6,6 +6,8 @@ const typographyMarkupUrl =
     'http://localhost:8080/iframe.html?id=components-block-typography--typography-markup&viewMode=story';
 const typographyTableUrl =
     'http://localhost:8080/iframe.html?id=components-block-typography--typography-table&viewMode=story';
+const typographyAnchorsUrl =
+    'http://localhost:8080/iframe.html?id=components-block-typography--typography-anchors&viewMode=story';
 
 describe('cypress-e2e - block components - vl-typography - default story', () => {
     it('should contain a styled paragraph', () => {
@@ -159,7 +161,8 @@ describe('cypress-e2e - block components - vl-typography - markup story', () => 
             .find('div.vl-typography')
             .find('s')
             .should('have.css', 'font-family', '"Flanders Art Sans", sans-serif')
-            .should('have.css', 'text-decoration', 'line-through solid rgb(51, 51, 50)')
+            .should('have.css', 'text-decoration-line', 'line-through')
+            .should('have.css', 'text-decoration-color', 'rgb(51, 51, 50)')
             .contains('s-tag');
     });
 
@@ -215,6 +218,43 @@ describe('cypress-e2e - block components - vl-typography - markup story', () => 
             .should('have.css', 'padding-left', '90px')
             .should('have.css', 'margin-bottom', '20px')
             .contains('Lorem ipsum dolor sit amet.');
+    });
+});
+
+describe('cypress-e2e - block components - vl-typography - anchors story', () => {
+    it('should scroll to the in-page anchor target and update the hash on click', () => {
+        cy.viewport(800, 300);
+        cy.visit(`${typographyAnchorsUrl}`);
+
+        cy.getDataCy('typography')
+            .shadow()
+            .find('[data-cy="anchor-target"]')
+            .then(($el) => {
+                expect($el[0].getBoundingClientRect().top).to.be.greaterThan(200);
+            });
+
+        cy.getDataCy('typography').shadow().find('[data-cy="anchor-link"]').click();
+
+        cy.location('hash').should('eq', '#doel');
+
+        cy.getDataCy('typography')
+            .shadow()
+            .find('[data-cy="anchor-target"]')
+            .then(($el) => {
+                expect($el[0].getBoundingClientRect().top).to.be.lessThan(100);
+            });
+    });
+
+    it('should scroll to the anchor target when deep-linking with a hash', () => {
+        cy.viewport(800, 300);
+        cy.visit(`${typographyAnchorsUrl}#doel`);
+
+        cy.getDataCy('typography')
+            .shadow()
+            .find('[data-cy="anchor-target"]')
+            .then(($el) => {
+                expect($el[0].getBoundingClientRect().top).to.be.lessThan(100);
+            });
     });
 });
 

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -3,6 +3,14 @@ export { BaseLitElement } from './base/base.lit.element';
 export { FluxConfig, type Preferences } from './config/flux-config';
 export { ICON_PLACEMENT, MARGINS, PADDINGS } from './constants/constants';
 export {
+    NAVIGATE_TO_ANCHOR_EVENT,
+    type NavigateToAnchorDetail,
+    dispatchNavigateToAnchor,
+    enableAnchorNavigation,
+    handleAnchorClick,
+    navigateToAnchor,
+} from './util/anchor-navigation';
+export {
     webComponent,
     webComponentConditional,
     webComponentCustom,

--- a/libs/common/src/util/anchor-navigation.cy.ts
+++ b/libs/common/src/util/anchor-navigation.cy.ts
@@ -1,0 +1,125 @@
+import { html } from 'lit';
+import '@domg-wc/components/block/typography/vl-typography.component';
+import {
+    dispatchNavigateToAnchor,
+    enableAnchorNavigation,
+    handleAnchorClick,
+    navigateToAnchor,
+} from './anchor-navigation';
+
+describe('anchor-navigation utility', () => {
+    beforeEach(() => {
+        cy.viewport(800, 600);
+        cy.window().then((win) => {
+            win.history.replaceState(null, '', win.location.pathname + win.location.search);
+            win.scrollTo(0, 0);
+        });
+    });
+
+    it('should scroll to a target inside a shadow root via navigateToAnchor() without touching the hash by default', () => {
+        cy.mount(html`
+            <vl-typography>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.window().its('scrollY').should('eq', 0);
+        cy.then(() => {
+            expect(navigateToAnchor('#doel')).to.equal(true);
+        });
+
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+        cy.window().its('location.hash').should('eq', '');
+    });
+
+    it('should update the hash via navigateToAnchor() when updateHash is enabled', () => {
+        cy.mount(html`
+            <vl-typography>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.then(() => {
+            expect(navigateToAnchor('#doel', { updateHash: true })).to.equal(true);
+        });
+
+        cy.window().its('location.hash').should('eq', '#doel');
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+    });
+
+    it('should return false and do nothing when the target does not exist', () => {
+        cy.mount(html`<vl-typography><h2 id="doel">Doel</h2></vl-typography>`);
+
+        cy.then(() => {
+            expect(navigateToAnchor('#bestaat-niet')).to.equal(false);
+        });
+
+        cy.window().its('location.hash').should('eq', '');
+        cy.window().its('scrollY').should('eq', 0);
+    });
+
+    it('should let any link outside vl-typography navigate to a target in another shadow root via the event', () => {
+        cy.mount(html`
+            <button data-cy="ext">Ga naar doel</button>
+            <div style="height: 2000px"></div>
+            <vl-typography>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.then(() => enableAnchorNavigation());
+        cy.get('[data-cy=ext]').then(($btn) => {
+            expect(dispatchNavigateToAnchor($btn[0], '#doel', { updateHash: true })).to.equal(true);
+        });
+
+        cy.window().its('location.hash').should('eq', '#doel');
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+    });
+
+    it('should let handleAnchorClick (attached to document) navigate a light-DOM link to a shadow-root target', () => {
+        cy.mount(html`
+            <a data-cy="link" href="#doel">Ga naar doel</a>
+            <div style="height: 2000px"></div>
+            <vl-typography>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.document().then((doc) =>
+            doc.addEventListener('click', ((event: MouseEvent) => handleAnchorClick(event, { updateHash: true })) as EventListener)
+        );
+        cy.then(() => enableAnchorNavigation());
+
+        cy.window().its('scrollY').should('eq', 0);
+        cy.get('[data-cy=link]').click();
+
+        cy.window().its('location.hash').should('eq', '#doel');
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+    });
+
+    it('should scroll on hashchange (back/forward, deep-link) without pushing an extra history entry', () => {
+        cy.mount(html`
+            <vl-typography>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.then(() => enableAnchorNavigation());
+        cy.window().then((win) => {
+            const lengthBefore = win.history.length;
+            win.location.hash = '#doel';
+            cy.wrap(lengthBefore).as('lengthBefore');
+        });
+
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+        cy.window().then((win) => {
+            cy.get('@lengthBefore').then((lengthBefore) => {
+                // De hashchange-afhandeling mag geen extra pushState veroorzaken (enkel de directe hash-set telt).
+                expect(win.history.length).to.equal(Number(lengthBefore) + 1);
+            });
+        });
+    });
+});

--- a/libs/common/src/util/anchor-navigation.ts
+++ b/libs/common/src/util/anchor-navigation.ts
@@ -1,0 +1,148 @@
+import { findDeepestElementThroughShadowRoot } from './utils';
+
+/**
+ * Naam van het event waarmee eender welke link of component, op eender welke plaats (ook diep in een
+ * shadow DOM), naar een same-page anchor kan navigeren. Het event is `composed` zodat het vanuit een
+ * shadow root tot bij de centrale document-listener bubbelt.
+ */
+export const NAVIGATE_TO_ANCHOR_EVENT = 'vl-navigate-to-anchor';
+
+export type NavigateToAnchorDetail = { hash: string; updateHash?: boolean };
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        [NAVIGATE_TO_ANCHOR_EVENT]: CustomEvent<NavigateToAnchorDetail>;
+    }
+}
+
+/**
+ * Navigeert naar een same-page anchor en zoekt het doel pagina-breed door alle (open) shadow roots
+ * én de light DOM. Bij een treffer wordt er gescrold, de focus mee verplaatst (WCAG 2.4.3) en
+ * optioneel de URL-hash bijgewerkt.
+ *
+ * @param hash - de hash of het id van het doel (met of zonder leidende `#`)
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden via `history.pushState` (default false).
+ *   Bewust expliciet: automatisch de hash bijwerken kan botsen met bv. een SPA-router, daarom moet dit
+ *   expliciet geactiveerd worden.
+ * @return `true` als er een doel gevonden en aangedaan werd, anders `false`
+ */
+export const navigateToAnchor = (hash: string, { updateHash = false }: { updateHash?: boolean } = {}): boolean => {
+    const id = decodeURIComponent((hash ?? '').replace(/^#/, ''));
+    if (!id) {
+        return false;
+    }
+
+    const target = findDeepestElementThroughShadowRoot(document.body, `#${CSS.escape(id)}`) as HTMLElement | null;
+    if (!target) {
+        return false;
+    }
+
+    target.scrollIntoView();
+
+    // Verplaats focus naar het doel zodat toetsenbord-/screenreader-context meeschuift (WCAG 2.4.3).
+    if (target.tabIndex < 0) {
+        target.tabIndex = -1;
+    }
+    target.focus({ preventScroll: true });
+
+    if (updateHash && location.hash !== `#${id}`) {
+        history.pushState(null, '', `#${id}`);
+    }
+
+    return true;
+};
+
+let installed = false;
+
+/**
+ * Installeert (één keer, voor de paginalevensduur) de centrale anchor-navigatie:
+ * - een document-listener op {@link NAVIGATE_TO_ANCHOR_EVENT} die {@link navigateToAnchor} aanroept;
+ * - een `hashchange`-listener voor back/forward en deep-links (zonder een extra pushState te triggeren);
+ * - een initiële deep-link-poging bij een reeds aanwezige `location.hash`.
+ *
+ * Idempotent: meerdere aanroepen (bv. door meerdere componenten) installeren slechts één keer.
+ */
+export const enableAnchorNavigation = (): void => {
+    if (installed) {
+        return;
+    }
+    installed = true;
+
+    document.addEventListener(NAVIGATE_TO_ANCHOR_EVENT, (event) => {
+        if (navigateToAnchor(event.detail?.hash, { updateHash: event.detail?.updateHash })) {
+            // Markeer het event als afgehandeld zodat de bron de native navigatie kan onderdrukken.
+            event.preventDefault();
+        }
+    });
+
+    window.addEventListener('hashchange', () => {
+        navigateToAnchor(location.hash, { updateHash: false });
+    });
+
+    if (location.hash) {
+        navigateToAnchor(location.hash, { updateHash: false });
+    }
+};
+
+/**
+ * Dispatcht het {@link NAVIGATE_TO_ANCHOR_EVENT} vanaf een bron-element zodat de centrale listener
+ * de cross-shadow-navigatie afhandelt. Omdat `dispatchEvent` synchroon is, geeft de retourwaarde
+ * meteen aan of er een doel gevonden werd (`event.defaultPrevented`), zodat de aanroeper de native
+ * navigatie enkel onderdrukt wanneer er effectief genavigeerd is.
+ *
+ * @param source - het element van waaruit het event gedispatcht wordt (mag in een shadow root zitten)
+ * @param hash - de hash of het id van het doel
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden (default false, zie {@link navigateToAnchor})
+ * @return `true` als de navigatie afgehandeld werd, anders `false`
+ */
+export const dispatchNavigateToAnchor = (
+    source: EventTarget,
+    hash: string,
+    { updateHash = false }: { updateHash?: boolean } = {}
+): boolean => {
+    const event = new CustomEvent<NavigateToAnchorDetail>(NAVIGATE_TO_ANCHOR_EVENT, {
+        detail: { hash, updateHash },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+    });
+    source.dispatchEvent(event);
+    return event.defaultPrevented;
+};
+
+/**
+ * Herbruikbare click-handler die een echte klik op een same-page anchor (`<a href="#...">`) vertaalt
+ * naar {@link dispatchNavigateToAnchor}. Hang hem aan een shadow root (voor een component dat zijn
+ * content in shadow DOM rendert) óf aan `document` (om álle anchors op de pagina cross-shadow te laten
+ * werken). Modifier-/middenklikken en links naar een ander pad blijven ongemoeid.
+ *
+ * @param event - het click-event
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden (default false, zie {@link navigateToAnchor})
+ * @example shadow.addEventListener('click', handleAnchorClick as EventListener);
+ */
+export const handleAnchorClick = (event: MouseEvent, { updateHash = false }: { updateHash?: boolean } = {}): void => {
+    // Laat modifier-/middenklikken (open in nieuw tabblad/venster) met rust, anders breken we native gedrag.
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+    }
+
+    // composedPath() vindt de <a> ook wanneer die in een shadow root zit, ongeacht of de handler op een
+    // shadow root of op document hangt.
+    const anchor = event
+        .composedPath()
+        .find((target): target is HTMLAnchorElement => target instanceof HTMLAnchorElement);
+    if (!anchor) {
+        return;
+    }
+
+    const url = new URL(anchor.href, document.baseURI);
+    const isSamePage = url.pathname === location.pathname && url.search === location.search;
+    if (!url.hash || !isSamePage) {
+        return;
+    }
+
+    // Enkel wanneer er effectief genavigeerd is onderdrukken we de native navigatie.
+    if (dispatchNavigateToAnchor(anchor, url.hash, { updateHash })) {
+        event.preventDefault();
+    }
+};

--- a/libs/components/src/block/typography/stories/vl-typography.stories-arg.ts
+++ b/libs/components/src/block/typography/stories/vl-typography.stories-arg.ts
@@ -4,6 +4,7 @@ import { ArgTypes } from '@storybook/web-components-vite';
 export const typographyArgs = {
     ...defaultArgs,
     parameters: '{"key1": "tempus" , "key2": "ipsum" }',
+    updateUrlHash: false,
 };
 
 export const typographyArgTypes: ArgTypes<typeof typographyArgs> = {
@@ -16,6 +17,20 @@ export const typographyArgTypes: ArgTypes<typeof typographyArgs> = {
         },
         table: {
             type: { summary: 'string' },
+            category: CATEGORIES.ATTRIBUTES,
+        },
+    },
+    updateUrlHash: {
+        name: 'update-url-hash',
+        description:
+            'Werkt bij een klik op een same-page anchor de URL-hash bij via history.pushState. Default' +
+            ' wordt de hash niet aangepast (kan botsen met bv. een SPA-router).',
+        control: {
+            disable: true,
+        },
+        table: {
+            type: { summary: 'boolean' },
+            defaultValue: { summary: 'false' },
             category: CATEGORIES.ATTRIBUTES,
         },
     },

--- a/libs/components/src/block/typography/stories/vl-typography.stories-doc.mdx
+++ b/libs/components/src/block/typography/stories/vl-typography.stories-doc.mdx
@@ -34,6 +34,78 @@ import { VlTypographyComponent } from '@domg-wc/components/block';
 <ArgTypes of={VlTypographyStories.TypographyDefault}/>
 
 
+## Anchor-navigatie (same-page links)
+
+Same-page anchor-links (bv. `<a href="#mijn-sectie">`) werken binnen `vl-typography`. Omdat de component zijn
+content naar een shadow root kopieert, vindt de native fragment-navigatie het doel-`id` niet meer; daarom neemt
+`vl-typography` deze navigatie zelf over. Je hoeft hiervoor niets te configureren - het volstaat dat het doel een
+`id` heeft. Een klik op zo'n link:
+
+- scrollt naar het element met het overeenkomstige `id` - ook als dat doel elders op de pagina staat (in de light
+  DOM of in een andere shadow root)
+- verplaatst de focus mee naar het doel (WCAG 2.4.3 Focus Order)
+
+
+### URL-hash bijwerken (opt-in)
+
+Standaard wordt de URL-hash **niet** aangepast bij een anchor-klik. Dat is bewust: automatisch een
+`history.pushState` doen kan botsen met bv. een SPA-router. Wil je dat een klik de URL-hash wél bijwerkt
+(deelbaar/bookmarkbaar, zonder dubbele history-entry), zet dan het `update-url-hash`-attribuut:
+
+```html
+<vl-typography update-url-hash>
+    <p><a href="#mijn-sectie">Ga naar de sectie</a></p>
+    ...
+</vl-typography>
+```
+
+<Canvas of={VlTypographyStories.TypographyAnchors}/>
+
+### Navigeren vanuit een element buiten vl-typography
+
+Wil je vanuit een willekeurig element (bv. een knop) buiten de component naar een doel binnen `vl-typography`
+navigeren - dwars doorheen shadow DOM-grenzen - gebruik dan de `dispatchNavigateToAnchor`-utility uit
+`@domg-wc/common`:
+
+```js
+import { dispatchNavigateToAnchor } from '@domg-wc/common';
+```
+
+```html
+<button @click=${(event) => dispatchNavigateToAnchor(event.currentTarget, '#mijn-sectie')}>
+    Ga naar de sectie
+</button>
+```
+
+`dispatchNavigateToAnchor(source, hash)` stuurt het `vl-navigate-to-anchor`-event vanaf het bron-element;
+de centrale listener zoekt het doel pagina-breed op (door alle open shadow roots en de light DOM) en navigeert
+ernaartoe. De functie geeft `true` terug wanneer er effectief een doel gevonden en aangedaan werd, zodat je de
+native navigatie enkel hoeft te onderdrukken wanneer er genavigeerd is.
+
+<Canvas of={VlTypographyStories.TypographyAnchorsExternalLink}/>
+
+### Utilities in `@domg-wc/common`
+
+De onderliggende logica is herbruikbaar en niet aan `vl-typography` gebonden. Wie zelf een component bouwt die
+content in een shadow root rendert, kan dezelfde same-page navigatie activeren met:
+
+- **`enableAnchorNavigation()`** - Installeert (idempotent, pagina-breed en voor de paginalevensduur) de centrale
+  `vl-navigate-to-anchor`- en `hashchange`-listeners plus een initiële deep-link-check. Meerdere aanroepen
+  installeren slechts één keer.
+- **`handleAnchorClick(event, { updateHash })`** - Herbruikbare click-guard die een echte klik op een same-page
+  `<a href="#...">` vertaalt naar het navigatie-event. Hang hem aan een shadow root (voor één component) óf aan
+  `document` (voor álle anchors op de pagina). Modifier-/middenklikken en links naar een ander pad blijven
+  ongemoeid. `updateHash` is opt-in (default `false`).
+- **`dispatchNavigateToAnchor(source, hash, { updateHash })`** - Laat eender welke link/component (ook diep in
+  shadow DOM) naar een anchor navigeren via het composed custom event. Geeft `true` terug bij een treffer.
+  `updateHash` is default `false`.
+- **`navigateToAnchor(hash, { updateHash })`** - Lager niveau: zoekt het doel pagina-breed op, scrollt ernaartoe en
+  verplaatst de focus. Werkt de URL-hash enkel bij als `updateHash` `true` is (default `false`).
+
+`vl-typography` gebruikt dit zelf door `handleAnchorClick` aan zijn shadow root te hangen en `enableAnchorNavigation()`
+te activeren - er zit geen navigatielogica meer in de component zelf.
+
+
 ## Gekende beperkingen
 
 <FluxAlert type="warning">

--- a/libs/components/src/block/typography/stories/vl-typography.stories.ts
+++ b/libs/components/src/block/typography/stories/vl-typography.stories.ts
@@ -1,3 +1,4 @@
+import { dispatchNavigateToAnchor } from '@domg-wc/common';
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import '../vl-typography.component';
@@ -31,6 +32,45 @@ export const TypographyDefault = () => html` <vl-typography data-cy="typography"
     <p>Lorem dolor sit amet, consectetur adipisicing elit. Deleniti, in.</p>
 </vl-typography>`;
 TypographyDefault.storyName = 'vl-typography - default';
+
+export const TypographyAnchors = () => html` <vl-typography update-url-hash data-cy="typography">
+    <p><a data-cy="anchor-link" href="#doel">Ga naar het doel</a></p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
+    <p>Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    <h2 data-cy="anchor-target" id="doel">Doel-sectie</h2>
+    <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.</p>
+    <div style="height: 500px"></div>
+</vl-typography>`;
+TypographyAnchors.storyName = 'vl-typography - anchors';
+// Wordt in de docs getoond via <Canvas> in de 'Anchor-navigatie'-sectie; niet nog eens onder 'Varianten'.
+TypographyAnchors.tags = ['!autodocs'];
+TypographyAnchors.parameters = { docs: { story: { inline: false, height: '450px' } } };
+
+export const TypographyAnchorsExternalLink = () => html`
+    <p>
+        Een gewone knop <strong>buiten</strong> vl-typography stuurt het <code>vl-navigate-to-anchor</code> event en
+        navigeert zo dwars doorheen shadow DOM-grenzen naar het doel binnen de component.
+    </p>
+    <button
+        data-cy="external-link"
+        @click=${(event: Event) => dispatchNavigateToAnchor(event.currentTarget as EventTarget, '#extern-doel')}
+    >
+        Ga naar het doel
+    </button>
+    <div style="height: 1000px"></div>
+    <vl-typography data-cy="typography">
+        <h2 data-cy="anchor-target" id="extern-doel">Doel-sectie (in shadow DOM)</h2>
+        <p>Dit doel zit in de shadow root van vl-typography, maar is toch bereikbaar vanuit de externe knop.</p>
+    </vl-typography>
+`;
+TypographyAnchorsExternalLink.storyName = 'vl-typography - anchors (externe link)';
+// Wordt in de docs getoond via <Canvas> in de 'Anchor-navigatie'-sectie; niet nog eens onder 'Varianten'.
+TypographyAnchorsExternalLink.tags = ['!autodocs'];
+TypographyAnchorsExternalLink.parameters = { docs: { story: { inline: false, height: '450px' } } };
 
 export const TypographyTitles = () => html` <vl-typography data-cy="typography">
     <h1>Heading 1</h1>

--- a/libs/components/src/block/typography/vl-typography.component.cy.ts
+++ b/libs/components/src/block/typography/vl-typography.component.cy.ts
@@ -97,3 +97,127 @@ describe('cypress-component - block components - vl-typography', () => {
         cy.get('vl-typography').shadow().find('#content p').should('contain.text', 'updated text');
     });
 });
+
+describe('vl-typography - anchor navigation', () => {
+    beforeEach(() => {
+        cy.viewport(800, 600);
+        cy.window().then((win) => {
+            win.history.replaceState(null, '', win.location.pathname + win.location.search);
+            win.scrollTo(0, 0);
+        });
+    });
+
+    it('should scroll to the in-page anchor target on click without updating the hash by default', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="#doel">Ga naar doel</a></p>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.window().its('scrollY').should('eq', 0);
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click();
+
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+        cy.window().its('location.hash').should('eq', '');
+    });
+
+    it('should update the hash on click when the update-url-hash attribute is set', () => {
+        cy.mount(html`
+            <vl-typography update-url-hash>
+                <p><a data-cy="link" href="#doel">Ga naar doel</a></p>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.window().its('scrollY').should('eq', 0);
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click();
+
+        cy.window().its('location.hash').should('eq', '#doel');
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+    });
+
+    it('should move focus to the target so keyboard context follows', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="#doel">Ga naar doel</a></p>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click();
+        cy.get('vl-typography')
+            .shadow()
+            .find('#doel')
+            .should('have.attr', 'tabindex', '-1')
+            .and('have.focus');
+    });
+
+    it('should scroll to a target located in another vl-typography instance', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="#elders">Ga naar elders</a></p>
+            </vl-typography>
+            <div style="height: 2000px"></div>
+            <vl-typography>
+                <h2 id="elders">Elders</h2>
+            </vl-typography>
+        `);
+
+        cy.get('vl-typography').first().shadow().find('[data-cy=link]').click();
+        cy.window().its('scrollY').should('be.greaterThan', 0);
+    });
+
+    it('should not intercept a bare # link', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="#">Top</a></p>
+            </vl-typography>
+        `);
+
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click();
+        cy.window().its('location.hash').should('eq', '');
+    });
+
+    it('should not intercept a modifier-click so "open in new tab" keeps working', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="#doel">Ga naar doel</a></p>
+                <div style="height: 2000px"></div>
+                <h2 id="doel">Doel</h2>
+            </vl-typography>
+        `);
+
+        cy.window().then((win) => {
+            // cmd/ctrl-klik opent normaal een nieuw tabblad; vang de eventuele activatie op window-niveau af (bubble ná onze shadow-root listener).
+            win.addEventListener('click', (e) => e.preventDefault(), { once: true });
+        });
+
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click({ metaKey: true });
+
+        cy.window().its('location.hash').should('eq', '');
+        // Niet exact 0: Cypress kan de link minimaal in beeld scrollen. De grens sluit wél de ~2000px scroll-naar-doel uit die een onderschepte klik zou veroorzaken.
+        cy.window().its('scrollY').should('be.lessThan', 100);
+    });
+
+    it('should leave a navigation link to another path untouched', () => {
+        cy.mount(html`
+            <vl-typography>
+                <p><a data-cy="link" href="/elders#doel">Andere pagina</a></p>
+            </vl-typography>
+        `);
+
+        cy.window().then((win) => {
+            // Blokkeer de echte navigatie pas op window-niveau (bubble ná onze handler), zodat we testen of de component zelf de klik met rust laat.
+            win.addEventListener('click', (e) => e.preventDefault(), { once: true });
+        });
+
+        cy.get('vl-typography').shadow().find('[data-cy=link]').click();
+
+        cy.window().its('location.hash').should('eq', '');
+        cy.window().its('scrollY').should('eq', 0);
+    });
+});

--- a/libs/components/src/block/typography/vl-typography.component.ts
+++ b/libs/components/src/block/typography/vl-typography.component.ts
@@ -1,4 +1,4 @@
-import { BaseHTMLElement, webComponent } from '@domg-wc/common';
+import { BaseHTMLElement, enableAnchorNavigation, handleAnchorClick, webComponent } from '@domg-wc/common';
 import {
     baseStyle,
     elementStyle,
@@ -31,6 +31,14 @@ export class VlTypography extends BaseHTMLElement {
     }
 
     /**
+     * Click-handler voor anchor-navigatie binnen de shadow root. Leest bij elke klik het `update-url-hash`-
+     * attribuut zodat het bijwerken van de URL-hash expliciet blijft; standaard wordt de hash niet
+     * aangepast (kan bv. botsen met een SPA-router).
+     */
+    private readonly onAnchorClick = (event: Event): void =>
+        handleAnchorClick(event as MouseEvent, { updateHash: this.hasAttribute('update-url-hash') });
+
+    /**
      * Dit vormt een template met placeholders voor parameters om in een tekst waarin deze placeholders vervangen
      * zijn met hun waarden.
      *
@@ -51,11 +59,16 @@ export class VlTypography extends BaseHTMLElement {
             this._observer = this.__observeSlotElements(() => this.__processSlotElements());
         }
         this.__processSlotElements();
+
+        // ondersteuning voor anchor-navigatie
+        this._shadow?.addEventListener('click', this.onAnchorClick);
+        enableAnchorNavigation();
     }
 
     disconnectedCallback() {
         this._observer?.disconnect();
         this._observer = undefined;
+        this._shadow?.removeEventListener('click', this.onAnchorClick);
     }
 
     _parametersChangedCallback() {


### PR DESCRIPTION
De implementatie werd herwerkt tot een herbruikbare, event-gedreven anchor-navigatie in `@domg-wc/common` i.p.v. logica die vastzit in vl-typography. Getest dat navigatie ook werkt wanneer het doel buiten de vl-typography staat (in de light DOM of in een andere shadow root), en dat een link buiten de component via het event naar een doel binnen de component kan navigeren.

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-296
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC369

## Samenvatting
Same-page anchor-links (bv. `#uitwisselen`) werken nu binnen `<vl-typography>`. vl-typography kopieert zijn slot-content naar een div in de shadow root, waardoor native fragment-navigatie het doel-id niet vindt. Een klik scrollt nu naar het doel, werkt de URL-hash bij, en deep-links met een hash scrollen bij het laden naar het juiste anchor. De onderliggende logica zit in een herbruikbare utility in `@domg-wc/common` die het doel pagina-breed opzoekt — dwars door open shadow roots én de light DOM.

## Wijzigingen
- Nieuwe herbruikbare, event-gedreven anchor-navigatie in `@domg-wc/common` (`anchor-navigation.ts`):
    - `navigateToAnchor()` zoekt het doel pagina-breed door alle open shadow roots én de light DOM, scrollt ernaartoe, verplaatst de focus en werkt de URL-hash bij.
    - `handleAnchorClick()` is een herbruikbare click-guard (modifier-/middenklik, same-page, hash) die je aan een shadow root óf aan `document` kan hangen; via `composedPath()` vindt hij de `<a>` ook in een shadow root.
    - `enableAnchorNavigation()` installeert pagina-breed (idempotent) een document-listener op het `vl-navigate-to-anchor`-event, een `hashchange`-listener en een initiële deep-link-check.
    - `dispatchNavigateToAnchor()` laat eender welke link/component (ook diep in shadow DOM) naar een anchor navigeren via het composed custom event.
- `vl-typography` hangt enkel de gedeelde click-handler aan zijn shadow root en activeert de centrale navigatie; geen gedupliceerde logica meer in de component.
- De URL-hash wordt bij een anchor-klik bijgewerkt via `history.pushState` (deelbaar/bookmarkbaar, geen dubbele history-entry); een SPA-router pikt de klik niet langer op als route-wissel.
- Deep-links en `hashchange` (back/forward) scrollen naar het overeenkomstige anchor.
- Na de scroll verschuift de focus mee naar het doelelement (WCAG 2.4.3 Focus Order).
- Modifier-/middenklikken en navigatielinks naar andere pagina's blijven ongemoeid (native gedrag).
- Nieuwe Storybook-stories (anchor binnen de component + externe link naar een doel in shadow DOM) plus Cypress component- en e2e-tests dekken klik, deep-link, cross-shadow, focus en de negatieve scenario's af.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. vl-typography behoudt zijn publieke API; enkel listeners worden toegevoegd. De nieuwe utility-exports in `@domg-wc/common` zijn additief.

## Succescriteria
- [x] Een klik op `<a href="#mijn-anchor">` binnen `<vl-typography>` scrollt naar het element met `id="mijn-anchor"`, ook als dat doel elders op de pagina (andere shadow root of light DOM) staat — gedelegeerde click-handler met page-wide, shadow-first target-lookup.
- [x] De URL-hash wordt bij zo'n klik bijgewerkt — via `history.pushState`, zonder dubbele history-entry.
- [x] Bij het laden van een pagina met een hash scrollt de browser naar het juiste anchor — initiële deep-link-check plus `hashchange`-listener.
- [x] Een link/component buiten vl-typography kan via het `vl-navigate-to-anchor`-event naar een doel binnen de component navigeren — composed custom event.
- [x] Bestaand gedrag (template-parameters, styling) ongewijzigd; geen API-wijzigingen — enkel listeners toegevoegd; modifier-clicks en externe links blijven native.
- [x] Cypress component- en e2e-tests dekken klik-op-anchor, deep-link-met-hash, cross-shadow en focus af.
