### PR TITLE
fix: FLUX-671 - vl-footer-next - reserveer ruimte voor sticky footer bar

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -8,6 +8,7 @@ import {
     VlPropertiesComponent,
 } from '@domg-wc/components/block';
 import { VlHeader } from '@domg-wc/components/compliance';
+import { VlFooter as VlFooterNext } from '@domg-wc/components/compliance/next';
 import { VlDatepickerComponent } from '@domg-wc/components/form';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -24,6 +25,7 @@ export class AppComponent extends LitElement {
             VlDatepickerComponent,
             VlInfoTile,
             VlPropertiesComponent,
+            VlFooterNext,
         ]);
     }
 
@@ -175,6 +177,26 @@ export class AppComponent extends LitElement {
                             </div>
                         </div>
                     </section>
+
+                    <section class="vl-section" style="padding-bottom: 0;">
+                        <div class="vl-content-block vl-content-block--full-width" style="margin-bottom: 0;">
+                            <vl-title type="h2">Sticky footer overlap repro</vl-title>
+                            <p>
+                                Echte global footer widget (tni, MJV identifier, collapsible). Zonder fix bedekt de
+                                fixed bar (35px) de onderste content; met fix reserveert
+                                <code>#footer__container</code> de bar-hoogte via <code>min-height</code>.
+                            </p>
+                            <div style="height: 900px;"></div>
+                            <div
+                                id="sticky-footer-last-content"
+                                style="border: 3px solid crimson; background: #fffbe6; padding: 6px 10px;
+                                       font-weight: bold; margin-bottom: 0;"
+                            >
+                                ONDERSTE CONTENT: moet volledig zichtbaar blijven boven de footer-bar
+                            </div>
+                        </div>
+                    </section>
+                    <vl-footer-next development identifier="9e74e418-5be0-48ba-9c43-7d420f3a0e1c"></vl-footer-next>
                 </main>
             </vl-template>
         `;

--- a/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
+++ b/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
@@ -44,6 +44,30 @@ import { VlFooter } from '@domg-wc/components/compliance/next';
 <ArgTypes of={VlFooterStories.FooterDefault}/>
 
 
+## Sticky footer bar
+
+In collapsible modus toont de widget een `position: fixed` bar onderaan de pagina. Zonder
+gereserveerde ruimte bedekt die bar de onderste content. De component reserveert daarom
+standaard `48px`: dat is de hoogte van de bar op een smal scherm, op een breed scherm is
+de bar `35px`.
+
+Afnemers kunnen die hoogte overschrijven of de reservering volledig uitzetten via de
+CSS-variabele `--vl-footer--bar-reserved-height`, gezet op `:root`, `body` of een ander
+element boven de footer container:
+
+```css
+/* Eigen hoogte reserveren */
+:root {
+    --vl-footer--bar-reserved-height: 60px;
+}
+
+/* Reservering uitzetten (bv. wanneer de pagina de ruimte zelf al voorziet) */
+:root {
+    --vl-footer--bar-reserved-height: 0px;
+}
+```
+
+
 ## Referenties
 
 ### Digitaal Vlaanderen

--- a/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
@@ -83,4 +83,32 @@ describe('cypress-component - compliance components - vl-footer-next', () => {
             cy.get('@ready').should('have.been.calledOnce');
         });
     });
+
+    describe('sticky footer spacer', () => {
+        const RESERVED_HEIGHT_VAR = '--vl-footer--bar-reserved-height';
+
+        afterEach(() => {
+            document.documentElement.style.removeProperty(RESERVED_HEIGHT_VAR);
+        });
+
+        it('should reserve space for the fixed footer bar on the container', () => {
+            mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+            cy.get('#footer__container').should('have.css', 'min-height', '48px');
+        });
+
+        it('should let consumers override the reserved height via CSS variable', () => {
+            document.documentElement.style.setProperty(RESERVED_HEIGHT_VAR, '60px');
+            mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+            cy.get('#footer__container').should('have.css', 'min-height', '60px');
+        });
+
+        it('should let consumers disable the reservation via CSS variable', () => {
+            document.documentElement.style.setProperty(RESERVED_HEIGHT_VAR, '0px');
+            mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+            cy.get('#footer__container').should('have.css', 'min-height', '0px');
+        });
+    });
 });

--- a/libs/components/src/compliance/next/footer/vl-footer.component.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.ts
@@ -52,7 +52,7 @@ export class VlFooter extends BaseLitElement {
 
         (vlBody || document.body).insertAdjacentHTML(
             'beforeend',
-            '<footer id="footer__container"><div id="footer"></div></footer>'
+            '<footer id="footer__container" style="min-height: var(--vl-footer--bar-reserved-height, 48px)"><div id="footer"></div></footer>'
         );
     }
 


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-671
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC373 ✅ 

## Fix bekijken (Lit playground)

1. `npm run apps:playground-lit:dev`
2. Open de dev server (bv. http://localhost:8080), scroll naar de sectie
   "Sticky footer overlap repro" onderaan.
3. De rode marker "ONDERSTE CONTENT" blijft volledig zichtbaar: onder de marker
   is 48px ruimte gereserveerd waar de footer bar normaal valt.
4. Controleer in devtools dat `#footer__container` `min-height: 48px` heeft.
5. CSS-variabele live testen in de devtools console:

   ```js
   // reservering uitzetten (oude bug-gedrag: marker wordt bedekt)
   document.documentElement.style.setProperty('--vl-footer--bar-reserved-height', '0px')

   // grotere reservering
   document.documentElement.style.setProperty('--vl-footer--bar-reserved-height', '80px')

   // terug naar default
   document.documentElement.style.removeProperty('--vl-footer--bar-reserved-height')
   ```

Let op: de echte grijze footer bar rendert niet op localhost (widget is
referer-gated, geeft 400 buiten de geregistreerde domeinen). De reservering is wel
volledig testbaar, want die wordt bij injectie gezet, los van de widget.
