### PR TITLE
fix: FLUX-462 - vl-rich-data / vl-pager - paginatie state-sync

### DIFF
--- a/libs/components/src/block/pager/vl-pager.component.cy.ts
+++ b/libs/components/src/block/pager/vl-pager.component.cy.ts
@@ -1,0 +1,66 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { html } from 'lit';
+import { VlPagerComponent } from './vl-pager.component';
+
+registerWebComponents([VlPagerComponent]);
+
+describe('cypress-component - block components - vl-pager', () => {
+    it('should be accessible', () => {
+        cy.mount(html`<vl-pager total-items="25" items-per-page="5" current-page="1"></vl-pager>`);
+        cy.injectAxe();
+        cy.checkA11y('vl-pager');
+    });
+
+    it('should not dispatch a change event when the effective page does not change', () => {
+        const onChange = cy.stub().as('onChange');
+        cy.mount(html`<vl-pager total-items="25" items-per-page="5" current-page="5"></vl-pager>`);
+        cy.get('vl-pager').then(($el) => $el[0].addEventListener('change', onChange));
+
+        cy.get('vl-pager').invoke('attr', 'total-items', '5');
+        cy.get('vl-pager').invoke('attr', 'current-page', '1');
+
+        cy.get('@onChange').should('not.have.been.called');
+    });
+
+    it('should not dispatch a change event when the effective page does not change, regardless of attribute order', () => {
+        const onChange = cy.stub().as('onChange');
+        cy.mount(html`<vl-pager total-items="25" items-per-page="5" current-page="5"></vl-pager>`);
+        cy.get('vl-pager').then(($el) => $el[0].addEventListener('change', onChange));
+
+        // De consumer (vl-rich-data._paging) zet beide attributen in een synchrone batch, met
+        // current-page voor total-items. De effectieve pagina blijft 1 (pagina 5 bestaat niet
+        // meer met 5 items), dus er mag geen event vuren ongeacht de volgorde binnen de batch.
+        cy.get('vl-pager').then(($el) => {
+            $el[0].setAttribute('current-page', '1');
+            $el[0].setAttribute('total-items', '5');
+        });
+
+        cy.get('@onChange').should('not.have.been.called');
+    });
+
+    it('should dispatch a change event with the clamped current page on a real change', () => {
+        const onChange = cy.stub().as('onChange');
+        cy.mount(html`<vl-pager total-items="25" items-per-page="5" current-page="1"></vl-pager>`);
+        cy.get('vl-pager').then(($el) => $el[0].addEventListener('change', onChange));
+
+        cy.get('vl-pager').invoke('attr', 'current-page', '3');
+
+        cy.get('@onChange')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail.currentPage')
+            .should('equal', 3);
+    });
+
+    it('should clamp an out-of-range current-page in the change event detail', () => {
+        const onChange = cy.stub().as('onChange');
+        cy.mount(html`<vl-pager total-items="25" items-per-page="5" current-page="1"></vl-pager>`);
+        cy.get('vl-pager').then(($el) => $el[0].addEventListener('change', onChange));
+
+        cy.get('vl-pager').invoke('attr', 'current-page', '99');
+
+        cy.get('@onChange')
+            .should('have.been.calledOnce')
+            .its('firstCall.args.0.detail.currentPage')
+            .should('equal', 5);
+    });
+});

