### PR TITLE
fix: FLUX-692 - vl-button - noopener,noreferrer toegevoegd bij externe cta-link

### DIFF
--- a/libs/components/src/atom/button/stories/vl-button.stories-arg.ts
+++ b/libs/components/src/atom/button/stories/vl-button.stories-arg.ts
@@ -207,7 +207,8 @@ export const buttonArgTypes: ArgTypes<ButtonArgs> = {
     },
     label: {
         name: 'label',
-        description: 'Stelt het aria-label attribuut van de button in.',
+        description:
+            'Stelt het aria-label attribuut van de button in. Gebruik je een `cta-link` met `external`, geef dan een duidelijke omschrijving mee van waar de link naartoe leidt, bv. "Ga naar Vlaanderen.be (opent in een nieuw venster)".',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/atom/button/vl-button.component.cy.ts
+++ b/libs/components/src/atom/button/vl-button.component.cy.ts
@@ -306,6 +306,14 @@ describe('cypress-component - atom components - vl-button - cta-link', () => {
 
         cy.get('vl-button').should('have.attr', 'external');
         cy.get('vl-button').shadow().find('a').should('have.attr', 'target', '_blank');
+        cy.get('vl-button').shadow().find('a').should('have.attr', 'rel', 'noopener noreferrer nofollow');
+    });
+
+    it('should not set target and rel when not external', () => {
+        cy.mount(html` <vl-button cta-link="https://www.vlaanderen.be">Klik op mij</vl-button>`);
+
+        cy.get('vl-button').shadow().find('a').should('not.have.attr', 'target');
+        cy.get('vl-button').shadow().find('a').should('not.have.attr', 'rel');
     });
 
     it('should set disabled', () => {

--- a/libs/components/src/atom/button/vl-button.component.ts
+++ b/libs/components/src/atom/button/vl-button.component.ts
@@ -218,6 +218,7 @@ export class VlButtonComponent extends BaseLitElement {
                 tabindex=${ifDefined(this.disabled ? '-1' : undefined)}
                 class=${classMap(classes)}
                 target=${this.ctaLink && this.external ? '_blank' : nothing}
+                rel=${this.ctaLink && this.external ? 'noopener noreferrer nofollow' : nothing}
                 @click=${this.handleLinkClick}
                 aria-label=${ifDefined(this.ariaLabel || undefined)}
                 aria-pressed=${ifDefined(this.toggle ? (this.on ? 'true' : 'false') : undefined)}
@@ -239,7 +240,9 @@ export class VlButtonComponent extends BaseLitElement {
                 ${positionIconBefore ? this.renderIcon() : nothing}
                 <slot @slotchange=${this.handleSlotChange}></slot>
                 ${!positionIconBefore ? this.renderIcon() : nothing}
-                ${this.external ? html`<span class="vl-icon vl-icon--external vl-icon--after"></span>` : nothing}
+                ${this.external
+                    ? html`<span class="vl-icon vl-icon--external vl-icon--after" aria-hidden="true"></span>`
+                    : nothing}
             </a>
         `;
     }


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-692
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC371 ✅ 