### PR TITLE
feat: FLUX-652 - vl-textarea - teller voor aantal tekens

### DIFF
--- a/libs/components/src/form/textarea-rich/stories/vl-textarea-rich.stories.ts
+++ b/libs/components/src/form/textarea-rich/stories/vl-textarea-rich.stories.ts
@@ -17,7 +17,8 @@ export default {
     parameters: {
         // Excluding 'block' en 'cols': veld neemt altijd de volledige breedte van de parent in
         // Excluding 'placeholder': de vl-typography CSS van DV zorgt ervoor dat de placeholder niet zichtbaar is
-        controls: { exclude: ['block', 'cols', 'placeholder'] },
+        // Excluding 'character-count': TinyMCE handhaaft geen 'max-length' en de value bevat HTML-opmaak, dus de teller werkt niet correct in de rich editor
+        controls: { exclude: ['block', 'cols', 'placeholder', 'character-count'] },
         docs: {
             page: textareaRichDocs,
         },

--- a/libs/components/src/form/textarea/stories/vl-textarea.stories-arg.ts
+++ b/libs/components/src/form/textarea/stories/vl-textarea.stories-arg.ts
@@ -35,6 +35,18 @@ export const textareaArgTypes: ArgTypes<TextareaArgs> = {
             defaultValue: { summary: String(textareaArgs.readonly) },
         },
     },
+    characterCount: {
+        name: 'character-count',
+        description:
+            'Toont onder de textarea een teller `{huidig}/{max}` van het aantal getypte tekens t.o.v. `max-length`.' +
+            ' Een (visueel verborgen) `aria-live` regio kondigt het aantal resterende tekens aan vanaf de laatste 10.' +
+            ' Vereist een gezette `max-length`.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(textareaArgs.characterCount) },
+        },
+    },
     value: {
         name: 'value',
         description: 'De waarde van het textarea veld.',

--- a/libs/components/src/form/textarea/stories/vl-textarea.stories-doc.mdx
+++ b/libs/components/src/form/textarea/stories/vl-textarea.stories-doc.mdx
@@ -29,6 +29,15 @@ import { VlTextareaComponent } from '@domg-wc/components/form';
 <Canvas of={VlTextAreaStories.TextareaDefault} />
 
 
+## Karakterteller
+
+Zet het `character-count` attribute samen met `max-length` om onder de textarea een teller `{huidig}/{max}` te tonen
+die live meetelt terwijl je typt. Vanaf de laatste 10 resterende tekens wordt het aantal beschikbare tekens
+toegankelijk aangekondigd voor screenreader-gebruikers.
+
+<Canvas of={VlTextAreaStories.TextareaCharacterCount} />
+
+
 ## Configuratie
 
 <ArgTypes of={VlTextAreaStories.TextareaDefault} />

--- a/libs/components/src/form/textarea/stories/vl-textarea.stories.ts
+++ b/libs/components/src/form/textarea/stories/vl-textarea.stories.ts
@@ -34,6 +34,7 @@ export const TextareaDefault = story(
         blurValidation,
         block,
         readonly,
+        characterCount,
         value,
         placeholder,
         autocomplete,
@@ -57,6 +58,7 @@ export const TextareaDefault = story(
             ?blur-validation=${blurValidation}
             ?block=${block}
             ?readonly=${readonly}
+            ?character-count=${characterCount}
             value=${value}
             placeholder=${placeholder}
             autocomplete=${autocomplete}
@@ -80,4 +82,12 @@ TextareaBlurValidation.args = {
     minLength: 5,
     blurValidation: true,
     placeholder: 'Min. 5 karakters',
+};
+
+export const TextareaCharacterCount = TextareaDefault.bind({});
+TextareaCharacterCount.storyName = 'vl-textarea - character count';
+TextareaCharacterCount.args = {
+    block: true,
+    characterCount: true,
+    maxLength: 250,
 };

--- a/libs/components/src/form/textarea/vl-textarea.component.css.ts
+++ b/libs/components/src/form/textarea/vl-textarea.component.css.ts
@@ -1,3 +1,4 @@
+import { vlVisuallyHiddenMixin } from '@domg-wc/styles';
 import { css, CSSResult, unsafeCSS } from 'lit';
 import textareaComponentRawCss from './vl-textarea.component.raw.css?raw';
 
@@ -142,5 +143,19 @@ export const vlTextareaComponentStyles: CSSResult = css`
     .vl-textarea[disabled]:hover {
         border-width: var(--vl-border--width);
         padding: var(--vl-textarea--padding);
+    }
+
+    /* ===================================================================
+       Textarea Character Counter
+       =================================================================== */
+
+    .vl-textarea__counter {
+        font-family: var(--vl-font);
+        font-size: var(--vl-font-size--small);
+        color: var(--vl-textarea--counter-color);
+    }
+
+    .vl-textarea__counter-status {
+        ${vlVisuallyHiddenMixin()};
     }
 `;

--- a/libs/components/src/form/textarea/vl-textarea.component.cy.ts
+++ b/libs/components/src/form/textarea/vl-textarea.component.cy.ts
@@ -150,6 +150,100 @@ describe('vl-textarea - properties & states', () => {
     });
 });
 
+describe('vl-textarea - character count', () => {
+    it('should not render a counter without the character-count attribute', () => {
+        cy.mount(html`<vl-textarea max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('not.exist');
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter-status').should('not.exist');
+    });
+
+    it('should not render a counter when character-count is set without max-length', () => {
+        cy.mount(html`<vl-textarea character-count></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('not.exist');
+    });
+
+    it('should render the counter in the {current}/{max} format', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50" value="hallo"></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.text', '5/50');
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.attr', 'aria-hidden', 'true');
+    });
+
+    it('should update the counter live while typing', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.text', '0/50');
+        cy.get('vl-textarea').shadow().find('textarea').type('test');
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.text', '4/50');
+    });
+
+    it('should update the counter on programmatic value change', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea').invoke('attr', 'value', 'programmatic');
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.text', '12/50');
+    });
+
+    it('should keep the live region empty above the 10 character threshold', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        // 39 chars => 11 remaining, still above threshold.
+        cy.get('vl-textarea').shadow().find('textarea').type('a'.repeat(39));
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter-status').should('have.text', '');
+    });
+
+    it('should announce the remaining characters from the last 10 characters', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        // 40 chars => 10 remaining, threshold reached.
+        cy.get('vl-textarea').shadow().find('textarea').type('a'.repeat(40));
+        cy.get('vl-textarea')
+            .shadow()
+            .find('.vl-textarea__counter-status')
+            .should('have.text', 'Nog 10 tekens beschikbaar');
+    });
+
+    it('should use the singular form when one character remains', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('textarea').type('a'.repeat(49));
+        cy.get('vl-textarea')
+            .shadow()
+            .find('.vl-textarea__counter-status')
+            .should('have.text', 'Nog 1 teken beschikbaar');
+    });
+
+    it('should announce zero remaining characters at the limit', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea').shadow().find('textarea').type('a'.repeat(50));
+        cy.get('vl-textarea').shadow().find('.vl-textarea__counter').should('have.text', '50/50');
+        cy.get('vl-textarea')
+            .shadow()
+            .find('.vl-textarea__counter-status')
+            .should('have.text', 'Nog 0 tekens beschikbaar');
+    });
+
+    it('should keep the live region permanently in the DOM with polite/atomic semantics', () => {
+        cy.mount(html`<vl-textarea character-count max-length="50"></vl-textarea>`);
+
+        cy.get('vl-textarea')
+            .shadow()
+            .find('.vl-textarea__counter-status')
+            .should('have.attr', 'aria-live', 'polite')
+            .and('have.attr', 'aria-atomic', 'true');
+    });
+
+    it('should be accessible with the counter enabled', () => {
+        cy.mount(html`<vl-textarea label="bericht" character-count max-length="50" value="hallo"></vl-textarea>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-textarea');
+    });
+});
+
 describe('vl-textarea - events', () => {
     it('should dispatch both vl-input & vl-change events on input', () => {
         cy.mount(html`<vl-textarea></vl-textarea>`);

--- a/libs/components/src/form/textarea/vl-textarea.component.raw.css
+++ b/libs/components/src/form/textarea/vl-textarea.component.raw.css
@@ -7,4 +7,7 @@
 
     /* Margin */
     --vl-textarea--margin: 0.5rem 0;
+
+    /* Character counter */
+    --vl-textarea--counter-color: var(--vl-color--text-alt);
 }

--- a/libs/components/src/form/textarea/vl-textarea.component.ts
+++ b/libs/components/src/form/textarea/vl-textarea.component.ts
@@ -8,11 +8,15 @@ import { FormControl } from '../form-control/form-control';
 import { vlTextareaComponentStyles } from './vl-textarea.component.css';
 import { textareaDefaults } from './vl-textarea.defaults';
 
+// de resterende tekens worden pas via aria-live aangekondigd vanaf de laatste 10 tekens
+const CHARACTER_COUNT_LIVE_THRESHOLD = 10;
+
 @webComponent('vl-textarea')
 export class VlTextareaComponent extends FormControl {
     // Attributes
     protected block = textareaDefaults.block;
     protected readonly = textareaDefaults.readonly;
+    protected characterCount = textareaDefaults.characterCount;
     protected value = textareaDefaults.value;
     protected placeholder = textareaDefaults.placeholder;
     protected autocomplete = textareaDefaults.autocomplete;
@@ -36,6 +40,7 @@ export class VlTextareaComponent extends FormControl {
         return {
             block: { type: Boolean },
             readonly: { type: Boolean },
+            characterCount: { type: Boolean, attribute: 'character-count' },
             value: { type: String, reflect: true },
             placeholder: { type: String },
             autocomplete: { type: String },
@@ -98,7 +103,21 @@ export class VlTextareaComponent extends FormControl {
                 rows=${this.rows ?? nothing}
                 cols=${this.cols ?? nothing}
                 @input=${this.onInput}
-            />
+            ></textarea>
+            ${this.characterCount && this.maxLength != null ? this.renderCharacterCount(this.maxLength) : nothing}
+        `;
+    }
+
+    private renderCharacterCount(maxLength: number): TemplateResult {
+        const remaining = maxLength - this.value.length;
+        const announcement =
+            remaining <= CHARACTER_COUNT_LIVE_THRESHOLD
+                ? `Nog ${remaining} ${remaining === 1 ? 'teken' : 'tekens'} beschikbaar`
+                : '';
+
+        return html`
+            <div class="vl-textarea__counter" aria-hidden="true">${this.value.length}/${maxLength}</div>
+            <div class="vl-textarea__counter-status" aria-live="polite" aria-atomic="true">${announcement}</div>
         `;
     }
 

--- a/libs/components/src/form/textarea/vl-textarea.defaults.ts
+++ b/libs/components/src/form/textarea/vl-textarea.defaults.ts
@@ -4,6 +4,7 @@ export const textareaDefaults = {
     ...formControlDefaults,
     block: false as boolean,
     readonly: false as boolean,
+    characterCount: false as boolean,
     value: '' as string,
     placeholder: '' as string,
     autocomplete: '' as string,


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-652
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC384

## Samenvatting
`vl-textarea` krijgt een opt-in karakterteller: met het nieuwe `character-count` attribute verschijnt onder de textarea een teller `{huidig}/{max}` zodra `max-length` gezet is. Screenreader-gebruikers krijgen vanaf de laatste 10 resterende tekens een toegankelijke aankondiging van het aantal beschikbare tekens, naar het voorbeeld van het Nord design system.

## Wijzigingen
- Nieuw boolean attribute `character-count` op `vl-textarea`; toont samen met `max-length` een live bijgewerkte teller `{huidig}/{max}` onder de textarea.
- Teller updatet live bij typen, plakken en programmatische `value`-wijzigingen.
- Toegankelijke aankondiging "Nog X tekens beschikbaar" via een visueel verborgen `aria-live="polite" aria-atomic="true"` regio, pas vanaf de laatste 10 resterende tekens, met correcte enkelvoudsvorm ("Nog 1 teken beschikbaar"); de zichtbare teller is `aria-hidden` om dubbele voorlezing te vermijden.
- Nieuwe CSS custom property `--vl-textarea--counter-color` (default `--vl-color--text-alt`) om de tellerkleur te themen.
- Storybook: nieuwe story "vl-textarea - character count", argType en documentatiesectie "Karakterteller".

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Onder de textarea verschijnt een teller `{huidig}/{max}` wanneer `max-length` gezet is — via het opt-in `character-count` attribute, gerenderd in de shadow DOM.
- [x] De teller updatet live bij typen, plakken en programmatische `value`-wijzigingen — teller leest de reactive `value` property; getest voor typen en programmatische wijziging.
- [x] Visueel verborgen `aria-live="polite" aria-atomic="true"` regio kondigt "nog X tekens beschikbaar" aan vanaf de laatste 10 resterende tekens — permanente live-regio waarvan enkel de tekst wijzigt op de drempel; getest op grens 11 (stil) vs 10 (aangekondigd) en op de limiet (0).
- [x] De zichtbare teller wordt niet dubbel voorgelezen — `aria-hidden="true"` op het teller-element, getest.
- [x] Bestaande consumers zonder de nieuwe feature zien geen enkele visuele of gedragswijziging — opt-in attribute; zonder `character-count` rendert de component exact dezelfde DOM, bevestigd door de ongewijzigde visuele snapshot-tests.
