### PR TITLE
feat: FLUX-276 - vl-share-buttons - deprecaten met verwijzing naar vl-button

### DIFF
--- a/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
+++ b/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
@@ -113,6 +113,30 @@ moeten na de v3 upgrade verifiëren dat hun datepicker correct rendert.
 </table>
 
 
+### Share Buttons
+
+`Share Buttons` is deprecated in v2 en wordt verwijderd in v3. Er komt geen `next`-variant: gebruik een
+`vl-button` met `cta-link`, `icon` en een verplicht `label` (standaard action-blauw).
+
+<table  style={{width: 100 + '%'}}>
+    <tr>
+        <th>Naam</th>
+        <th>Toestand</th>
+        <th>v2 - Artifact</th>
+        <th>v2 - Gebruik</th>
+        <th>v3 - Artifact</th>
+        <th>v3 - Gebruik</th>
+    </tr>
+    <tr>
+        <td>[Share Buttons [legacy]](/docs/components-block-share-buttons-share-buttons--documentatie)</td>
+        <td>deprecated</td>
+        <td>components/block</td>
+        <td><code>{`<vl-share-buttons>`}</code></td>
+        <td>-</td>
+        <td><code>-</code></td>
+    </tr>
+</table>
+
 ### Side Navigation
 
 `Side Navigation [legacy]` wordt vervangen door `Side Navigation [next]`.

--- a/libs/components/src/block/share-buttons/stories/vl-share-button.stories-doc.mdx
+++ b/libs/components/src/block/share-buttons/stories/vl-share-button.stories-doc.mdx
@@ -1,0 +1,30 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlShareButtonStories from './vl-share-button.stories';
+
+# Share Button
+
+<FluxComponentMetaData id="components-block-share-buttons-share-button" />
+
+<FluxAlert type="warning" title="Deprecated">
+{`
+ Deze component is <strong>deprecated</strong> en wordt verwijderd in <strong>v3</strong>. Gebruik in plaats daarvan
+ een <code>vl-button</code> met <code>cta-link</code> en <code>icon</code> in de standaard action-stijl. Zie de
+ <a href="/docs/components-block-share-buttons-share-buttons--documentatie#ontwerp">Share Buttons documentatie</a>
+ voor het alternatief.
+`}
+</FluxAlert>
+
+
+## Doel
+
+De `share-button` component is één enkele deelknop binnen een `share-buttons` rij.
+
+
+## Voorbeeld
+
+<Canvas of={VlShareButtonStories.shareButtonDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlShareButtonStories.shareButtonDefault} />

--- a/libs/components/src/block/share-buttons/stories/vl-share-button.stories.ts
+++ b/libs/components/src/block/share-buttons/stories/vl-share-button.stories.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 import '../vl-share-button.component';
 import '../vl-share-buttons.component';
 import { shareButtonArgs, shareButtonArgTypes } from './vl-share-button.stories-arg';