--- a/libs/components/src/block/pager/vl-pager.component.ts
+++ b/libs/components/src/block/pager/vl-pager.component.ts
@@ -72,12 +72,14 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
     }
 
     get currentPage() {
-        const currentPage = parseInt(this.getAttribute('current-page') ?? '0');
-        if (currentPage < 1) {
+        return this._clampPage(parseInt(this.getAttribute('current-page') ?? '0'));
+    }
+
+    private _clampPage(page: number): number {
+        if (page < 1) {
             return 1;
-        } else {
-            return currentPage <= this.totalPages ? currentPage : this.totalPages;
         }
+        return page <= this.totalPages ? page : this.totalPages;
     }
 
     get itemsPerPage() {
@@ -219,19 +221,35 @@ export class VlPagerComponent extends BaseHTMLElement implements Pagination {
 
     _currentPageChangedCallback(oldValue: string, newValue: string) {
         this._update();
-        if (oldValue && newValue != oldValue) {
-            const event = {
-                detail: {
-                    currentPage: Number(newValue),
-                    totalPage: this.totalPages,
-                    itemsPerPage: this.itemsPerPage,
-                    totalItems: this.totalItems,
-                },
-                bubbles: true,
-            };
-            this.dispatchEvent(new CustomEvent('change', event));
+        if (!oldValue) {
+            return;
+        }
+        // Vergelijk de effectieve pagina's: een attribuut wijziging naar bv. "1" terwijl de effectieve pagina
+        // al 1 was (door gekrompen total-items) mag geen event vuren. Het gedrag onafhankelijk van de volgorde
+        // waarin de consumer de attributen zet.
+        if (this.__previousPageBeforeChange == null) {
+            this.__previousPageBeforeChange = parseInt(oldValue);
+            queueMicrotask(() => {
+                const previousPage = this._clampPage(this.__previousPageBeforeChange!);
+                this.__previousPageBeforeChange = undefined;
+                const currentPage = this.currentPage;
+                if (currentPage !== previousPage) {
+                    const event = {
+                        detail: {
+                            currentPage,
+                            totalPage: this.totalPages,
+                            itemsPerPage: this.itemsPerPage,
+                            totalItems: this.totalItems,
+                        },
+                        bubbles: true,
+                    };
+                    this.dispatchEvent(new CustomEvent('change', event));
+                }
+            });
         }
     }
+
+    private __previousPageBeforeChange?: number;
 
     _paginationDisabledChangedCallback(oldValue: string, newValue: string) {
         if (newValue !== null) {

--- a/libs/components/src/block/rich-data/vl-rich-data.component.cy.ts
+++ b/libs/components/src/block/rich-data/vl-rich-data.component.cy.ts
@@ -8,7 +8,7 @@ import { VlSelectComponent } from '../../form/select';
 import { VlPagerComponent } from '../pager';
 import { VlSearchFilterComponent } from '../search-filter';
 import { VlSearchResultComponent } from '../search-result';
-import { VlRichData } from './vl-rich-data.component';
+import { RichData, VlRichData } from './vl-rich-data.component';
 
 registerWebComponents([
     VlRichData,
@@ -68,6 +68,21 @@ describe('cypress-component - block components - vl-rich-data', () => {
             .then((child) => {
                 expect(child[0]).to.contain('6-10');
             });
+    });
+
+    it('should reflect the live pager page in the data property after a page change', () => {
+        cy.get('vl-rich-data').then(($el) => {
+            ($el[0] as VlRichData).data = {
+                data: [],
+                paging: { currentPage: 1, totalPages: 5, itemsPerPage: 5, totalItems: 25 },
+            };
+        });
+
+        cy.get('vl-pager').shadow().find('li[data-pager-page=2]').click({ force: true });
+
+        cy.get('vl-rich-data').then(($el) => {
+            expect((($el[0] as VlRichData).data as RichData).paging?.currentPage).to.equal(2);
+        });
     });
 });
 

--- a/libs/components/src/block/rich-data/vl-rich-data.component.ts
+++ b/libs/components/src/block/rich-data/vl-rich-data.component.ts
@@ -114,11 +114,15 @@ export class VlRichData extends BaseHTMLElement {
     protected _data: RichData | undefined;
 
     /**
-     * Geeft de data terug die in de tabel wordt getoond.
+     * Geeft de data terug die in de tabel wordt getoond. De actieve pagina komt
+     * uit de pager, ze is dus altijd up-to-date, ook na een pagina-wissel.
      * @return {Object[]}
      */
     get data() {
-        return this._data || <any>{ data: [] };
+        if (!this._data) {
+            return <any>{ data: [] };
+        }
+        return this._paging ? { ...this._data, paging: this._paging } : this._data;
     }
 
     /**
@@ -225,7 +229,7 @@ export class VlRichData extends BaseHTMLElement {
         return Boolean(this._paging && this._paging.totalItems > 0);
     }
 
-    get _paging(): Pagination | void {
+    get _paging(): Pagination | undefined {
         if (this.__pager) {
             return {
                 currentPage: this.__pager.currentPage,
@@ -234,9 +238,10 @@ export class VlRichData extends BaseHTMLElement {
                 totalItems: this.__pager.totalItems,
             };
         }
+        return undefined;
     }
 
-    set _paging(paging: Pagination | void) {
+    set _paging(paging: Pagination | undefined) {
         if (paging) {
             if (paging.currentPage != null) {
                 this.__pager?.setAttribute('current-page', String(paging.currentPage));
@@ -320,11 +325,11 @@ export class VlRichData extends BaseHTMLElement {
 
     __getState({ paging }: { paging: boolean }): {
         formData: FormData | undefined;
-        paging: Pagination | void;
+        paging: Pagination | undefined;
     } {
         const state: {
             formData: FormData | undefined;
-            paging: Pagination | void;
+            paging: Pagination | undefined;
         } = {
             formData: this.__formDataState,
             paging: this._paging,


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-462
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC378

## Samenvatting
Lost twee paginatie-bugs op in `vl-rich-data` en `vl-pager`. De `data`-property van `vl-rich-data` geeft na een pagina-wissel nu het actuele pagina-nummer terug, en `vl-pager` vuurt geen overbodig `change`-event meer wanneer de effectieve pagina niet wijzigt. Hierdoor kunnen consumers (lvbr) hun eigen workarounds verwijderen.

## Wijzigingen
- `vl-rich-data`: `data.paging` komt nu live uit de pager, zodat `data.paging.currentPage` consistent is met de actieve pagina na een pagina-wissel.
- `vl-pager`: het `change`-event wordt enkel nog gedispatcht wanneer de effectieve (geclampte) pagina echt verandert — geen spurious "1 → 1"-event meer bij een nieuwe zoekopdracht vanaf pagina ≥ 2.
- `vl-pager`: de `currentPage` in de `change`-event-detail bevat altijd de geclampte waarde, nooit een out-of-range pagina-nummer.

## Backwards compatibility
Additieve bugfix — geen API-wijziging. Gedragswijziging: duplicate `change`-events vallen weg en `detail.currentPage` is voortaan geclampt; beide corrigeren foutief gedrag.

## Succescriteria
- [x] `data.paging.currentPage` actueel na pagina-wissel — getter merget live pager-state over de snapshot.
- [x] Geen `change`-event wanneer de effectieve pagina niet wijzigt — callback vergelijkt geclampte oude/nieuwe pagina.
- [x] `detail.currentPage` bevat de effectieve (geclampte) waarde, nooit out-of-range — detail leest `this.currentPage`.
- [x] Bestaand gedrag van `vl-rich-data-table` blijft intact, bestaande specs groen, aangevuld met tests voor beide scenario's — pager-spec (4) + rich-data-spec (14) + rich-data-table-spec (26) groen.
- [x] Lvbr-workarounds niet langer nodig — beide oorzaken aan component-kant opgelost.
