### PR TITLE
feat: FLUX-251 - vl-modal - reactief open-attribuut en open/close events

### DIFF
--- a/libs/components/src/block/modal/stories/vl-modal.stories-arg.ts
+++ b/libs/components/src/block/modal/stories/vl-modal.stories-arg.ts
@@ -1,5 +1,6 @@
 import { CATEGORIES, defaultArgs, defaultArgTypes, TYPES } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
+import { action } from 'storybook/actions';
 
 export const modalArgs = {
     ...defaultArgs,
@@ -15,6 +16,8 @@ export const modalArgs = {
     size: 'default',
     position: 'center',
     focusOnModal: false,
+    onVlOpen: action('vl-open'),
+    onVlClose: action('vl-close'),
 };
 
 export const modalArgTypes: ArgTypes<typeof modalArgs> = {
@@ -41,7 +44,8 @@ export const modalArgTypes: ArgTypes<typeof modalArgs> = {
     },
     open: {
         name: 'open',
-        description: 'Attribuut om de modal onmiddellijk te openen na de rendering.',
+        description:
+            'Reactief attribuut dat de open-staat van de modal stuurt: toevoegen opent de modal, verwijderen sluit hem. Het attribuut blijft in sync met de werkelijke staat (na sluiten via knop, escape of backdrop is het weg).',
         table: {
             type: { summary: 'Boolean' },
             defaultValue: { summary: 'false' },
@@ -131,6 +135,22 @@ export const modalArgTypes: ArgTypes<typeof modalArgs> = {
             type: { summary: 'Boolean' },
             defaultValue: { summary: String(modalArgs.focusOnModal) },
             category: CATEGORIES.ATTRIBUTES,
+        },
+    },
+    onVlOpen: {
+        name: 'vl-open',
+        description:
+            'Event dat afgevuurd wordt wanneer de modal opent, ongeacht of dat via het `open`-attribuut, de `open()`-methode, een knop of escape gebeurt.',
+        table: {
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlClose: {
+        name: 'vl-close',
+        description:
+            'Event dat afgevuurd wordt wanneer de modal sluit, ongeacht of dat via het `open`-attribuut, de `close()`-methode, een knop of escape gebeurt.',
+        table: {
+            category: CATEGORIES.EVENTS,
         },
     },
 };

--- a/libs/components/src/block/modal/stories/vl-modal.stories-doc.mdx
+++ b/libs/components/src/block/modal/stories/vl-modal.stories-doc.mdx
@@ -28,6 +28,53 @@ import { VlModalComponent } from '@domg-wc/components/block';
 <ArgTypes of={VlModalStories.modalDefault} />
 
 
+## Reactief open-attribuut
+
+Het `open` attribuut is reactief en weerspiegelt de werkelijke open-staat van de modal. Het attribuut toevoegen opent
+de modal, het verwijderen sluit ze:
+
+```html
+<vl-modal open></vl-modal>
+```
+
+Wanneer de modal sluit via de annuleer-knop, de sluit-knop, de escape-toets of de backdrop, wordt het `open` attribuut
+automatisch van de host verwijderd.
+
+> **Let op met toegankelijkheid:** openen via het `open` attribuut (of via de `open()` methode) ontslaat de afnemer niet
+> van de regel dat een modal idealiter via een knop of link getriggerd wordt. Wie de modal opent zonder zo'n trigger
+> is zelf verantwoordelijk om de focus correct te beheren - in het bijzonder om de focus bij het sluiten terug te
+> plaatsen op een logisch element (typisch het element dat de modal opende). Doe je dat niet, dan blijft de focus achter
+> op een onvoorspelbare plaats, wat de toegankelijkheid voor toetsenbord- en schermlezer-gebruikers schaadt. Zie
+> [Toegankelijkheid](#toegankelijkheid) voor de aanbevolen werkwijze.
+
+
+## Events
+
+<table>
+    <tr>
+        <td>Event</td>
+        <td>Beschrijving</td>
+    </tr>
+    <tr>
+        <td>`vl-open`</td>
+        <td>Wordt afgevuurd wanneer de modal opent, ongeacht of dat via het `open` attribuut, de `open()` methode of een trigger gebeurde.</td>
+    </tr>
+    <tr>
+        <td>`vl-close`</td>
+        <td>Wordt afgevuurd wanneer de modal sluit, ongeacht of dat via het `open` attribuut, de `close()` methode, de annuleer-/sluit-knop, escape of de backdrop gebeurde.</td>
+    </tr>
+</table>
+
+Beide events bubbelen en gaan door de shadow-DOM (`bubbles: true, composed: true`), zodat ze ook buiten de component
+opgevangen kunnen worden:
+
+```js
+document.querySelector('vl-modal').addEventListener('vl-close', () => {
+    // reageer op het sluiten van de modal
+});
+```
+
+
 ## Varianten
 
 ### Met andere actie
@@ -60,17 +107,29 @@ import { VlModalComponent } from '@domg-wc/components/block';
 
 ## Toegankelijkheid
 
-Het triggeren van de modal moet altijd gebeuren via een knop of link. Voor screen readers is het belangrijk dat deze knop of link de juiste aria-attributen bevat. Het gebruik van `aria-haspopup="dialog"` is in dit geval verplicht. Optioneel kan je `aria-controls` toevoegen met als value de ID van de modal (dit is echter overbodig wanneer de knop binnen een shadow DOM zit (bv vl-button), omdat de koppeling met de ID niet werkt doorheen de shadow DOM). **Deze aria-attributen moet de afnemer zelf implementeren!**.
+Het triggeren van de modal moet altijd gebeuren via een knop of link. Voor screen readers is het belangrijk dat deze
+knop of link de juiste aria-attributen bevat. Het gebruik van `aria-haspopup="dialog"` is in dit geval verplicht.
+Optioneel kan je `aria-controls` toevoegen met als value de ID van de modal (dit is echter overbodig wanneer de knop
+binnen een shadow DOM zit (bv vl-button), omdat de koppeling met de ID niet werkt doorheen de shadow DOM). **Deze
+aria-attributen moet de afnemer zelf implementeren!**.
 
-De vl-modal zal standaard de focus leggen op het eerste focusbare element binnenin de modal wanneer deze geopend wordt. 
-Dit kan aangepast worden door het `focus-on-modal` attribuut toe te voegen aan de modal, 
+Een belangrijke reden voor deze regel is het focusbeheer: wanneer de modal sluit, moet de focus terugkeren naar de
+trigger (de knop of link die de modal opende). Door de modal via zo'n trigger te openen, gebeurt dit op een
+natuurlijke en voorspelbare manier. Het [reactief openen via het `open` attribuut](#reactief-open-attribuut) of de
+`open()` methode blijft mogelijk en is soms nodig (bv. om de open-staat declaratief te sturen), maar wie deze weg
+kiest in plaats van een trigger, moet het terugplaatsen van de focus bij het sluiten zelf afhandelen. De
+`vl-close`-event is hiervoor een geschikt aangrijpingspunt.
+
+De vl-modal zal standaard de focus leggen op het eerste focusbare element binnenin de modal wanneer deze geopend wordt.
+Dit kan aangepast worden door het `focus-on-modal` attribuut toe te voegen aan de modal,
 in dat geval zal de focus op de modal zelf gelegd worden bij het openen. Gebruik dit enkel indien
-het automatisch focussen op het eerste focusbare element problemen veroorzaakt, bijvoorbeeld wanneer dit meteen een popover triggert.
+het automatisch focussen op het eerste focusbare element problemen veroorzaakt, bijvoorbeeld wanneer dit meteen een
+popover triggert.
 
 Het is essentieel dat de modal goed gelabeld is voor gebruikers van schermlezers.
 Dit kan op twee manieren bereikt worden:
 - Door het `title` attribuut te gebruiken. Onderliggend wordt dit gekoppeld adhv `aria-labelledby`.
-- Indien het design geen titel toelaat, moet het `label` attribuut gebruikt worden zodat een beschrijvende `aria-label` 
+- Indien het design geen titel toelaat, moet het `label` attribuut gebruikt worden zodat een beschrijvende `aria-label`
   kan toegevoegd worden aan de modal.
 
 

--- a/libs/components/src/block/modal/vl-modal.component.cy.ts
+++ b/libs/components/src/block/modal/vl-modal.component.cy.ts
@@ -282,6 +282,92 @@ describe('cypress-component - block components - vl-modal', () => {
     });
 });
 
+describe('cypress-component - block components - vl-modal - reactive open attribuut', () => {
+    it('should close the modal when the open attribuut is removed', () => {
+        cy.mount(renderModal({ open: true }));
+        cy.injectAxe();
+
+        isDialogVisible();
+        cy.getDataCy('modal').invoke('removeAttr', 'open');
+        isDialogHidden();
+        cy.checkA11y('vl-modal');
+    });
+
+    it('should open the modal when the open attribuut is added', () => {
+        cy.mount(renderModal({}));
+        cy.injectAxe();
+
+        isDialogHidden();
+        cy.getDataCy('modal').invoke('attr', 'open', '');
+        isDialogVisible();
+        cy.checkA11y('vl-modal');
+    });
+
+    it('should remove the open attribuut from the host when closing via the cancel button', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({})}`);
+
+        openModal();
+        isDialogVisible();
+        cy.getDataCy('modal').should('have.attr', 'open');
+        closeWithCancelButton();
+        isDialogHidden();
+        cy.getDataCy('modal').should('not.have.attr', 'open');
+    });
+});
+
+describe('cypress-component - block components - vl-modal - events', () => {
+    it('should dispatch vl-open when opening via the open attribuut', () => {
+        cy.mount(renderModal({}));
+        cy.get('vl-modal').then(($el) => {
+            $el[0].addEventListener('vl-open', cy.stub().as('vlOpen'));
+        });
+
+        cy.getDataCy('modal').invoke('attr', 'open', '');
+        isDialogVisible();
+        cy.get('@vlOpen').should('have.been.calledOnce');
+    });
+
+    it('should dispatch vl-close when closing via the open attribuut', () => {
+        cy.mount(renderModal({ open: true }));
+        cy.get('vl-modal').then(($el) => {
+            $el[0].addEventListener('vl-close', cy.stub().as('vlClose'));
+        });
+
+        isDialogVisible();
+        cy.getDataCy('modal').invoke('removeAttr', 'open');
+        isDialogHidden();
+        cy.get('@vlClose').should('have.been.calledOnce');
+    });
+
+    it('should dispatch vl-open via a trigger and vl-close via the cancel button', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({})}`);
+        cy.get('vl-modal').then(($el) => {
+            $el[0].addEventListener('vl-open', cy.stub().as('vlOpen'));
+            $el[0].addEventListener('vl-close', cy.stub().as('vlClose'));
+        });
+
+        openModal();
+        isDialogVisible();
+        cy.get('@vlOpen').should('have.been.calledOnce');
+        closeWithCancelButton();
+        isDialogHidden();
+        cy.get('@vlClose').should('have.been.calledOnce');
+    });
+
+    it('should dispatch vl-close when closing by pressing escape', () => {
+        cy.mount(html`${renderOpenButton()} ${renderModal({ button: otherActionButton })}`);
+        cy.get('vl-modal').then(($el) => {
+            $el[0].addEventListener('vl-close', cy.stub().as('vlClose'));
+        });
+
+        openModal();
+        isDialogVisible();
+        closeByPressingEscape();
+        isDialogHidden();
+        cy.get('@vlClose').should('have.been.calledOnce');
+    });
+});
+
 describe('cypress-component - block components - vl-modal - notAutoClosable (true)', () => {
     it('should NOT automatically close the modal when using the action button', () => {
         cy.mount(html`${renderOpenButton()} ${renderModal({ notAutoClosable: true })}`);

--- a/libs/components/src/block/modal/vl-modal.component.ts
+++ b/libs/components/src/block/modal/vl-modal.component.ts
@@ -24,6 +24,9 @@ export class VlModalComponent extends BaseHTMLElement {
         registerWebComponents([VlLinkComponent]);
     }
 
+    private _openObserver?: MutationObserver;
+    private _lastDispatchedOpen = false;
+
     constructor() {
         const html = `
             <div class="vl-modal">
@@ -134,6 +137,7 @@ export class VlModalComponent extends BaseHTMLElement {
         super.connectedCallback();
 
         this.dress();
+        this._observeDialogOpenState();
         this._shadow?.host.addEventListener('keyup', this._onEscape);
 
         if (this.hasAttribute('size')) {
@@ -147,7 +151,38 @@ export class VlModalComponent extends BaseHTMLElement {
     }
 
     disconnectedCallback() {
+        this._openObserver?.disconnect();
         this._shadow?.host?.removeEventListener('keyup', this._onEscape);
+    }
+
+    /**
+     * Houdt het host `open`-attribuut in sync met de werkelijke dialog-staat en vuurt de vl-open / vl-close events af,
+     * ongeacht via welk pad (attribuut, methode, knop, Escape, backdrop) de modal opent of sluit. De native `<dialog>`
+     * kent geen open-event, daarom observeren we het `open`-attribuut van de dialog zelf.
+     */
+    private _observeDialogOpenState() {
+        this._openObserver?.disconnect();
+        const dialog = this._dialogElement;
+        if (!dialog) {
+            return;
+        }
+        this._lastDispatchedOpen = !!this.isOpen();
+        this._openObserver = new MutationObserver(() => this._onDialogOpenStateChanged());
+        this._openObserver.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+    }
+
+    private _onDialogOpenStateChanged() {
+        const isOpen = !!this.isOpen();
+        if (isOpen === this._lastDispatchedOpen) {
+            return;
+        }
+        this._lastDispatchedOpen = isOpen;
+        if (isOpen && !this.hasAttribute('open')) {
+            this.setAttribute('open', '');
+        } else if (!isOpen && this.hasAttribute('open')) {
+            this.removeAttribute('open');
+        }
+        this.dispatchEvent(new CustomEvent(isOpen ? 'vl-open' : 'vl-close', { bubbles: true, composed: true }));
     }
 
     /**
@@ -164,8 +199,10 @@ export class VlModalComponent extends BaseHTMLElement {
      * Handmatig openen van modal.
      */
     open() {
-        vl.modal.lastClickedToggle = this._dialogElement;
         if (!this.isOpen()) {
+            // enkel bij effectief openen zetten: anders zouden we de trigger-referentie die de lib bij een knop-klik
+            // bewaart overschrijven, waardoor focus bij sluiten niet terugkeert naar de openende knop
+            vl.modal.lastClickedToggle = this._dialogElement;
             awaitUntil(() => this._dialogElement.isConnected).then(() => {
                 vl.modal.toggle(this._dialogElement);
             });
@@ -259,8 +296,12 @@ export class VlModalComponent extends BaseHTMLElement {
         }
     }
 
-    _openChangedCallback() {
-        this.open();
+    _openChangedCallback(oldValue: string, newValue: string) {
+        if (newValue == undefined) {
+            this.close();
+        } else {
+            this.open();
+        }
     }
 
     _closableChangedCallback(oldValue: string, newValue: string) {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-251
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC376

## Samenvatting
Het `open`-attribuut van `vl-modal` is voortaan reactief en weerspiegelt de werkelijke staat: toevoegen opent de modal, verwijderen sluit ze, en na sluiten via knop, Escape of backdrop verdwijnt het attribuut vanzelf. Daarnaast vuurt de modal nu `vl-open`- en `vl-close`-events, zodat consumers declaratief op statuswijzigingen kunnen reageren zonder de component te queryen.

## Wijzigingen
- Het `open`-attribuut sluit de modal bij verwijderen (i.p.v. de modal te heropenen) en blijft gesynchroniseerd met de werkelijke open-staat.
- Nieuwe events `vl-open` en `vl-close` (`bubbles: true, composed: true`) vuren bij elke open-/sluit-route: attribuut, methode, trigger, knop, Escape en backdrop.
- Focus keert bij sluiten correct terug naar de openende knop (latente regressie rond de trigger-referentie opgelost).
- Storybook-documentatie en argTypes beschrijven het reactieve `open`-gedrag en de nieuwe events.
- Cypress-tests uitgebreid met dekking voor attribuut-sync en event-dispatch over alle routes.

## Backwards compatibility
Additieve wijziging met één gedragscorrectie: het verwijderen van `open` sluit voortaan de modal (voorheen zonder effect / heropende ze). Dit is het gedocumenteerde gedrag en herstelt een latente bug; geen API-rename en geen migratie nodig voor bestaande consumers.

## Succescriteria
- [x] Verwijderen van `open` sluit de modal (toevoegen opent ze) — `_openChangedCallback` kiest `open()`/`close()` op basis van het attribuut.
- [x] Host-`open` blijft gesynchroniseerd met de werkelijke staat (na knop/Escape/backdrop is het attribuut weg) — een `MutationObserver` op de interne `<dialog>` synct het host-attribuut terug.
- [x] `vl-modal` dispatcht een event bij openen én sluiten (`bubbles: true, composed: true`), ongeacht de route — gedispatcht vanuit dezelfde observer.
- [x] Storybook-documentatie beschrijft het reactieve `open`-gedrag en de events — `stories-arg.ts` + nieuwe secties in `stories-doc.mdx`.
- [x] Cypress dekt: attribuut verwijderen → dicht, sluiten via knop → attribuut weg, events bij elke flow — 7 nieuwe tests, 28/28 passing.
