### PR TITLE
feat: FLUX-746 - vl-upload - documenteren MiB vs MB voor max-size

### DIFF
--- a/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
+++ b/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
@@ -83,14 +83,32 @@ Dropzone genereert achterliggend ook fouten, typisch wanneer er een bestand te v
 te groot is.
 Deze fouten worden getoond in de preview van het toegevoegde bestand en tellen mee in de validatie van het formulier.
 
-Om deze functionaliteit te bekomen wordt er een `dropzoneValidator` gebruikt die overeenkomt met de `customError` [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) key.
+Om deze functionaliteit te bekomen wordt er een `dropzoneValidator` gebruikt die overeenkomt met de `customError`
+[ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) key.
 Via de `customError` ValidityState key kan je een error message linken aan de `dropzoneValidator`.
+
+### Bestandsgrootte: MiB vs MB
+
+De `max-size`-waarde wordt achterliggend door Dropzone (`maxFilesize`) binair geïnterpreteerd, dus in **MiB**
+(1024-basis), niet in **MB** (1000-basis). De UI en de foutmelding spreken bewust over "MB" omdat Windows - de
+voornaamste use-case van onze doelgroep - diezelfde binaire waarden in de verkenner ook als "MB" toont. Voor de
+eindgebruiker op Windows klopt het getal in de UI dus visueel.
+
+Op macOS of Linux (die bestandsgroottes decimaal in MB tonen) en bij een MB-validerende backend kan dat verschil
+verwarren. Een `max-size` van bijvoorbeeld `900` laat een bestand tot 900 MiB = 943.718.400 bytes toe, wat decimaal
+neerkomt op ~943,7 MB.
+
+> **Advies voor afnemers:** valideer de bestandsgrootte ook aan de backend-zijde en reken die in MB (1000-basis),
+ zet die backend-limiet dan iets hoger dan `max-size`. Zo wordt een bestand dat de gebruiker volgens het upload-veld
+ mag uploaden, niet alsnog door de backend geweigerd.
 
 ### Aanbevelingen
 
-Breid de `sub-title`-attribuut uit met een korte uitleg over maximaal aantal bestanden, maximale bestandsgrootte en de toegestane bestandstypes indien relevant.
+Breid de `sub-title`-attribuut uit met een korte uitleg over maximaal aantal bestanden, maximale bestandsgrootte en de
+toegestane bestandstypes indien relevant.
 
-De reden hiervoor is dat het belangrijk is om de gebruiker te informeren over de beperkingen van het upload-veld. Het is cruciaal om duidelijke instructies te geven aan de gebruiker, zodat het risico op validatiefouten wordt verkleind.
+De reden hiervoor is dat het belangrijk is om de gebruiker te informeren over de beperkingen van het upload-veld. Het
+is cruciaal om duidelijke instructies te geven aan de gebruiker, zodat het risico op validatiefouten wordt verkleind.
 
 <details>
     <summary>voorbeeld aangepaste sub-titel</summary>
@@ -107,7 +125,8 @@ De reden hiervoor is dat het belangrijk is om de gebruiker te informeren over de
 
 Naast het slepen van bestanden, kan de gebruiker ook één of meerdere bestanden uploaden door op de
 link in het upload-veld te klikken en de bestanden
-selecteren in het bestandsmenu. Tenslotte is het ook mogelijk bestanden programmatorisch toe te voegen via de `addFile()` methode.
+selecteren in het bestandsmenu. Tenslotte is het ook mogelijk bestanden programmatorisch toe te voegen via de
+`addFile()` methode.
 
 ### Duplicaat detectie
 
@@ -121,7 +140,8 @@ dat bestanden werden verwijderd wegens duplicaat detectie.
 ### Content Security Policy
 
 De `vl-upload` component maakt gebruik van de [Dropzone](https://www.dropzonejs.com/) library. Deze library maakt
-gebruik van inline styles. Deze inline styles worden niet toegelaten in een strikte [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) policy.
+gebruik van inline styles. Deze inline styles worden niet toegelaten in een strikte [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+policy.
 Deze inline styles zijn echter niet nodig voor de werking van de `vl-upload` component.
 
 


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-746

## Samenvatting
De Storybook-documentatie van `vl-upload` legt nu uit dat `max-size` achterliggend in MiB (1024-basis) wordt gevalideerd en niet in MB (1000-basis). Consumers begrijpen daardoor waarom de getoonde "MB"-waarde op Windows klopt maar elders kan afwijken, en hoe ze hun backend-limiet best instellen.

## Wijzigingen
- Nieuwe subsectie "Bestandsgrootte: MiB vs MB" in de "Validatie"-sectie van de `vl-upload`-storydoc.
- Uitleg dat de "MB"-tekst in UI en foutmelding bewust behouden blijft omdat Windows binaire waarden óók als "MB" toont (de FLUX-525-beslissing wordt zo navolgbaar).
- Concreet rekenvoorbeeld (`max-size` 900 → 943.718.400 bytes ≈ 943,7 MB) en advies om een MB-validerende backend-limiet iets hoger dan `max-size` te zetten.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Storybook-doc legt uit dat `max-size` in MiB (1024-basis via Dropzone) wordt gevalideerd, niet in MB — subsectie toegevoegd in de Validatie-sectie.
- [x] De reden is opgenomen: Windows toont MiB als "MB" en is de default use-case, waardoor FLUX-525 navolgbaar wordt.
- [x] Concreet gevolg voor consumers vermeld: backend-limiet iets hoger dan `max-size` zetten — als advies-blockquote.
- [x] Geen functionele wijziging; `maxSize`/`max-size`-gedrag (`vl-upload.component.ts`) ongewijzigd — diff raakt enkel de MDX.
