### PR TITLE
feat: FLUX-710 - vl-button, vl-link - download attribuut toegevoegd

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { registerWebComponents } from '@domg-wc/common';
+import { VlButtonComponent } from '@domg-wc/components/atom';
 import {
     VlInfoTile,
     VlPopoverActionComponent,
@@ -15,6 +16,7 @@ import { customElement } from 'lit/decorators.js';
 export class AppComponent extends LitElement {
     static {
         registerWebComponents([
+            VlButtonComponent,
             VlHeader,
             VlPopoverComponent,
             VlPopoverActionListComponent,
@@ -144,6 +146,32 @@ export class AppComponent extends LitElement {
                                         <div style="height: 400px;"></div>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="vl-section">
+                        <div class="vl-content-block vl-content-block--full-width">
+                            <vl-title type="h2">FLUX-710: vl-button cta-link met download attribuut</vl-title>
+                            <p>
+                                Drie varianten: zonder download (navigeert), download zonder waarde (browser kiest
+                                bestandsnaam) en download met bestandsnaam. Klik en controleer dat de browser het
+                                bestand downloadt in plaats van te navigeren.
+                            </p>
+                            <div style="display: flex; gap: 12px; margin-top: 16px;">
+                                <vl-button cta-link="data:text/plain;charset=utf-8,FLUX-710 demo">
+                                    Zonder download (navigeert)
+                                </vl-button>
+                                <vl-button download cta-link="data:text/plain;charset=utf-8,FLUX-710 demo">
+                                    Download zonder bestandsnaam
+                                </vl-button>
+                                <vl-button
+                                    download="verslag.txt"
+                                    icon="file-download"
+                                    cta-link="data:text/plain;charset=utf-8,FLUX-710 demo"
+                                >
+                                    Download als verslag.txt
+                                </vl-button>
                             </div>
                         </div>
                     </section>

--- a/apps/playground-lit/src/index.html
+++ b/apps/playground-lit/src/index.html
@@ -9,6 +9,6 @@
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
     </head>
     <body>
-        <form-blur-poc></form-blur-poc>
+        <app-component></app-component>
     </body>
 </html>

--- a/libs/components/src/atom/button/stories/vl-button.stories-arg.ts
+++ b/libs/components/src/atom/button/stories/vl-button.stories-arg.ts
@@ -186,6 +186,16 @@ export const buttonArgTypes: ArgTypes<ButtonArgs> = {
             defaultValue: { summary: buttonArgs.ctaLink },
         },
     },
+    download: {
+        name: 'download',
+        description:
+            'Duidt aan dat de cta-link een download is in plaats van een navigatie.<br>Optioneel kan een bestandsnaam als waarde meegegeven worden, zonder waarde kiest de browser de bestandsnaam.<br>Werkt enkel voor same-origin URLs (browser-beperking).<br>Dit attribuut wordt enkel gebruikt als de `cta-link` is ingesteld.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(buttonArgs.download) },
+        },
+    },
     external: {
         name: 'external',
         description:

--- a/libs/components/src/atom/button/stories/vl-button.stories-doc.mdx
+++ b/libs/components/src/atom/button/stories/vl-button.stories-doc.mdx
@@ -141,6 +141,24 @@ Meer context over wanneer een button of een link te gebruiken kan je vinden in d
 
 <Canvas of={VlButtonStories.ButtonCtaLink}/>
 
+### CTA link als download
+
+Wijst de `cta-link` naar een bestand, gebruik dan het `download` attribuut om aan te geven dat de browser het bestand
+moet downloaden in plaats van ernaar te navigeren. Geef je een waarde mee, dan wordt die gebruikt als suggestie voor de
+bestandsnaam; zonder waarde kiest de browser zelf een bestandsnaam.
+
+Beperkingen:
+
+-   het `download` attribuut werkt enkel voor same-origin URLs (en `data:` of `blob:` URLs), dit is een
+browser-beperking van het [native anchor `download` attribuut](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download)
+-   het attribuut wordt enkel gebruikt als de `cta-link` is ingesteld
+
+Tip: maak in de zichtbare tekst of het `label` attribuut duidelijk dat het om een download gaat, zodat ook
+screen-reader gebruikers dit weten (bv. "Download verslag.pdf" i.p.v. "Verslag"). Een anchor met het `download`
+attribuut wordt nog steeds aangekondigd als een gewone link.
+
+<Canvas of={VlButtonStories.ButtonCtaLinkDownload}/>
+
 ### Input Group
 
 Het `input-group` attribuut is er om de knop een specifieke stijl te geven in combinatie met een input-field. Het

--- a/libs/components/src/atom/button/stories/vl-button.stories.ts
+++ b/libs/components/src/atom/button/stories/vl-button.stories.ts
@@ -38,6 +38,7 @@ const ButtonTemplate = story(
         loading,
         icon,
         ctaLink,
+        download,
         iconPlacement,
         toggle,
         on,
@@ -65,6 +66,7 @@ const ButtonTemplate = story(
                 label=${label}
                 icon=${icon}
                 cta-link=${ctaLink}
+                download=${download}
                 icon-placement=${iconPlacement}
                 ?toggle=${toggle}
                 ?on=${on}
@@ -199,6 +201,15 @@ ButtonCtaLink.args = {
     icon: 'add',
     defaultSlot: 'Voeg nieuw object toe.',
     ctaLink: 'https://www.vlaanderen.be',
+};
+
+export const ButtonCtaLinkDownload = ButtonTemplate.bind({});
+ButtonCtaLinkDownload.storyName = 'vl-button - cta-link - download';
+ButtonCtaLinkDownload.args = {
+    icon: 'file-download',
+    defaultSlot: 'Download het verslag',
+    ctaLink: 'data:text/plain;charset=utf-8,Verslag FLUX-710',
+    download: 'verslag.txt',
 };
 
 export const ButtonInputGroup = ButtonTemplate.bind({});

--- a/libs/components/src/atom/button/vl-button.component.cy.ts
+++ b/libs/components/src/atom/button/vl-button.component.cy.ts
@@ -316,6 +316,40 @@ describe('cypress-component - atom components - vl-button - cta-link', () => {
         cy.get('vl-button').shadow().find('a').should('not.have.attr', 'rel');
     });
 
+    it('should set download without filename', () => {
+        cy.mount(html` <vl-button download cta-link="https://www.vlaanderen.be/document.pdf">Download</vl-button>`);
+
+        cy.get('vl-button').should('have.attr', 'download');
+        cy.get('vl-button').shadow().find('a').should('have.attr', 'download', '');
+    });
+
+    it('should set download with filename', () => {
+        cy.mount(
+            html` <vl-button download="verslag.pdf" cta-link="https://www.vlaanderen.be/document.pdf"
+                >Download</vl-button
+            >`
+        );
+
+        cy.get('vl-button').should('have.attr', 'download', 'verslag.pdf');
+        cy.get('vl-button').shadow().find('a').should('have.attr', 'download', 'verslag.pdf');
+    });
+
+    it('should not set download when absent', () => {
+        cy.mount(html` <vl-button cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
+
+        cy.get('vl-button').shadow().find('a').should('not.have.attr', 'download');
+    });
+
+    it('should not set download when disabled', () => {
+        cy.mount(
+            html` <vl-button disabled download="verslag.pdf" cta-link="https://www.vlaanderen.be/document.pdf"
+                >Download</vl-button
+            >`
+        );
+
+        cy.get('vl-button').shadow().find('a').should('not.have.attr', 'download');
+    });
+
     it('should set disabled', () => {
         cy.mount(html` <vl-button disabled cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
 

--- a/libs/components/src/atom/button/vl-button.component.ts
+++ b/libs/components/src/atom/button/vl-button.component.ts
@@ -25,6 +25,7 @@ export class VlButtonComponent extends BaseLitElement {
     private toggle = buttonDefaults.toggle;
     private controlled = buttonDefaults.controlled;
     private ctaLink = buttonDefaults.ctaLink;
+    private download: string | null = buttonDefaults.download;
     private external = buttonDefaults.external;
     private inputGroup = buttonDefaults.inputGroup;
     private label = buttonDefaults.label;
@@ -51,6 +52,7 @@ export class VlButtonComponent extends BaseLitElement {
             toggle: { type: Boolean },
             controlled: { type: Boolean },
             ctaLink: { type: String, attribute: 'cta-link' },
+            download: { type: String },
             external: { type: Boolean },
             inputGroup: { type: Boolean, attribute: 'input-group' },
             label: { type: String },
@@ -219,6 +221,7 @@ export class VlButtonComponent extends BaseLitElement {
                 class=${classMap(classes)}
                 target=${this.ctaLink && this.external ? '_blank' : nothing}
                 rel=${this.ctaLink && this.external ? 'noopener noreferrer nofollow' : nothing}
+                download=${ifDefined(this.disabled ? undefined : (this.download ?? undefined))}
                 @click=${this.handleLinkClick}
                 aria-label=${ifDefined(this.ariaLabel || undefined)}
                 aria-pressed=${ifDefined(this.toggle ? (this.on ? 'true' : 'false') : undefined)}

--- a/libs/components/src/atom/button/vl-button.defaults.ts
+++ b/libs/components/src/atom/button/vl-button.defaults.ts
@@ -17,6 +17,8 @@ export const buttonDefaults = {
     toggle: false as boolean,
     controlled: false as boolean,
     ctaLink: '' as string,
+    // null = attribuut afwezig; lege string betekent downloaden met de bestandsnaam die de browser kiest
+    download: null as string | null,
     external: false as boolean,
     inputGroup: false as boolean,
     label: '' as string,

--- a/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
@@ -78,6 +78,16 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
             defaultValue: { summary: String(linkArgs.error) },
         },
     },
+    download: {
+        name: 'download',
+        description:
+            'Duidt aan dat de link een download is in plaats van een navigatie.<br>Optioneel kan een bestandsnaam als waarde meegegeven worden, zonder waarde kiest de browser de bestandsnaam.<br>Werkt enkel voor same-origin URLs (browser-beperking).<br>Werkt niet in combinatie met `button-as-link`-attribuut.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(linkArgs.download) },
+        },
+    },
     external: {
         name: 'external',
         description: 'Opent de link in een nieuw tabblad.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.',

--- a/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
+++ b/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
@@ -57,6 +57,24 @@ Vul steeds het `label` attribuut in om duidelijk te maken dat de link in een nie
 
 <Canvas of={VlLinkStories.LinkIcon} />
 
+### Download
+
+Wijst de link naar een bestand, gebruik dan het `download` attribuut om aan te geven dat de browser het bestand
+moet downloaden in plaats van ernaar te navigeren. Geef je een waarde mee, dan wordt die gebruikt als suggestie voor de
+bestandsnaam; zonder waarde kiest de browser zelf een bestandsnaam.
+
+Beperkingen:
+
+-   het `download` attribuut werkt enkel voor same-origin URLs (en `data:` of `blob:` URLs), dit is een
+browser-beperking van het [native anchor `download` attribuut](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download)
+-   het attribuut werkt niet in combinatie met `button-as-link`
+
+Tip: maak in de zichtbare tekst of het `label` attribuut duidelijk dat het om een download gaat, zodat ook
+screen-reader gebruikers dit weten (bv. "Download verslag.pdf" i.p.v. "Verslag"). Een anchor met het `download`
+attribuut wordt nog steeds aangekondigd als een gewone link.
+
+<Canvas of={VlLinkStories.LinkDownload} />
+
 ### Button als link
 
 Soms wil je een button stylen als een link. Een specifieke use-case is bvb. om van `Annuleren` een link te maken

--- a/libs/components/src/atom/link/stories/vl-link.stories.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories.ts
@@ -31,6 +31,7 @@ const LinkTemplate = story(
         large,
         error,
         external,
+        download,
         buttonAsLink,
         type,
         icon,
@@ -46,6 +47,7 @@ const LinkTemplate = story(
             ?large=${large}
             ?error=${error}
             ?external=${external}
+            download=${download}
             ?button-as-link=${buttonAsLink}
             type=${type}
             icon=${icon}
@@ -126,6 +128,17 @@ LinkIconOnly.args = {
     href: 'https://www.vlaanderen.be',
     icon: 'arrow-right-fat',
     label: 'Ga naar Vlaanderen.be',
+};
+
+export const LinkDownload = LinkTemplate.bind({});
+LinkDownload.storyName = 'vl-link - download';
+LinkDownload.args = {
+    href: 'data:text/plain;charset=utf-8,FLUX-710 link download demo',
+    defaultSlot: 'Download het verslag',
+    download: 'verslag.txt',
+    icon: 'file-download',
+    iconPlacement: 'before',
+    label: 'Download verslag.txt',
 };
 
 export const ButtonStyledAsLink = LinkTemplate.bind({});

--- a/libs/components/src/atom/link/vl-link.component.cy.ts
+++ b/libs/components/src/atom/link/vl-link.component.cy.ts
@@ -61,6 +61,26 @@ describe('cypress-component - atom components - vl-link', () => {
         cy.get('vl-link').shadow().find('a').should('have.attr', 'rel', 'noopener noreferrer nofollow');
     });
 
+    it('should set download without filename', () => {
+        cy.mount(html`<vl-link download href="data:text/plain,demo">Download</vl-link>`);
+
+        cy.get('vl-link').should('have.attr', 'download');
+        cy.get('vl-link').shadow().find('a').should('have.attr', 'download', '');
+    });
+
+    it('should set download with filename', () => {
+        cy.mount(html`<vl-link download="verslag.pdf" href="data:text/plain,demo">Download</vl-link>`);
+
+        cy.get('vl-link').should('have.attr', 'download', 'verslag.pdf');
+        cy.get('vl-link').shadow().find('a').should('have.attr', 'download', 'verslag.pdf');
+    });
+
+    it('should not set download when absent', () => {
+        cy.mount(html`<vl-link href="https://www.vlaanderen.be">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('a').should('not.have.attr', 'download');
+    });
+
     it('should set aria-label', () => {
         cy.mount(html`<vl-link label="link naar Vlaanderen">Vlaanderen</vl-link>`);
 

--- a/libs/components/src/atom/link/vl-link.component.ts
+++ b/libs/components/src/atom/link/vl-link.component.ts
@@ -18,6 +18,7 @@ export class VlLinkComponent extends BaseLitElement {
     private large = linkDefaults.large;
     private error = linkDefaults.error;
     private external = linkDefaults.external;
+    private download: string | null = linkDefaults.download;
     private icon = linkDefaults.icon;
     private iconPlacement = linkDefaults.iconPlacement;
     private buttonAsLink = linkDefaults.buttonAsLink;
@@ -37,6 +38,7 @@ export class VlLinkComponent extends BaseLitElement {
             small: { type: Boolean },
             large: { type: Boolean },
             external: { type: Boolean },
+            download: { type: String },
             icon: { type: String },
             iconPlacement: { type: String, attribute: 'icon-placement' },
             buttonAsLink: { type: Boolean, attribute: 'button-as-link' },
@@ -60,6 +62,7 @@ export class VlLinkComponent extends BaseLitElement {
                       href=${this.href}
                       target=${target}
                       rel=${rel}
+                      download=${ifDefined(this.download ?? undefined)}
                       part="link"
                       aria-label=${this.label || nothing}
                       aria-haspopup=${ifDefined(

--- a/libs/components/src/atom/link/vl-link.defaults.ts
+++ b/libs/components/src/atom/link/vl-link.defaults.ts
@@ -8,6 +8,8 @@ export const linkDefaults = {
     large: false as boolean,
     error: false as boolean,
     external: false as boolean,
+    // null = attribuut afwezig; lege string betekent downloaden met de bestandsnaam die de browser kiest
+    download: null as string | null,
     icon: '' as string,
     iconPlacement: '' as ICON_PLACEMENT,
     buttonAsLink: false as boolean,


### PR DESCRIPTION
`download`-attribuut toegevoegd:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-710
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC372 ✅ 