### PR TITLE
fix: FLUX-172 - vl-tabs - mobiele toggle niet langer zichtbaar op desktop

### DIFF
--- a/libs/components/src/block/tabs/vl-tabs.component.cy.ts
+++ b/libs/components/src/block/tabs/vl-tabs.component.cy.ts
@@ -270,6 +270,17 @@ describe('cypress-component - block components - vl-tabs - functionality on larg
                 expect($el.css('display')).to.eq('block');
             });
     });
+
+    it('should hide the responsive toggle button', () => {
+        mountDefault({ ...props });
+
+        cy.get('vl-tabs')
+            .shadow()
+            .find('button.vl-tabs__toggle')
+            .should(($el) => {
+                expect($el.css('display')).to.eq('none');
+            });
+    });
 });
 
 describe('cypress-component - block components - vl-tabs - functionality on smaller devices', () => {
@@ -311,6 +322,17 @@ describe('cypress-component - block components - vl-tabs - functionality on smal
         cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'show', 'true');
         cy.get('vl-tabs').shadow().find('button.vl-tabs__toggle').click();
         cy.get('vl-tabs').shadow().find('ul#tab-list').should('have.attr', 'show', 'false');
+    });
+
+    it('should show the responsive toggle button', () => {
+        mountDefault({ ...props });
+
+        cy.get('vl-tabs')
+            .shadow()
+            .find('button.vl-tabs__toggle')
+            .should(($el) => {
+                expect($el.css('display')).to.eq('block');
+            });
     });
 
     it('should render as vertical tabs with "tabs" as displayStyle', () => {

--- a/libs/components/src/block/tabs/vl-tabs.component.ts
+++ b/libs/components/src/block/tabs/vl-tabs.component.ts
@@ -107,7 +107,7 @@ export class VlTabsComponent extends BaseLitElement {
             <div id="tabs" tabs tabs-responsive-label="Navigatie">
                 <div id="tabs-wrapper" class="vl-tabs__wrapper">
                     <ul id="tab-list" class="vl-tabs" tabs-list role="tablist" aria-label="tabs"></ul>
-                    <button type="button" tabs-toggle class="vl-tabs__toggle vl-icon vl-icon--arrow" close="false">
+                    <button type="button" tabs-toggle class="vl-tabs__toggle vl-icon--arrow" close="false">
                         <span id="tabs-responsive-label">Navigatie</span>
                     </button>
                 </div>


### PR DESCRIPTION
De basis-class 'vl-icon' op de toggle-button zorgde ervoor dat de govflanders .vl-icon { display: inline } regel (via vlLegacyStyles, de laatste in de styles-array) won van .vl-tabs__toggle { display: none }. Daardoor was de mobiele toggle ook op desktop zichtbaar, zonder te werken.

Enkel de modifier 'vl-icon--arrow' behouden zodat de glyph-by-name aanpak intact blijft zonder het display probleem.