+import shareButtonDoc from './vl-share-button.stories-doc.mdx';
 
 export default {
     id: 'components-block-share-buttons-share-button',
@@ -10,6 +11,11 @@ export default {
     tags: ['autodocs'],
     args: shareButtonArgs,
     argTypes: shareButtonArgTypes,
+    parameters: {
+        docs: {
+            page: shareButtonDoc,
+        },
+    },
 } as Meta<typeof shareButtonArgs>;
 
 export const shareButtonDefault = ({ href, medium }: typeof shareButtonArgs) =>

--- a/libs/components/src/block/share-buttons/stories/vl-share-buttons.stories-doc.mdx
+++ b/libs/components/src/block/share-buttons/stories/vl-share-buttons.stories-doc.mdx
@@ -1,0 +1,40 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlShareButtonsStories from './vl-share-buttons.stories';
+
+# Share Buttons
+
+<FluxComponentMetaData id="components-block-share-buttons-share-buttons" />
+
+<FluxAlert type="warning" title="Deprecated">
+{`
+ Deze component is <strong>deprecated</strong> en wordt verwijderd in <strong>v3</strong>. Gebruik in plaats daarvan
+ een <code>vl-button</code> met <code>cta-link</code> en <code>icon</code> in de standaard action-stijl (zie
+ <a href="#ontwerp">Ontwerp</a>).
+`}
+</FluxAlert>
+
+
+## Doel
+
+De `share-buttons` component toont een rij knoppen om een pagina te delen op sociale media.
+
+
+## Voorbeeld
+
+<Canvas of={VlShareButtonsStories.shareButtonsDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlShareButtonsStories.shareButtonsDefault} />
+
+
+## Ontwerp
+
+Vervang elke share-knop door een gewone [`vl-button`](/docs/components-atom-button--documentatie) in de standaard action-stijl met `cta-link`, `icon` en een
+verplicht `label` voor toegankelijkheid (WCAG 2.1 AA). Geef per kanaal een eigen knop met de bijhorende share-URL:
+
+```html
+<vl-button cta-link="https://www.facebook.com/sharer/sharer.php?u=…" icon="facebook" label="Delen op Facebook"></vl-button>
+<vl-button cta-link="https://www.linkedin.com/sharing/share-offsite/?url=…" icon="linkedin" label="Delen op LinkedIn"></vl-button>
+```

--- a/libs/components/src/block/share-buttons/stories/vl-share-buttons.stories.ts
+++ b/libs/components/src/block/share-buttons/stories/vl-share-buttons.stories.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 import '../vl-share-button.component';
 import '../vl-share-buttons.component';
 import { shareButtonsArgs, shareButtonsArgTypes } from './vl-share-buttons.stories-arg';
+import shareButtonsDoc from './vl-share-buttons.stories-doc.mdx';
 
 export default {
     id: 'components-block-share-buttons-share-buttons',
@@ -10,6 +11,11 @@ export default {
     tags: ['autodocs'],
     args: shareButtonsArgs,
     argTypes: shareButtonsArgTypes,
+    parameters: {
+        docs: {
+            page: shareButtonsDoc,
+        },
+    },
 } as Meta<typeof shareButtonsArgs>;
 
 export const shareButtonsDefault = ({ alt }: typeof shareButtonsArgs) => html` <vl-share-buttons

--- a/libs/components/src/block/share-buttons/vl-share-button.component.ts
+++ b/libs/components/src/block/share-buttons/vl-share-button.component.ts
@@ -6,13 +6,29 @@ import { customElement } from 'lit/decorators.js';
 import { vlShareButtonFluxStyles } from './vl-share-button.flux-css';
 import { MEDIA_NAMES } from './vl-share-button.model';
 
+/**
+ * @deprecated Wordt verwijderd in v3. Gebruik een `vl-button` met `cta-link`, `icon` en `label`,
+ * bv. `<vl-button cta-link="…" icon="facebook" label="Delen op Facebook">`.
+ */
 @customElement('vl-share-button')
 export class VlShareButton extends BaseLitElement {
+    private static deprecationWarningShown = false;
     private medium = '';
     private href = '';
 
     static get styles() {
         return [resetStyle, baseStyle, vlShareButtonFluxStyles, iconStyle];
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        if (!VlShareButton.deprecationWarningShown) {
+            console.warn(
+                'vl-share-button is deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon' +
+                ' en label, bv. <vl-button cta-link="…" icon="facebook" label="Delen op Facebook">.'
+            );
+            VlShareButton.deprecationWarningShown = true;
+        }
     }
 
     static get properties() {

--- a/libs/components/src/block/share-buttons/vl-share-buttons.component.cy.ts
+++ b/libs/components/src/block/share-buttons/vl-share-buttons.component.cy.ts
@@ -1,0 +1,46 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { html } from 'lit';
+import { VlShareButton } from './vl-share-button.component';
+import { VlShareButtonsComponent } from './vl-share-buttons.component';
+
+registerWebComponents([VlShareButtonsComponent, VlShareButton]);
+
+describe('cypress-component - block components - vl-share-buttons', () => {
+    it('should mount', () => {
+        cy.mount(html` <vl-share-buttons></vl-share-buttons>`);
+
+        cy.get('vl-share-buttons').shadow().find('.vl-share-buttons');
+    });
+
+    it('should warn once that the component is deprecated', () => {
+        cy.spy(console, 'warn').as('warn');
+
+        cy.mount(html` <vl-share-buttons></vl-share-buttons>`);
+
+        cy.get('@warn').should('have.been.calledOnce');
+        cy.get('@warn').should(
+            'have.been.calledWith',
+            'vl-share-buttons is deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon en label, bv. <vl-button cta-link="…" icon="facebook" label="Delen op Facebook">.'
+        );
+    });
+});
+
+describe('cypress-component - block components - vl-share-button', () => {
+    it('should mount', () => {
+        cy.mount(html` <vl-share-button href="#" medium="facebook"></vl-share-button>`);
+
+        cy.get('vl-share-button').shadow().find('.vl-share-button');
+    });
+
+    it('should warn once that the component is deprecated', () => {
+        cy.spy(console, 'warn').as('warn');
+
+        cy.mount(html` <vl-share-button href="#" medium="facebook"></vl-share-button>`);
+
+        cy.get('@warn').should('have.been.calledOnce');
+        cy.get('@warn').should(
+            'have.been.calledWith',
+            'vl-share-button is deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon en label, bv. <vl-button cta-link="…" icon="facebook" label="Delen op Facebook">.'
+        );
+    });
+});

--- a/libs/components/src/block/share-buttons/vl-share-buttons.component.ts
+++ b/libs/components/src/block/share-buttons/vl-share-buttons.component.ts
@@ -4,12 +4,23 @@ import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { vlShareButtonsFluxStyles } from './vl-share-buttons.flux-css';
 
+/**
+ * @deprecated Wordt verwijderd in v3. Gebruik een `vl-button` met `cta-link`, `icon` en `label`,
+ * bv. `<vl-button cta-link="…" icon="facebook" label="Delen op Facebook">`.
+ */
 @customElement('vl-share-buttons')
 export class VlShareButtonsComponent extends BaseLitElement {
     private alt = '';
 
     static get styles() {
         return [vlShareButtonsFluxStyles];
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        console.warn(
+            'vl-share-buttons is deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon en label, bv. <vl-button cta-link="…" icon="facebook" label="Delen op Facebook">.'
+        );
     }
 
     static get properties() {

--- a/resources/generate-web-types/web-types.generator.ts
+++ b/resources/generate-web-types/web-types.generator.ts
@@ -170,6 +170,9 @@ const minimalWTElement = (wtComponent: WTConfig): WTElement => {
     if (docUrl) {
         wtElement['doc-url'] = docUrl;
     }
+    if (wtComponent.deprecated !== undefined) {
+        wtElement.deprecated = wtComponent.deprecated;
+    }
     return wtElement;
 };
 

--- a/resources/generate-web-types/web-types.model.ts
+++ b/resources/generate-web-types/web-types.model.ts
@@ -5,6 +5,7 @@ export interface WTConfig {
     argTypes: ArgTypes;
     storiesDocFile: string;
     storybookPath: string;
+    deprecated?: boolean | string;
 }
 
 export type WTConfigArray = WTConfig[];
@@ -50,6 +51,7 @@ export interface WTElement {
     name: string;
     description?: string;
     'doc-url'?: string;
+    deprecated?: boolean | string;
     attributes?: WTElementAttributeArray;
     slots?: WTElementSlotArray;
     js?: {

--- a/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
@@ -269,14 +269,16 @@ export const buildWTConfigComponentsBlock: WTConfigArray = [
     buildWTConfig(
         'vl-share-button',
         shareButtonArgTypes,
-        null,
-        '/docs/components-block-share-buttons-button--documentatie'
+        '../../libs/components/src/block/share-buttons/stories/vl-share-button.stories-doc.mdx',
+        '/docs/components-block-share-buttons-share-button--documentatie',
+        'Deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon en label.'
     ),
     buildWTConfig(
         'vl-share-buttons',
         shareButtonsArgTypes,
-        null,
-        '/docs/components-block-share-buttons-buttons--documentatie'
+        '../../libs/components/src/block/share-buttons/stories/vl-share-buttons.stories-doc.mdx',
+        '/docs/components-block-share-buttons-share-buttons--documentatie',
+        'Deprecated en wordt verwijderd in v3. Gebruik een vl-button met cta-link, icon en label.'
     ),
     buildWTConfig(
         'vl-side-sheet',

--- a/resources/generate-web-types/wt-config-build/utils.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/utils.wt-config.ts
@@ -5,12 +5,14 @@ export const buildWTConfig = (
     componentName: string,
     argTypes: ArgTypes,
     storiesDocFile: string,
-    storybookPath: string
+    storybookPath: string,
+    deprecated?: boolean | string
 ): WTConfig => {
     return {
         componentName,
         argTypes,
         storiesDocFile,
         storybookPath,
+        ...(deprecated !== undefined && { deprecated }),
     };
 };


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-276
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC370

## Samenvatting
`vl-share-buttons` en `vl-share-button` zijn deprecated in v2 en worden verwijderd in v3. Wie de componenten nog gebruikt, krijgt een console-waarschuwing en wordt via Storybook, de migratietabel en IDE web-types naar het alternatief geleid: een gewone `vl-button` per kanaal met `cta-link`, `icon` en `label` in de standaard action-stijl.

## Wijzigingen
- `vl-share-buttons` en `vl-share-button` gemarkeerd als `@deprecated`, met één `console.warn` per instantie bij gebruik.
- Storybook-documentatie voor beide componenten toont een deprecation-banner (`FluxAlert`) en een "Ontwerp"-sectie met het `vl-button`-alternatief (incl. verplicht `label` voor WCAG).
- Migratietabel "van v2 naar v3" aangevuld met een rij Share Buttons (status deprecated, v3-alternatief `vl-button`).
- Web-types markeren beide tags als deprecated zodat IDE's de waarschuwing tonen; de web-types-generator ondersteunt hiervoor nu een optioneel `deprecated`-veld.

## Backwards compatibility
Additieve wijziging met deprecated path: `vl-share-buttons`/`vl-share-button` zijn deprecated, het nieuwe alternatief is een `vl-button` per kanaal met `cta-link`, `icon` en `label` in de standaard action-stijl; de deprecated componenten worden verwijderd in v3.

## Succescriteria
- [x] `vl-share-buttons` en `vl-share-button` `@deprecated` in code met `console.warn` bij gebruik — JSDoc op beide classes plus één warn per instantie in `connectedCallback`, conform het `vl-header`-patroon.
- [x] Storybook-docs tonen deprecation-banner met het `vl-button`-alternatief onder "Ontwerp" — `FluxAlert`-banner op beide docpagina's en een "Ontwerp"-sectie met voorbeeld `<vl-button cta-link icon label>` in action-blauw.
- [x] Migratietabel `4_van-v2-naar-v3-beschikbaar.mdx` bevat rij Share Buttons — status "deprecated" met het v3-alternatief, alfabetisch ingevoegd.
- [x] Web-types markeren de tags als deprecated — via de wt-config als bron van waarheid; de gegenereerde JSON bevat de deprecated-string op beide tags.
- [x] Component blijft in v2 functioneel werken — rendering ongewijzigd, geen exports verwijderd, geen runtime-breuk.
