### PR TITLE
feat: FLUX-526 - vl-side-navigation-next - meerdere items als actief aanduiden

### DIFF
--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-arg.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories-arg.ts
@@ -100,6 +100,19 @@ export const sideNavigationLayoutArgTypes: ArgTypes<SideNavigationLayoutArgs> = 
             defaultValue: { summary: sideNavigationLayoutArgs.childSpacing },
         },
     },
+    multiActive: {
+        name: 'multi-active',
+        description:
+            'Wanneer aanwezig worden alle items waarvan content zichtbaar is als actief gemarkeerd, in plaats van ' +
+            'enkel het bovenste. De actieve items worden aangeduid met een doorlopende lijn uiterst links. Zonder ' +
+            'dit attribuut kan het zijn dat de onderste items onderaan nooit aangeduid worden. Wordt doorgegeven aan ' +
+            'vl-side-navigation-next.<br>Dit attribuut is niet reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(sideNavigationLayoutArgs.multiActive) },
+        },
+    },
     contentSlot: {
         name: 'content',
         description:

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation-layout.stories.ts
@@ -48,11 +48,12 @@ const loremIpsumParagraph = html`
 
 export const SideNavigationLayoutDefault = story(
     sideNavigationLayoutArgs,
-    ({ compact, contentBlock, navigationTitle, excludeSelectors, childSpacing }) => {
+    ({ compact, contentBlock, navigationTitle, excludeSelectors, childSpacing, multiActive }) => {
         return html`
             <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
+                ?multi-active=${multiActive}
                 heading-root-selector="#story-default-content"
                 navigation-title=${navigationTitle}
                 exclude-selectors=${excludeSelectors}
@@ -96,17 +97,18 @@ export const SideNavigationLayoutDefault = story(
                 </div>
             </vl-side-navigation-layout-next>
         `;
-    }
+    },
 );
 SideNavigationLayoutDefault.storyName = 'vl-side-navigation-layout-next - default';
 
 export const SideNavigationLayoutWithSteps = story(
     sideNavigationLayoutArgs,
-    ({ compact, contentBlock, maxDepth, excludeSelectors, childSpacing }) => {
+    ({ compact, contentBlock, maxDepth, excludeSelectors, childSpacing, multiActive }) => {
         return html`
             <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
+                ?multi-active=${multiActive}
                 max-depth=${maxDepth}
                 heading-root-selector="#steps-content-container"
                 max-depth="0"
@@ -169,7 +171,7 @@ export const SideNavigationLayoutWithSteps = story(
                 </div>
             </vl-side-navigation-layout-next>
         `;
-    }
+    },
 );
 SideNavigationLayoutWithSteps.storyName = 'vl-side-navigation-layout-next - met steps';
 SideNavigationLayoutWithSteps.parameters = {
@@ -183,11 +185,12 @@ SideNavigationLayoutWithSteps.parameters = {
 
 export const SideNavigationLayoutTwoLayouts = story(
     sideNavigationLayoutArgs,
-    ({ compact, contentBlock, excludeSelectors, childSpacing }) => {
+    ({ compact, contentBlock, excludeSelectors, childSpacing, multiActive }) => {
         return html`
             <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
+                ?multi-active=${multiActive}
                 heading-root-selector="#content-subsidies"
                 exclude-selectors=${excludeSelectors}
                 child-spacing=${childSpacing}
@@ -259,6 +262,7 @@ export const SideNavigationLayoutTwoLayouts = story(
             <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
+                ?multi-active=${multiActive}
                 heading-root-selector="#content-diensten"
                 exclude-selectors=${excludeSelectors}
             >
@@ -323,7 +327,7 @@ export const SideNavigationLayoutTwoLayouts = story(
                 </div>
             </vl-side-navigation-layout-next>
         `;
-    }
+    },
 );
 SideNavigationLayoutTwoLayouts.storyName = 'vl-side-navigation-layout-next - twee layouts met eigen content';
 SideNavigationLayoutTwoLayouts.parameters = {
@@ -337,11 +341,12 @@ SideNavigationLayoutTwoLayouts.parameters = {
 
 export const SideNavigationLayoutWithCustomToc = story(
     sideNavigationLayoutArgs,
-    ({ compact, contentBlock, excludeSelectors, childSpacing }) => {
+    ({ compact, contentBlock, excludeSelectors, childSpacing, multiActive }) => {
         return html`
             <vl-side-navigation-layout-next
                 ?compact=${compact}
                 ?content-block=${contentBlock}
+                ?multi-active=${multiActive}
                 heading-root-selector="#story-custom-toc-content"
                 exclude-selectors=${excludeSelectors}
                 child-spacing=${childSpacing}
@@ -428,6 +433,6 @@ export const SideNavigationLayoutWithCustomToc = story(
                 </div>
             </vl-side-navigation-layout-next>
         `;
-    }
+    },
 );
 SideNavigationLayoutWithCustomToc.storyName = 'vl-side-navigation-layout-next - custom table of contents';

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-arg.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories-arg.ts
@@ -92,4 +92,17 @@ export const sideNavigationArgTypes: ArgTypes<SideNavigationArgs> = {
             defaultValue: { summary: sideNavigationArgs.childSpacing },
         },
     },
+    multiActive: {
+        name: 'multi-active',
+        description:
+            'Wanneer aanwezig worden alle items waarvan content zichtbaar is als actief gemarkeerd, in plaats van ' +
+            'enkel het bovenste. De actieve items worden aangeduid met een doorlopende lijn uiterst links. Zonder ' +
+            'dit attribuut kan het zijn dat de onderste items onderaan nooit aangeduid worden.<br>Dit attribuut is ' +
+            'niet reactief.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(sideNavigationArgs.multiActive) },
+        },
+    },
 };

--- a/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories.ts
+++ b/libs/components/src/block/next/side-navigation/stories/vl-side-navigation.stories.ts
@@ -141,13 +141,14 @@ const sampleContent = html`
 
 export const SideNavigationDefault = story(
     sideNavigationArgs,
-    ({ closed, compact, headingRootSelector, maxDepth, navigationTitle, childSpacing }) => {
+    ({ closed, compact, headingRootSelector, maxDepth, navigationTitle, childSpacing, multiActive }) => {
         return html`
             <div class="vl-grid vl-content-block">
                 <vl-side-navigation-next
                     class="vl-column vl-column--3 vl-column--start-10 vl-column--m-3  vl-column--s-12 vl-side-navigation--order-1"
                     ?closed=${closed}
                     ?compact=${compact}
+                    ?multi-active=${multiActive}
                     child-spacing=${childSpacing}
                     max-depth=${maxDepth}
                     heading-root-selector=${headingRootSelector}
@@ -157,7 +158,7 @@ export const SideNavigationDefault = story(
                 <div class="vl-column vl-column--8 vl-column--m-9 vl-column--s-12 ">${sampleContent}</div>
             </div>
         `;
-    }
+    },
 );
 SideNavigationDefault.storyName = 'vl-side-navigation-next - default';
 SideNavigationDefault.args = {
@@ -166,13 +167,14 @@ SideNavigationDefault.args = {
 
 export const SideNavigationCompact = story(
     sideNavigationArgs,
-    ({ closed, headingRootSelector, maxDepth, navigationTitle, childSpacing }) => {
+    ({ closed, headingRootSelector, maxDepth, navigationTitle, childSpacing, multiActive }) => {
         return html`
             <div class="vl-grid vl-content-block">
                 <vl-side-navigation-next
                     class="vl-column vl-column--12 vl-side-navigation--order-1"
                     ?closed=${closed}
                     compact
+                    ?multi-active=${multiActive}
                     child-spacing=${childSpacing}
                     max-depth=${maxDepth}
                     heading-root-selector=${headingRootSelector}
@@ -182,7 +184,7 @@ export const SideNavigationCompact = story(
                 <div class="vl-column vl-column--12">${sampleContent}</div>
             </div>
         `;
-    }
+    },
 );
 SideNavigationCompact.storyName = 'vl-side-navigation-next - compact';
 SideNavigationCompact.args = {
@@ -190,189 +192,194 @@ SideNavigationCompact.args = {
     headingRootSelector: '#story-content-container',
 };
 
-export const SideNavigationWithCustomToc = story(sideNavigationArgs, ({ closed, compact, maxDepth, childSpacing }) => {
-    return html`
-        <div class="vl-grid vl-content-block">
-            <vl-side-navigation-next
-                class="vl-column vl-column--3 vl-column--start-10 vl-column--m-3  vl-column--s-12  vl-side-navigation--order-1"
-                ?closed=${closed}
-                ?compact=${compact}
-                child-spacing=${childSpacing}
-                max-depth=${maxDepth}
-            >
-                <ul>
-                    <li>
-                        <div class="nav-item-wrapper">
-                            <vl-link href="#custom-intro">1. Inleiding</vl-link>
-                            <vl-button
-                                ghost
-                                icon="arrow-right-fat"
-                                class="toggle-button"
-                                @click=${toggleCustomTocChildren}
-                            ></vl-button>
-                        </div>
-                        <ul>
-                            <li>
-                                <vl-link href="#custom-vereisten">1.1 Vereisten</vl-link>
-                            </li>
-                            <li>
-                                <vl-link href="#custom-documenten">1.2 Documenten</vl-link>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <div class="nav-item-wrapper">
-                            <vl-link href="#custom-aanvraag">2. Aanvraag indienen</vl-link>
-                            <vl-button
-                                ghost
-                                icon="arrow-right-fat"
-                                class="toggle-button"
-                                @click=${toggleCustomTocChildren}
-                            ></vl-button>
-                        </div>
-                        <ul>
-                            <li>
-                                <vl-link href="#custom-online">2.1 Online</vl-link>
-                            </li>
-                            <li>
-                                <vl-link href="#custom-per-post">2.2 Per post</vl-link>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <div class="nav-item-wrapper">
-                            <vl-link href="#custom-termijnen">3. Termijnen</vl-link>
-                        </div>
-                    </li>
-                </ul>
-            </vl-side-navigation-next>
-            <div class="vl-column vl-column--8 vl-column--m-9 vl-column--s-12 ">
-                <div id="custom-toc-content">
-                    <section>
-                        <vl-title type="h2" id="custom-intro">Over deze pagina</vl-title>
-                        <vl-paragraph>
-                            Let op: de titels in de side-navigatie links zijn anders dan de koppen in de inhoud
-                            hiernaast. Dit is een voorbeeld van een custom inhoudsopgave — je kunt zelf de teksten in de
-                            navigatie kiezen. Bekijk de code van dit voorbeeld om te zien hoe je dit kunt doen.
-                        </vl-paragraph>
-                    </section>
-                    <section>
-                        <vl-title type="h3" id="custom-vereisten">Wat meebrengen</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                    </section>
-                    <section>
-                        <vl-title type="h3" id="custom-documenten">Welke documenten</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                    </section>
-                    <section>
-                        <vl-title type="h2" id="custom-aanvraag">Hoe indienen</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-title type="h3" id="custom-online">Online indienen</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-title type="h3" id="custom-per-post">Per post indienen</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                    </section>
-                    <section>
-                        <vl-title type="h2" id="custom-termijnen">Verwachtingsdatum</vl-title>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                        <vl-paragraph>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-                            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                            laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
-                            adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-                            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                            consequat. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                            exercitation ullamco
-                        </vl-paragraph>
-                    </section>
+export const SideNavigationWithCustomToc = story(
+    sideNavigationArgs,
+    ({ closed, compact, maxDepth, childSpacing, multiActive }) => {
+        return html`
+            <div class="vl-grid vl-content-block">
+                <vl-side-navigation-next
+                    class="vl-column vl-column--3 vl-column--start-10 vl-column--m-3  vl-column--s-12  vl-side-navigation--order-1"
+                    ?closed=${closed}
+                    ?compact=${compact}
+                    ?multi-active=${multiActive}
+                    child-spacing=${childSpacing}
+                    max-depth=${maxDepth}
+                >
+                    <ul>
+                        <li>
+                            <div class="nav-item-wrapper">
+                                <vl-link href="#custom-intro">1. Inleiding</vl-link>
+                                <vl-button
+                                    ghost
+                                    icon="arrow-right-fat"
+                                    class="toggle-button"
+                                    @click=${toggleCustomTocChildren}
+                                ></vl-button>
+                            </div>
+                            <ul>
+                                <li>
+                                    <vl-link href="#custom-vereisten">1.1 Vereisten</vl-link>
+                                </li>
+                                <li>
+                                    <vl-link href="#custom-documenten">1.2 Documenten</vl-link>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <div class="nav-item-wrapper">
+                                <vl-link href="#custom-aanvraag">2. Aanvraag indienen</vl-link>
+                                <vl-button
+                                    ghost
+                                    icon="arrow-right-fat"
+                                    class="toggle-button"
+                                    @click=${toggleCustomTocChildren}
+                                ></vl-button>
+                            </div>
+                            <ul>
+                                <li>
+                                    <vl-link href="#custom-online">2.1 Online</vl-link>
+                                </li>
+                                <li>
+                                    <vl-link href="#custom-per-post">2.2 Per post</vl-link>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <div class="nav-item-wrapper">
+                                <vl-link href="#custom-termijnen">3. Termijnen</vl-link>
+                            </div>
+                        </li>
+                    </ul>
+                </vl-side-navigation-next>
+                <div class="vl-column vl-column--8 vl-column--m-9 vl-column--s-12 ">
+                    <div id="custom-toc-content">
+                        <section>
+                            <vl-title type="h2" id="custom-intro">Over deze pagina</vl-title>
+                            <vl-paragraph>
+                                Let op: de titels in de side-navigatie links zijn anders dan de koppen in de inhoud
+                                hiernaast. Dit is een voorbeeld van een custom inhoudsopgave — je kunt zelf de teksten
+                                in de navigatie kiezen. Bekijk de code van dit voorbeeld om te zien hoe je dit kunt
+                                doen.
+                            </vl-paragraph>
+                        </section>
+                        <section>
+                            <vl-title type="h3" id="custom-vereisten">Wat meebrengen</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                        </section>
+                        <section>
+                            <vl-title type="h3" id="custom-documenten">Welke documenten</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                        </section>
+                        <section>
+                            <vl-title type="h2" id="custom-aanvraag">Hoe indienen</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-title type="h3" id="custom-online">Online indienen</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-title type="h3" id="custom-per-post">Per post indienen</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                        </section>
+                        <section>
+                            <vl-title type="h2" id="custom-termijnen">Verwachtingsdatum</vl-title>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                            <vl-paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor
+                                sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+                                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                                nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+                                adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                                enim ad minim veniam, quis nostrud exercitation ullamco
+                            </vl-paragraph>
+                        </section>
+                    </div>
                 </div>
             </div>
-        </div>
-    `;
-});
+        `;
+    },
+);
 SideNavigationWithCustomToc.storyName = 'vl-side-navigation-next - custom table of contents';

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-custom-toc.utils.ts
@@ -166,11 +166,11 @@ export function initializeCustomTocHiddenState(slottedElements: Element[]): void
  * current active heading ID. Used so scroll position is reflected in the custom TOC.
  *
  * @param slottedElements - Elements assigned to the TOC slot
- * @param activeHeadingId - ID of the heading currently considered active (e.g. from IntersectionObserver)
+ * @param activeHeadingIds - IDs of the headings currently considered active (single entry in single-active mode)
  */
 export function applyActiveStateToCustomTocLinks(
     slottedElements: Element[],
-    activeHeadingId: string
+    activeHeadingIds: Set<string>
 ): void {
     slottedElements.forEach((element) => {
         const links = element.querySelectorAll('a[href^="#"], vl-link[href^="#"]');
@@ -178,7 +178,7 @@ export function applyActiveStateToCustomTocLinks(
             const href = link.getAttribute('href');
             if (href) {
                 const id = href.substring(1);
-                if (id === activeHeadingId) {
+                if (activeHeadingIds.has(id)) {
                     link.classList.add('active');
                     link.setAttribute('aria-current', 'location');
                 } else {
@@ -243,14 +243,20 @@ function getSectionLinkForUl(ul: Element): Element | null {
  * stay visible and in tab order); all other nested sections stay collapsed.
  *
  * @param slottedElements - Elements assigned to the TOC slot (e.g. <ul>, fragment children)
- * @param activeHeadingId - ID of the heading currently considered active (e.g. from IntersectionObserver)
+ * @param activeHeadingIds - IDs of the headings currently considered active (single entry in single-active mode)
  */
-export function applyExpandCollapseToCustomToc(slottedElements: Element[], activeHeadingId: string): void {
-    const activeLink = findLinkByHeadingId(slottedElements, activeHeadingId);
-    const pathUls = activeLink ? getAncestorUlsForLink(activeLink) : new Set<HTMLUListElement>();
+export function applyExpandCollapseToCustomToc(slottedElements: Element[], activeHeadingIds: Set<string>): void {
+    const pathUls = new Set<HTMLUListElement>();
 
-    // Also expand the active link's own section (its li's direct child ul) so nested links stay visible and in tab order
-    if (activeLink) {
+    for (const activeHeadingId of activeHeadingIds) {
+        const activeLink = findLinkByHeadingId(slottedElements, activeHeadingId);
+        if (!activeLink) continue;
+
+        for (const ul of getAncestorUlsForLink(activeLink)) {
+            pathUls.add(ul);
+        }
+
+        // Also expand the active link's own section (its li's direct child ul) so nested links stay visible and in tab order
         const activeLi = activeLink.closest('li');
         const activeSectionUl = activeLi?.querySelector(':scope > ul');
         if (activeSectionUl) {

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.cy.ts
@@ -542,7 +542,10 @@ const runDesktopTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) =>
 const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => {
     it('should apply full width classes on mobile viewport', () => {
         mountFn();
-        cy.get('vl-side-navigation-layout-next').shadow().find('navigation-part').should('have.class', 'vl-column--s-12');
+        cy.get('vl-side-navigation-layout-next')
+            .shadow()
+            .find('navigation-part')
+            .should('have.class', 'vl-column--s-12');
         cy.get('vl-side-navigation-layout-next').shadow().find('content-part').should('have.class', 'vl-column--s-12');
 
         cy.injectAxe();
@@ -632,7 +635,7 @@ const runMobileTests = (mountFn: () => Cypress.Chainable, isAutoNav = false) => 
         mountFn();
         // TODO: onderstaande functionaliteit werkt ook met Enter (in de browser) maar niet binnen Cypress testen - te onderzoeken
         getSideNavigation(false).shadow().find('table-of-contents').should('not.have.attr', 'hidden');
-        
+
         // Establish focus context, then close overlay via keyboard
         getSideNavigation(false).shadow().find('nav').click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB);
@@ -732,10 +735,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
         mountSideNavigationLayoutWithCustomToc();
 
         // Ensure IntersectionObserver is running (initial active state is applied to any link)
-        cy.get('vl-side-navigation-layout-next')
-            .find('vl-side-navigation-next')
-            .find('vl-link.active')
-            .should('exist');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').find('vl-link.active').should('exist');
 
         cy.get('#custom-aanvraag').scrollIntoView();
 
@@ -749,10 +749,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
         mountSideNavigationLayoutWithCustomToc();
 
         // Ensure IntersectionObserver is running (initial active state is applied to any link)
-        cy.get('vl-side-navigation-layout-next')
-            .find('vl-side-navigation-next')
-            .find('vl-link.active')
-            .should('exist');
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').find('vl-link.active').should('exist');
 
         cy.get('#custom-vereisten').scrollIntoView();
         // Wait for IntersectionObserver to update and apply expand state to parent section
@@ -810,7 +807,11 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should support keyboard navigation through custom TOC items', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
+        cy.get('vl-side-navigation-layout-next')
+            .find('vl-side-navigation-next')
+            .shadow()
+            .find('table-of-contents')
+            .click();
 
         cy.press(Cypress.Keyboard.Keys.TAB);
         cy.get('vl-side-navigation-layout-next').find('vl-link').first().shadow().find('a').should('have.focus');
@@ -835,7 +836,11 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should navigate to section when pressing Enter on custom TOC link', () => {
         mountSideNavigationLayoutWithCustomToc();
 
-        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('table-of-contents').click();
+        cy.get('vl-side-navigation-layout-next')
+            .find('vl-side-navigation-next')
+            .shadow()
+            .find('table-of-contents')
+            .click();
         cy.press(Cypress.Keyboard.Keys.TAB); // First link
         cy.press(Cypress.Keyboard.Keys.TAB); // Second link
         cy.press(Cypress.Keyboard.Keys.TAB); // Third link
@@ -922,7 +927,11 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
         mountSideNavigationLayoutWithCustomToc();
 
         // Establish focus context, then close overlay via keyboard
-        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav').click({ force: true });
+        cy.get('vl-side-navigation-layout-next')
+            .find('vl-side-navigation-next')
+            .shadow()
+            .find('nav')
+            .click({ force: true });
         cy.press(Cypress.Keyboard.Keys.TAB);
         cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
@@ -1310,7 +1319,7 @@ const preloadProzaMessages = () => {
             'section-2-title': 'Implementatie',
             'section-2-sub-1': 'Preloaden van berichten',
             'section-3-title': 'Resultaat',
-        })
+        }),
     );
     VlProzaMessage.__setToegelatenOperatiesCacheForDomain(prozaDomain, Promise.resolve({ update: false }));
 };
@@ -1378,8 +1387,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should resolve proza message text in the auto-generated TOC', () => {
         mountSideNavigationLayoutWithProzaMessage();
 
-        const nav = () =>
-            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         nav().find('a[href="#proza-section-1"]').should('exist').and('contain', 'Ontwerpprincipes');
         nav().find('a[href="#proza-section-2"]').should('exist').and('contain', 'Implementatie');
@@ -1389,8 +1397,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should resolve proza message text for nested h3 headings in the TOC', () => {
         mountSideNavigationLayoutWithProzaMessage();
 
-        const nav = () =>
-            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         nav().find('a[href="#proza-section-1-sub-1"]').should('exist').and('contain', 'Consistente headings');
         nav().find('a[href="#proza-section-1-sub-2"]').should('exist').and('contain', 'Scanbare content');
@@ -1400,8 +1407,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should maintain correct TOC hierarchy with proza message headings', () => {
         mountSideNavigationLayoutWithProzaMessage();
 
-        const nav = () =>
-            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         // Verify first top-level section exists
         nav().find('a[href="#proza-section-1"]').should('exist').and('contain', 'Ontwerpprincipes');
@@ -1458,8 +1464,7 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
     it('should not render proza message titles twice in the TOC', () => {
         mountSideNavigationLayoutWithProzaMessage();
 
-        const nav = () =>
-            cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
+        const nav = () => cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').shadow().find('nav');
 
         const expectedTitles: [string, string][] = [
             ['#proza-section-1', 'Ontwerpprincipes'],
@@ -1540,5 +1545,57 @@ describe('cypress-component - block components - vl-side-navigation-layout-next 
         cy.get('vl-side-navigation-layout-next')
             .find('vl-side-navigation-next')
             .should('have.attr', 'child-spacing', 'small');
+    });
+});
+
+describe('cypress-component - block components - vl-side-navigation-layout-next - multi-active attribuut', () => {
+    beforeEach(() => {
+        cy.viewport(1440, 900);
+    });
+
+    it('geeft multi-active door aan de automatisch gegenereerde vl-side-navigation-next', () => {
+        cy.mount(html`
+            <vl-side-navigation-layout-next multi-active>
+                <div slot="content" id="content">
+                    <h2>Sectie 1</h2>
+                    <p style="min-height: 200px">Lorem ipsum.</p>
+                    <h3>Sectie 1.1</h3>
+                    <p style="min-height: 200px">Lorem ipsum.</p>
+                </div>
+            </vl-side-navigation-layout-next>
+        `);
+
+        cy.get('vl-side-navigation-layout-next').find('vl-side-navigation-next').should('have.attr', 'multi-active');
+    });
+
+    it('geeft multi-active door aan een expliciet geslotde vl-side-navigation-next', () => {
+        cy.mount(html`
+            <vl-side-navigation-layout-next multi-active>
+                <vl-side-navigation-next slot="navigation"></vl-side-navigation-next>
+                <div slot="content" id="content">
+                    <h2>Sectie 1</h2>
+                    <p style="min-height: 200px">Lorem ipsum.</p>
+                    <h3>Sectie 1.1</h3>
+                    <p style="min-height: 200px">Lorem ipsum.</p>
+                </div>
+            </vl-side-navigation-layout-next>
+        `);
+
+        cy.get('vl-side-navigation-next').should('have.attr', 'multi-active');
+    });
+
+    it('zet geen multi-active op vl-side-navigation-next wanneer het attribuut niet aanwezig is', () => {
+        cy.mount(html`
+            <vl-side-navigation-layout-next>
+                <div slot="content" id="content">
+                    <h2>Sectie 1</h2>
+                    <p style="min-height: 200px">Lorem ipsum.</p>
+                </div>
+            </vl-side-navigation-layout-next>
+        `);
+
+        cy.get('vl-side-navigation-layout-next')
+            .find('vl-side-navigation-next')
+            .should('not.have.attr', 'multi-active');
     });
 });

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.component.ts
@@ -54,6 +54,11 @@ export class VlSideNavigationLayoutComponent extends BaseLitElement {
     excludeSelectors?: string;
     @property({ type: String, attribute: 'child-spacing' })
     childSpacing = 'small';
+    /**
+     * Markeer alle items waarvan content zichtbaar is als actief, in plaats van enkel het bovenste.
+     */
+    @property({ type: Boolean, attribute: 'multi-active' })
+    multiActive = false;
 
     static get styles(): CSSResult[] {
         return [
@@ -114,7 +119,8 @@ export class VlSideNavigationLayoutComponent extends BaseLitElement {
             changedProperties.has('minLevel') ||
             changedProperties.has('navigationTitle') ||
             changedProperties.has('excludeSelectors') ||
-            changedProperties.has('childSpacing')
+            changedProperties.has('childSpacing') ||
+            changedProperties.has('multiActive')
         ) {
             this.updateNavigationComponents();
         }
@@ -179,6 +185,10 @@ export class VlSideNavigationLayoutComponent extends BaseLitElement {
 
             nav.setAttribute('child-spacing', this.childSpacing);
 
+            if (this.multiActive) {
+                nav.setAttribute('multi-active', '');
+            }
+
             this.appendChild(nav);
         } else {
             this.updateNavigationComponents();
@@ -237,6 +247,12 @@ export class VlSideNavigationLayoutComponent extends BaseLitElement {
                 }
 
                 item.setAttribute('child-spacing', this.childSpacing);
+
+                if (this.multiActive) {
+                    item.setAttribute('multi-active', '');
+                } else {
+                    item.removeAttribute('multi-active');
+                }
             }
         });
     }

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.defaults.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-layout.defaults.ts
@@ -6,4 +6,5 @@ export const sideNavigationLayoutDefaults = {
     navigationTitle: '' as string,
     excludeSelectors: '' as string,
     childSpacing: 'small' as string,
+    multiActive: false as boolean,
 } as const;

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation-renderer.utils.ts
@@ -21,8 +21,8 @@ export interface ScrollConfig {
  * UI state and behavior configuration for navigation rendering
  */
 export interface NavigationState {
-    /** ID of the currently active heading */
-    activeHeadingId?: string;
+    /** Set of heading IDs that are currently active (single entry in single-active mode). */
+    activeHeadingIds?: Set<string>;
     /** Set of heading IDs that have their children expanded */
     expandedHeadingIds?: Set<string>;
 }
@@ -125,14 +125,14 @@ const renderHeadingTree = (
  */
 const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): TemplateResult => {
     // destructure config for clearer dependencies
-    const { activeHeadingId, expandedHeadingIds } = config.state;
+    const { activeHeadingIds, expandedHeadingIds } = config.state;
     const { onActiveHeadingChange } = config.callbacks;
     const { scrollRoot, scrollBehavior } = config.scroll;
 
     // calculate node state
-    const isActive = activeHeadingId === node.item.id;
+    const isActive = activeHeadingIds?.has(node.item.id) ?? false;
     const hasChildren = node.children.length > 0;
-    const isChildActive = hasChildren && isAnyChildActive(node.children, activeHeadingId);
+    const isChildActive = hasChildren && isAnyChildActive(node.children, activeHeadingIds);
 
     // check if user has manually toggled this item
     const hasManualToggle = expandedHeadingIds?.has(node.item.id) ?? false;
@@ -198,14 +198,14 @@ const renderHeadingNode = (node: HeadingTreeNode, config: RenderConfig): Templat
 /**
  * recursively checks if any child node in the tree is active
  */
-export const isAnyChildActive = (nodes: HeadingTreeNode[], activeHeadingId?: string): boolean => {
-    if (!activeHeadingId) return false;
+export const isAnyChildActive = (nodes: HeadingTreeNode[], activeHeadingIds?: Set<string>): boolean => {
+    if (!activeHeadingIds || activeHeadingIds.size === 0) return false;
 
     for (const node of nodes) {
-        if (node.item.id === activeHeadingId) {
+        if (activeHeadingIds.has(node.item.id)) {
             return true;
         }
-        if (node.children.length > 0 && isAnyChildActive(node.children, activeHeadingId)) {
+        if (node.children.length > 0 && isAnyChildActive(node.children, activeHeadingIds)) {
             return true;
         }
     }

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.css.ts
@@ -99,6 +99,11 @@ export const vlSideNavigationLightDomStyles = css`
             ${activeStateStyles}
         }
 
+        &[multi-active] a.active::before,
+        &[multi-active] vl-link.active::before {
+            display: none;
+        }
+
         /* Match auto-generated nav link text-decoration and font-weight for custom TOC */
         a {
             text-decoration: none;
@@ -284,6 +289,7 @@ export const vlSideNavigationStyles = css`
     }
 
     nav {
+        position: relative;
         background-color: var(--vl-color--white);
         padding: var(--vl-spacing--small);
         overflow-y: auto;
@@ -410,6 +416,23 @@ export const vlSideNavigationStyles = css`
         @media screen and (max-width: ${vlMediaScreenSmall}px) {
             max-height: 60vh;
         }
+    }
+
+    /* The continuous active-indicator line, positioned by the component over the run of active items.
+       Hidden until the component measures the active range and sets top/height. */
+    nav .active-indicator-line {
+        position: absolute;
+        left: calc(var(--vl-spacing--small) - 12px);
+        width: 3px;
+        background-color: var(--vl-color--action-400);
+        pointer-events: none;
+        display: none;
+    }
+
+    /* Multi-active replaces the stepped per-item bars with the single far-left line. */
+    :host([multi-active]) nav a.active::before,
+    :host([multi-active]) nav button.active::before {
+        display: none;
     }
 
     :host([child-spacing="medium"]) nav {

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.cy.ts
@@ -277,6 +277,47 @@ const mountSideNavigationAutoTocInShadowDom = () => {
     `);
 };
 
+const mountSideNavigationMultiActive = () => {
+    return cy.mount(html`
+        <div class="vl-grid">
+            <vl-side-navigation-next
+                class="${NAVIGATION_COLUMN_CLASSES}"
+                heading-root-selector="#story-content-container"
+                multi-active
+            >
+            </vl-side-navigation-next>
+            <div class="${CONTENT_COLUMN_CLASSES}">${sampleContent}</div>
+        </div>
+    `);
+};
+
+const mountSideNavigationWithCustomTocMultiActive = () => {
+    return cy.mount(html`
+        <div class="vl-grid">
+            <vl-side-navigation-next class="${NAVIGATION_COLUMN_CLASSES}" multi-active>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 8px;"><vl-link href="#custom-intro">Inleiding</vl-link></li>
+                    <li style="margin-bottom: 8px;"><vl-link href="#custom-aanvraag">Aanvraag indienen</vl-link></li>
+                    <li style="margin-bottom: 8px;"><vl-link href="#custom-termijnen">Termijnen</vl-link></li>
+                </ul>
+            </vl-side-navigation-next>
+            <div class="${CONTENT_COLUMN_CLASSES}">
+                <div id="custom-toc-content">
+                    <section style="min-height: 400px; margin-top: 100px;">
+                        <vl-title type="h2" id="custom-intro">Inleiding</vl-title>
+                    </section>
+                    <section style="min-height: 400px;">
+                        <vl-title type="h2" id="custom-aanvraag">Aanvraag indienen</vl-title>
+                    </section>
+                    <section style="min-height: 400px;">
+                        <vl-title type="h2" id="custom-termijnen">Termijnen</vl-title>
+                    </section>
+                </div>
+            </div>
+        </div>
+    `);
+};
+
 describe('cypress-component - block components - vl-side-navigation-next', () => {
     beforeEach(() => {
         cy.viewport(1440, 900);
@@ -1361,5 +1402,133 @@ describe('cypress-component - block components - vl-side-navigation-next - exter
         cy.then(() => {
             expect(defaultPrevented, 'vl-side-navigation-next must not prevent default for external links').to.be.false;
         });
+    });
+});
+
+describe('cypress-component - block components - vl-side-navigation-next - multi-active', () => {
+    beforeEach(() => {
+        cy.viewport(1440, 900);
+    });
+
+    it('should mark multiple items active when multiple sections are visible', () => {
+        mountSideNavigationMultiActive();
+
+        cy.get('#content-2-heading').scrollIntoView();
+
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#content-2-heading"].active').should('exist');
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#content-3-heading"].active').should('exist');
+        cy.get('vl-side-navigation-next').shadow().find('nav a.active').should('have.length.greaterThan', 1);
+    });
+
+    it('should mark the bottom item active when scrolled to the end of the page', () => {
+        mountSideNavigationMultiActive();
+
+        cy.scrollTo('bottom');
+
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#content-3-heading"].active').should('exist');
+    });
+
+    it('should keep a single active item by default (no multi-active attribute)', () => {
+        mountSideNavigation();
+
+        cy.get('#content-2-heading').scrollIntoView();
+
+        cy.get('vl-side-navigation-next').shadow().find('nav a[href="#content-2-heading"].active').should('exist');
+        cy.get('vl-side-navigation-next').shadow().find('nav a.active').should('have.length', 1);
+    });
+
+    it('should expose activeHeadingIds additively on the active-heading-changed event', () => {
+        mountSideNavigationMultiActive();
+
+        cy.get('vl-side-navigation-next').then(($el) => {
+            const spy = cy.spy().as('activeChanged');
+            $el[0].addEventListener('active-heading-changed', spy);
+        });
+
+        cy.get('#content-3-heading').scrollIntoView();
+
+        cy.get('@activeChanged').should('have.been.called');
+        cy.get('@activeChanged')
+            .its('lastCall.args.0.detail')
+            .should((detail) => {
+                expect(detail.activeHeadingId, 'activeHeadingId stays a string for existing consumers').to.be.a(
+                    'string'
+                );
+                expect(detail.activeHeadingIds, 'activeHeadingIds is added as an array').to.be.an('array');
+                expect(detail.activeHeadingIds).to.include('content-3-heading');
+            });
+    });
+
+    it('should be accessible with multiple active items', () => {
+        mountSideNavigationMultiActive();
+
+        cy.get('#content-2-heading').scrollIntoView();
+        cy.get('vl-side-navigation-next').shadow().find('nav a.active').should('have.length.greaterThan', 1);
+
+        cy.injectAxe();
+        cy.checkA11y('vl-side-navigation-next');
+    });
+
+    it('should mark multiple custom TOC links active when sections overlap', () => {
+        mountSideNavigationWithCustomTocMultiActive();
+
+        cy.get('#custom-aanvraag').scrollIntoView();
+
+        cy.get('vl-side-navigation-next').find('vl-link[href="#custom-aanvraag"].active').should('exist');
+        cy.get('vl-side-navigation-next').find('vl-link[href="#custom-termijnen"].active').should('exist');
+    });
+
+    it('should draw one continuous far-left line spanning all active items', () => {
+        mountSideNavigationMultiActive();
+
+        cy.get('#content-2-heading').scrollIntoView();
+        cy.get('vl-side-navigation-next').shadow().find('nav a.active').should('have.length.greaterThan', 1);
+
+        // the single line is visible and tall enough to cover more than one item
+        cy.get('vl-side-navigation-next')
+            .shadow()
+            .find('nav .active-indicator-line')
+            .should('be.visible')
+            .then(($line) => {
+                expect($line[0].getBoundingClientRect().height).to.be.greaterThan(0);
+            });
+
+        // the line sits at the far left, aligned regardless of nesting depth (no per-level indent)
+        cy.get('vl-side-navigation-next')
+            .shadow()
+            .find('nav')
+            .then(($nav) => {
+                const navRect = $nav[0].getBoundingClientRect();
+                cy.get('vl-side-navigation-next')
+                    .shadow()
+                    .find('nav .active-indicator-line')
+                    .then(($line) => {
+                        const lineRect = $line[0].getBoundingClientRect();
+                        // far left: within the nav's left padding, not stepped inward per level
+                        expect(lineRect.left - navRect.left).to.be.lessThan(20);
+                    });
+            });
+    });
+
+    it('should suppress the per-item indicator bars in multi-active mode', () => {
+        mountSideNavigationMultiActive();
+
+        cy.get('#content-2-heading').scrollIntoView();
+        cy.get('vl-side-navigation-next')
+            .shadow()
+            .find('nav a.active')
+            .first()
+            .then(($a) => {
+                const before = window.getComputedStyle($a[0], '::before');
+                expect(before.display).to.equal('none');
+            });
+    });
+
+    it('should not draw the continuous line without the multi-active attribute', () => {
+        mountSideNavigation();
+
+        cy.get('#content-2-heading').scrollIntoView();
+        cy.get('vl-side-navigation-next').shadow().find('nav a.active').should('exist');
+        cy.get('vl-side-navigation-next').shadow().find('nav .active-indicator-line').should('not.be.visible');
     });
 });

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -65,7 +65,13 @@ export class VlSideNavigationComponent extends BaseLitElement {
      */
     @property({ type: String, attribute: 'navigation-title' })
     navigationTitle = 'Op deze pagina';
+    /**
+     * Markeer alle items waarvan content zichtbaar is als actief, in plaats van enkel het bovenste.
+     */
+    @property({ type: Boolean, reflect: true, attribute: 'multi-active' })
+    multiActive = false;
     @state() private activeHeadingId: string = '';
+    @state() private activeHeadingIds: Set<string> = new Set();
     @state() private tocTemplate: TemplateResult = html``;
     @state() private hasCustomToc = false;
     @state() private expandedHeadingIds: Set<string> = new Set();
@@ -82,6 +88,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
     private focusRecoveryMutationObserver?: MutationObserver;
     private lastFocusedNavElement?: WeakRef<HTMLElement>;
     private previousTocEffectivelyHidden = false;
+    private navResizeObserver?: ResizeObserver;
 
     static get styles(): CSSResult[] {
         return [vlResetStyles, vlSideNavigationStyles, vlLinkStyles(), vlIconStyles];
@@ -89,6 +96,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
     override firstUpdated(): void {
         this.setupMediaQueryListener();
+        this.setupNavResizeObserver();
 
         const tocSlot = this.shadowRoot?.querySelector('slot') as HTMLSlotElement;
         const slottedElements = tocSlot?.assignedElements() ?? [];
@@ -148,6 +156,18 @@ export class VlSideNavigationComponent extends BaseLitElement {
             this.refreshTableOfContents();
         }
 
+        // Reposition the continuous multi-active line when anything that affects its span changes
+        if (
+            changedProperties.has('activeHeadingIds') ||
+            changedProperties.has('expandedHeadingIds') ||
+            changedProperties.has('multiActive') ||
+            changedProperties.has('isMobileView') ||
+            changedProperties.has('isTableOfContentsHidden') ||
+            changedProperties.has('tocTemplate')
+        ) {
+            this.updateComplete.then(() => this.updateActiveIndicatorLine());
+        }
+
         // When the TOC panel becomes hidden (e.g. viewport resize to mobile), move focus to show button
         const nowHidden = this.isTocEffectivelyHidden;
         if (nowHidden && !this.previousTocEffectivelyHidden) {
@@ -157,7 +177,9 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
         // When expand/collapse or active section changes, if the focused element is now hidden, move to logical neighbor
         if (
-            (changedProperties.has('expandedHeadingIds') || changedProperties.has('activeHeadingId')) &&
+            (changedProperties.has('expandedHeadingIds') ||
+                changedProperties.has('activeHeadingId') ||
+                changedProperties.has('activeHeadingIds')) &&
             this.isFocusInsideNav()
         ) {
             const el = this.getDeepActiveElement() as HTMLElement;
@@ -178,7 +200,10 @@ export class VlSideNavigationComponent extends BaseLitElement {
             this.setupIntersectionObserver();
         }
         this.setupMediaQueryListener();
-        this.updateComplete.then(() => this.setupFocusRecoveryObserver());
+        this.updateComplete.then(() => {
+            this.setupFocusRecoveryObserver();
+            this.setupNavResizeObserver();
+        });
     }
 
     override disconnectedCallback(): void {
@@ -187,6 +212,24 @@ export class VlSideNavigationComponent extends BaseLitElement {
         this.cleanupMediaQueryListener();
         this.cleanupFocusRecoveryObserver();
         this.cleanupCustomTocLinkHandlers();
+        this.cleanupNavResizeObserver();
+    }
+
+    /**
+     * Repositions the continuous multi-active line whenever the nav resizes (responsive wrapping,
+     * font load, expand/collapse changing item heights). Cheap: it only runs when multi-active is on.
+     */
+    private setupNavResizeObserver(): void {
+        if (this.navResizeObserver || typeof ResizeObserver === 'undefined') return;
+        const nav = this.shadowRoot?.querySelector('nav');
+        if (!nav) return;
+        this.navResizeObserver = new ResizeObserver(() => this.updateActiveIndicatorLine());
+        this.navResizeObserver.observe(nav);
+    }
+
+    private cleanupNavResizeObserver(): void {
+        this.navResizeObserver?.disconnect();
+        this.navResizeObserver = undefined;
     }
 
     private setupMediaQueryListener(): void {
@@ -416,7 +459,10 @@ export class VlSideNavigationComponent extends BaseLitElement {
 
         const observerOptions: IntersectionObserverInit = {
             root: null, // use viewport as root
-            rootMargin: '0px 0px -70% 0px',
+            // Multi-active needs the full viewport so a section whose heading scrolled just above
+            // the top (but whose content is still visible) keeps triggering recomputation; single-active
+            // keeps the -70% detection line that highlights the top-most heading only.
+            rootMargin: this.multiActive ? '0px' : '0px 0px -70% 0px',
             threshold: 0,
         };
 
@@ -435,6 +481,11 @@ export class VlSideNavigationComponent extends BaseLitElement {
     }
 
     private handleIntersection(entries: IntersectionObserverEntry[]): void {
+        if (this.multiActive) {
+            this.updateActiveSections();
+            return;
+        }
+
         const visibleEntries = entries.filter((entry) => entry.isIntersecting);
 
         if (visibleEntries.length > 0) {
@@ -445,9 +496,49 @@ export class VlSideNavigationComponent extends BaseLitElement {
             const newActiveId = topMostEntry.target.getAttribute('id');
             if (newActiveId && newActiveId !== this.activeHeadingId) {
                 this.activeHeadingId = newActiveId;
+                this.activeHeadingIds = new Set([newActiveId]);
                 this.updateActiveLinks();
             }
         }
+    }
+
+    /**
+     * Multi-active: a section spans from its heading to the next heading. A section is active when that
+     * range overlaps the viewport, so every section with visible content is marked active - including the
+     * last one once the page is scrolled to the bottom. Recomputed from heading positions on each observer
+     * callback (the set only changes when a heading crosses a viewport edge, which is what fires the observer).
+     */
+    private updateActiveSections(): void {
+        if (typeof window === 'undefined') return;
+
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+        const orderedIds = this.headingElements
+            .map((element) => ({ id: element.getAttribute('id') ?? '', top: element.getBoundingClientRect().top }))
+            .filter((entry) => entry.id)
+            .sort((a, b) => a.top - b.top);
+
+        const visibleIds = new Set<string>();
+        orderedIds.forEach((entry, index) => {
+            const sectionTop = entry.top;
+            const sectionBottom = index + 1 < orderedIds.length ? orderedIds[index + 1].top : Infinity;
+            if (sectionTop < viewportHeight && sectionBottom > 0) {
+                visibleIds.add(entry.id);
+            }
+        });
+
+        if (this.areSameIds(visibleIds, this.activeHeadingIds)) return;
+
+        this.activeHeadingId = orderedIds.find((entry) => visibleIds.has(entry.id))?.id ?? '';
+        this.activeHeadingIds = visibleIds;
+        this.updateActiveLinks();
+    }
+
+    private areSameIds(a: Set<string>, b: Set<string>): boolean {
+        if (a.size !== b.size) return false;
+        for (const id of a) {
+            if (!b.has(id)) return false;
+        }
+        return true;
     }
 
     private updateActiveLinks(): void {
@@ -457,12 +548,71 @@ export class VlSideNavigationComponent extends BaseLitElement {
             this.updateTableOfContents();
         }
 
+        const orderedActiveIds = this.headingElements
+            .map((element) => element.getAttribute('id'))
+            .filter((id): id is string => !!id && this.activeHeadingIds.has(id));
+
         this.dispatchEvent(
             new CustomEvent('active-heading-changed', {
-                detail: { activeHeadingId: this.activeHeadingId },
+                detail: { activeHeadingId: this.activeHeadingId, activeHeadingIds: orderedActiveIds },
                 bubbles: true,
             })
         );
+        // The continuous multi-active line is repositioned from updated() when activeHeadingIds changes.
+    }
+
+    /**
+     * Multi-active alternative to the per-item indicator: draws a single uninterrupted line at the far
+     * left of the nav, spanning the whole run of active items. Because the active set is always a
+     * contiguous range in document order, one vertical line from the first active link's top to the last
+     * active link's bottom exactly covers the active items - without the per-level indentation that made
+     * the per-item bars step inward.
+     */
+    private updateActiveIndicatorLine(): void {
+        const nav = this.shadowRoot?.querySelector('nav');
+        const line = nav?.querySelector('.active-indicator-line') as HTMLElement | null;
+        if (!nav || !line) return;
+
+        if (!this.multiActive || this.activeHeadingIds.size === 0 || this.isTocEffectivelyHidden) {
+            line.style.display = 'none';
+            return;
+        }
+
+        const rects = this.getActiveLinkElements()
+            .map((el) => el.getBoundingClientRect())
+            .filter((rect) => rect.height > 0);
+        if (rects.length === 0) {
+            line.style.display = 'none';
+            return;
+        }
+
+        const navRect = nav.getBoundingClientRect();
+        const top = Math.min(...rects.map((rect) => rect.top));
+        const bottom = Math.max(...rects.map((rect) => rect.bottom));
+
+        line.style.top = `${top - navRect.top + nav.scrollTop}px`;
+        line.style.height = `${bottom - top}px`;
+        line.style.display = 'block';
+    }
+
+    /**
+     * Resolves the link elements (shadow <a> for the auto TOC, slotted <a>/<vl-link> for a custom TOC)
+     * of the currently active headings. Used to measure the span of the continuous multi-active line.
+     */
+    private getActiveLinkElements(): HTMLElement[] {
+        const slot = this.shadowRoot?.querySelector('slot') as HTMLSlotElement | null;
+        const customRoots = this.hasCustomToc ? (slot?.assignedElements() ?? []) : [];
+        const nav = this.shadowRoot?.querySelector('nav');
+
+        const links: HTMLElement[] = [];
+        this.activeHeadingIds.forEach((id) => {
+            const selector = `a[href="#${CSS.escape(id)}"], vl-link[href="#${CSS.escape(id)}"]`;
+            const link =
+                customRoots.map((root) => root.querySelector(selector)).find(Boolean) ??
+                nav?.querySelector(selector);
+            if (link instanceof HTMLElement) links.push(link);
+        });
+        return links;
     }
 
     private cleanupIntersectionObserver(): void {
@@ -499,6 +649,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
                     @vl-click=${this.closeSideNavigation}
                 ></vl-button>
                 <nav aria-label="inhoudstafel navigatie">
+                    <div class="active-indicator-line" aria-hidden="true"></div>
                     <slot @slotchange=${this.handleTocSlotChange}></slot>
                     ${!this.hasCustomToc ? this.tocTemplate || nothing : nothing}
                 </nav>
@@ -582,8 +733,8 @@ export class VlSideNavigationComponent extends BaseLitElement {
         const slot = this.shadowRoot?.querySelector('slot') as HTMLSlotElement;
         if (!slot) return;
         const slottedElements = slot.assignedElements();
-        applyActiveStateToCustomTocLinks(slottedElements, this.activeHeadingId);
-        applyExpandCollapseToCustomToc(slottedElements, this.activeHeadingId);
+        applyActiveStateToCustomTocLinks(slottedElements, this.activeHeadingIds);
+        applyExpandCollapseToCustomToc(slottedElements, this.activeHeadingIds);
     }
 
     private get tableOfContents() {
@@ -642,8 +793,8 @@ export class VlSideNavigationComponent extends BaseLitElement {
             if (!id.startsWith('-')) return true;
             const realId = id.substring(1);
             const node = findNodeById(tree, realId);
-            const isActive = this.activeHeadingId === realId;
-            const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingId) : false;
+            const isActive = this.activeHeadingIds.has(realId);
+            const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingIds) : false;
             return isActive || isChildActive;
         });
         if (stillManualCollapsed.length !== this.expandedHeadingIds.size) {
@@ -657,7 +808,7 @@ export class VlSideNavigationComponent extends BaseLitElement {
                 maxDepth: this.maxDepth,
             },
             state: {
-                activeHeadingId: this.activeHeadingId,
+                activeHeadingIds: this.activeHeadingIds,
                 expandedHeadingIds: this.expandedHeadingIds,
             },
             callbacks: {
@@ -670,11 +821,11 @@ export class VlSideNavigationComponent extends BaseLitElement {
                         const hasManualCollapse = this.expandedHeadingIds.has(`-${headingId}`);
 
                         // check if children would be auto-expanded (active or child-active)
-                        const isActive = this.activeHeadingId === headingId;
+                        const isActive = this.activeHeadingIds.has(headingId);
 
                         // build tree and find the node to check if any children are active
                         const node = findNodeById(tree, headingId);
-                        const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingId) : false;
+                        const isChildActive = node ? isAnyChildActive(node.children, this.activeHeadingIds) : false;
 
                         const wouldBeAutoExpanded = isActive || isChildActive;
 

--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.defaults.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.defaults.ts
@@ -5,6 +5,7 @@ export const sideNavigationDefaults: SideNavigationDefaults = {
     maxDepth: undefined,
     navigationTitle: 'Op deze pagina',
     childSpacing: 'small',
+    multiActive: false,
 } as const;
 
 export type SideNavigationDefaults = {
@@ -14,4 +15,5 @@ export type SideNavigationDefaults = {
     maxDepth: number | undefined;
     navigationTitle: string;
     childSpacing: string;
+    multiActive: boolean;
 };


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-526

## Samenvatting
`vl-side-navigation-next` kan nu meerdere items tegelijk als actief tonen via een nieuw opt-in `multi-active` attribuut: alle items waarvan content zichtbaar is in de viewport worden gemarkeerd, in plaats van enkel het bovenste. Daardoor kunnen ook de onderste items actief worden wanneer de pagina volledig naar beneden gescrold is. Zonder het attribuut behouden bestaande consumers exact hetzelfde gedrag.

## Wijzigingen
- Nieuw opt-in `multi-active` attribuut (standaard uit) dat zichtbaarheid op sectie-niveau berekent, zodat alle zichtbare secties tegelijk actief zijn — in zowel auto-TOC als custom-TOC modus.
- Het onderste item kan nu actief worden onderaan de pagina; lost meteen op dat enkel headings in de bovenste 30% van de viewport meetelden.
- De actieve items worden samen aangeduid met één doorlopende verticale lijn uiterst links, zonder insprong per niveau. De component berekent het bereik van de actieve items en tekent één lijn die van het eerste tot het laatste actieve item loopt (in de shadow-nav, waar ook de slotted custom-TOC rendert). Een `ResizeObserver` herpositioneert bij herschalen en in-/uitklappen.
- Het `active-heading-changed` event krijgt additief `detail.activeHeadingIds: string[]` (alle actieve ids in volgorde); `detail.activeHeadingId` behoudt zijn betekenis.
- Expand/collapse en focus-recovery werken correct bij meerdere actieve items.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Meerdere zichtbare secties worden actief gemarkeerd (auto- én custom-TOC) — sectie-gebaseerde Set van zichtbare secties; renderer en custom-TOC links gebruiken `Set.has()`.
- [x] Onderste item kan actief worden onderaan de pagina — laatste sectie reikt tot het einde van de pagina, dus actief zodra tot beneden gescrold.
- [x] Aaneengesloten actieve items tonen één doorlopende aanduiding — één verticale lijn uiterst links die van het eerste tot het laatste actieve item loopt, onafhankelijk van het nesting-niveau (geen tegen elkaar inspringende lijntjes meer). De actieve set is altijd een aaneengesloten bereik in documentvolgorde, dus één lijn dekt exact de actieve items.
- [x] `active-heading-changed` blijft werken; multi-active info additief — `activeHeadingId` ongewijzigd, `activeHeadingIds` additief toegevoegd.
- [x] Expand/collapse en focus-recovery blijven correct bij meerdere actieve items — Set-bewuste cleanup en toggle-logica; focus-recovery kiest deterministisch de bovenste actieve sectie.
