### PR TITLE
feat: FLUX-270 - vl-search - deprecaten met zoek-patroon als alternatief

### DIFF
--- a/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
+++ b/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
@@ -113,6 +113,31 @@ moeten na de v3 upgrade verifiëren dat hun datepicker correct rendert.
 </table>
 
 
+### Search
+
+`Search` is deprecated in v2 en wordt verwijderd in v3. Bouw voortaan een zoekformulier
+met de [`input-group`](/docs/components-form-input-group--documentatie) (`vl-input-field` + `vl-button` met
+`loading`) - zie het [zoek-patroon](/docs/patronen-zoeken-loading-state--documentatie).
+
+<table  style={{width: 100 + '%'}}>
+    <tr>
+        <th>Naam</th>
+        <th>Toestand</th>
+        <th>v2 - Artifact</th>
+        <th>v2 - Gebruik</th>
+        <th>v3 - Artifact</th>
+        <th>v3 - Gebruik</th>
+    </tr>
+    <tr>
+        <td>[Search [legacy]](/docs/components-block-search--documentatie)</td>
+        <td>deprecated</td>
+        <td>components/block</td>
+        <td><code>{`<vl-search>`}</code></td>
+        <td>-</td>
+        <td><code>-</code></td>
+    </tr>
+</table>
+
 ### Share Buttons
 
 `Share Buttons` is deprecated in v2 en wordt verwijderd in v3. Er komt geen `next`-variant: gebruik een

--- a/apps/storybook/docs/f_patronen/navigatie/functionele-header/2_met-search/functionele-header-met-search.mdx
+++ b/apps/storybook/docs/f_patronen/navigatie/functionele-header/2_met-search/functionele-header-met-search.mdx
@@ -6,16 +6,23 @@ import { functionalHeaderWithSearchHtmlSourceCode } from '../functionele-header.
 
 # Functionele Header - met Search
 
-In dit voorbeeld tonen we hoe een [vl-search](/docs/components-block-search--documentatie) component kan toegevoegd worden aan de [vl-functional-header](/docs/components-block-functional-header--documentatie).
+In dit voorbeeld tonen we hoe een zoekformulier kan toegevoegd worden aan de
+[vl-functional-header](/docs/components-block-functional-header--documentatie).
 
-We gebruiken een [vl-search](/docs/components-block-search--documentatie) component gecombineerd met de [vl-group](/docs/styles-layout-group--documentatie) stijl om een zoekveld rechts uit te lijnen naast een breadcrumb of andere variant.
+We bouwen het zoekformulier met de [Input Group](/docs/components-form-input-group--documentatie)
+(een [vl-input-field](/docs/components-form-input-field--documentatie) en een
+[vl-button](/docs/components-atom-button--documentatie) in een `<form role="search">`), gecombineerd met de
+[vl-group](/docs/styles-layout-group--documentatie) stijl om het zoekveld rechts uit te lijnen naast een
+breadcrumb of andere variant. Zie ook het [zoek-patroon](/docs/patronen-zoeken-loading-state--documentatie)
+voor een uitwerking met loading state.
 
 In dit geval wordt custom CSS meegegeven om deze layout mogelijk te maken.
 
 ## Componenten
 
 - [vl-functional-header](/docs/components-block-functional-header--documentatie)
-- [vl-search](/docs/components-block-search--documentatie)
+- [vl-input-field](/docs/components-form-input-field--documentatie)
+- [vl-button](/docs/components-atom-button--documentatie)
 
 ## Stijlen
 

--- a/apps/storybook/docs/f_patronen/navigatie/functionele-header/2_met-search/functionele-header-met-search.stories.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/functionele-header/2_met-search/functionele-header-met-search.stories.ts
@@ -1,11 +1,12 @@
 import { story } from '@resources/utils-storybook';
 import { registerWebComponents } from '@domg-wc/common';
 import { vlGroupStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import { VlInputFieldComponent } from '@domg-wc/components/form';
 import {
     VlBreadcrumbComponent,
     VlBreadcrumbItemComponent,
     VlFunctionalHeaderComponent,
-    VlSearchComponent,
 } from '@domg-wc/components/block';
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
@@ -16,7 +17,8 @@ registerWebComponents([
     VlBreadcrumbComponent,
     VlBreadcrumbItemComponent,
     VlFunctionalHeaderComponent,
-    VlSearchComponent,
+    VlButtonComponent,
+    VlInputFieldComponent,
 ]);
 
 export default {

--- a/apps/storybook/docs/f_patronen/navigatie/functionele-header/3_met-back-en-tabs/functionele-header-met-back-en-tabs.stories.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/functionele-header/3_met-back-en-tabs/functionele-header-met-back-en-tabs.stories.ts
@@ -3,7 +3,6 @@ import {
     VlBreadcrumbComponent,
     VlBreadcrumbItemComponent,
     VlFunctionalHeaderComponent,
-    VlSearchComponent,
 } from '@domg-wc/components/block';
 import { VlTabLinkComponent, VlTabsComponent } from '@domg-wc/components/block/next';
 import { story } from '@resources/utils-storybook';
@@ -16,7 +15,6 @@ registerWebComponents([
     VlBreadcrumbComponent,
     VlBreadcrumbItemComponent,
     VlFunctionalHeaderComponent,
-    VlSearchComponent,
     VlTabsComponent,
     VlTabLinkComponent,
 ]);

--- a/apps/storybook/docs/f_patronen/navigatie/functionele-header/functionele-header.helpers.ts
+++ b/apps/storybook/docs/f_patronen/navigatie/functionele-header/functionele-header.helpers.ts
@@ -22,14 +22,24 @@ export const functionalHeaderWithButtonHtml = createFunctionalHeaderHtmlWithExtr
     '<vl-button>Actie knop</vl-button>'
 );
 export const functionalHeaderWithSearchHtml = createFunctionalHeaderHtmlWithExtraComponent(
-    '<vl-search id="search-inline" inline></vl-search>'
+    `<form role="search" aria-label="Zoeken op deze site">
+        <div class="vl-group vl-group--input-group">
+            <vl-input-field input-group block type="search" name="zoekterm" label="Zoekterm"></vl-input-field>
+            <vl-button input-group icon="search" type="submit" label="Zoeken" tertiary></vl-button>
+        </div>
+    </form>`
 );
 export const functionalHeaderWithButtonHtmlSourceCode = createFunctionalHeaderHtmlWithExtraComponent(
     '<vl-button>Actie knop</vl-button>',
     true
 );
 export const functionalHeaderWithSearchHtmlSourceCode = createFunctionalHeaderHtmlWithExtraComponent(
-    '<vl-search id="search-inline" inline></vl-search>',
+    `<form role="search" aria-label="Zoeken op deze site">
+        <div class="vl-group vl-group--input-group">
+            <vl-input-field input-group block type="search" name="zoekterm" label="Zoekterm"></vl-input-field>
+            <vl-button input-group icon="search" type="submit" label="Zoeken" tertiary></vl-button>
+        </div>
+    </form>`,
     true
 );
 

--- a/apps/storybook/docs/f_patronen/zoeken/zoeken-loading-state.mdx
+++ b/apps/storybook/docs/f_patronen/zoeken/zoeken-loading-state.mdx
@@ -1,0 +1,55 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as zoekenStories from './zoeken-loading-state.stories';
+
+<Meta of={zoekenStories} />
+
+# Zoeken - loading state
+
+Een zoekformulier wordt opgebouwd met de [Input Group](/docs/components-form-input-group--documentatie):
+een [vl-input-field](/docs/components-form-input-field--documentatie) en een
+[vl-button](/docs/components-atom-button--documentatie) in de juiste toestand, gewrapt in een
+`<form>`. Zo is er geen aparte zoek-component nodig.
+
+Bij trage backends (bv. een MAGDA-call) is het belangrijk om aan te geven dat de zoekopdracht loopt,
+zodat gebruikers niet meermaals klikken. De `loading`-toestand van `vl-button` blokkeert het klikken
+en zet `aria-busy`; zodra het resultaat binnen is zet je `loading` terug op `false`.
+
+<Canvas of={zoekenStories.ZoekenLoadingState} sourceState="none" />
+
+## Opbouw
+
+```html
+<form role="search" aria-label="Zoeken op deze site">
+    <div class="vl-group vl-group--input-group">
+        <vl-input-field input-group block type="search" name="zoekterm" label="Zoekterm"></vl-input-field>
+        <vl-button input-group icon="search" type="submit" label="Zoeken" tertiary></vl-button>
+    </div>
+    <p role="status" aria-live="polite"></p>
+</form>
+```
+
+De loading-state stuur je aan op de `vl-button`: zet `loading` zodra je de zoekopdracht start en
+haal het er weer af zodra het resultaat binnen is.
+
+```ts
+button.toggleAttribute('loading', true); // zoekopdracht gestart: knop geblokkeerd, aria-busy actief
+// ... resultaat binnen ...
+button.toggleAttribute('loading', false); // terug naar de normale toestand
+status.textContent = '8 resultaten geladen.'; // aankondiging via aria-live
+```
+
+## Toegankelijkheid (WCAG 2.2 AA)
+
+- **`role="search"` landmark** - gebruik dit enkel voor de globale site-search, zodat hulptechnologie
+  het zoekblok als landmark herkent. Staan er meerdere zoekvelden op één pagina (bv. een filter binnen
+  een lijst), geef dan elke `role="search"` een eigen `aria-label`, of laat de role weg voor secundaire
+  zoekvelden.
+- **`aria-busy` tijdens het zoeken** - `vl-button` zet `aria-busy="true"` en `aria-disabled="true"`
+  zolang `loading` aanstaat en blokkeert herhaald klikken. Dat is voldoende om de knop-toestand te
+  communiceren, maar niet om het resultaat aan te kondigen.
+- **Resultaten aankondigen via `aria-live`** - `aria-busy` alleen meldt een screenreader niet dat de
+  zoekopdracht klaar is. Voorzie een `aria-live="polite"`-regio (`role="status"`) en vul die met een
+  korte samenvatting zodra het resultaat binnen is (bv. "8 resultaten geladen"). Zo voldoe je aan
+  [WCAG 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html).
+- **Label** - het `label`-attribuut op `vl-input-field` is verplicht voor een toegankelijke naam; de
+  `vl-button` ontleent zijn naam aan het label "Zoeken" en is visueel gelabeld door het "search" icoon.

--- a/apps/storybook/docs/f_patronen/zoeken/zoeken-loading-state.stories.ts
+++ b/apps/storybook/docs/f_patronen/zoeken/zoeken-loading-state.stories.ts
@@ -1,0 +1,49 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { vlGroupStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import { VlInputFieldComponent } from '@domg-wc/components/form';
+import { Meta } from '@storybook/web-components-vite';
+import { html } from 'lit';
+
+registerWebComponents([VlButtonComponent, VlInputFieldComponent]);
+
+export default {
+    title: 'Patronen/Zoeken/loading state',
+} as Meta;
+
+const RESULT_DELAY_MS = 1500;
+
+// Simuleert een trage backend (bv. een MAGDA-call): de vl-button blokkeert klikken zolang `loading`
+// aanstaat en de aria-live-regio kondigt het resultaat aan zodra het binnen is. De guard voorkomt dat
+// een herhaalde submit (bv. Enter in het zoekveld) een tweede zoekopdracht start.
+const handleSearch = (event: Event) => {
+    event.preventDefault();
+    const form = event.currentTarget as HTMLFormElement;
+    const button = form.querySelector('vl-button')!;
+    if (button.hasAttribute('loading')) {
+        return;
+    }
+
+    const status = form.querySelector('[data-search-status]')!;
+    button.toggleAttribute('loading', true);
+    status.textContent = 'Bezig met zoeken…';
+
+    window.setTimeout(() => {
+        button.toggleAttribute('loading', false);
+        status.textContent = '8 resultaten geladen.';
+    }, RESULT_DELAY_MS);
+};
+
+export const ZoekenLoadingState = () => html`
+    <style>
+        ${vlGroupStyles}
+    </style>
+    <form role="search" aria-label="Zoeken op deze site" @submit=${handleSearch}>
+        <div class="vl-group vl-group--input-group">
+            <vl-input-field input-group block type="search" name="zoekterm" label="Zoekterm"></vl-input-field>
+            <vl-button input-group icon="search" type="submit" label="Zoeken" tertiary></vl-button>
+        </div>
+        <p data-search-status role="status" aria-live="polite"></p>
+    </form>
+`;
+ZoekenLoadingState.storyName = 'zoeken - loading state';

--- a/libs/components/src/block/search/stories/vl-search.stories-doc.mdx
+++ b/libs/components/src/block/search/stories/vl-search.stories-doc.mdx
@@ -1,0 +1,29 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlSearchStories from './vl-search.stories';
+
+# Search
+
+<FluxComponentMetaData id="components-block-search" />
+
+<FluxAlert type="warning" title="Deprecated">
+{`
+ Deze component is <strong>deprecated</strong> en wordt verwijderd in <strong>v3</strong>. Bouw voortaan een
+ zoekformulier met een <code>input-group</code> (<code>vl-input-field</code> + <code>vl-button</code> met
+ <code>loading</code>) zoals beschreven onder het [zoek-patroon](/docs/patronen-zoeken-loading-state--documentatie).
+`}
+</FluxAlert>
+
+
+## Doel
+
+De `search` component toont een zoekveld met een zoekknop.
+
+
+## Voorbeeld
+
+<Canvas of={VlSearchStories.searchDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlSearchStories.searchDefault} />

--- a/libs/components/src/block/search/stories/vl-search.stories.ts
+++ b/libs/components/src/block/search/stories/vl-search.stories.ts
@@ -2,6 +2,7 @@ import { defaultArgs, defaultArgTypes, story } from '@resources/utils-storybook'
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import '../vl-search.component';
+import searchDoc from './vl-search.stories-doc.mdx';
 
 export default {
     id: 'components-block-search',
@@ -9,6 +10,11 @@ export default {
     tags: ['autodocs'],
     args: defaultArgs,
     argTypes: defaultArgTypes,
+    parameters: {
+        docs: {
+            page: searchDoc,
+        },
+    },
 } as Meta<typeof defaultArgs>;
 
 // TODO Add options to the story.

--- a/libs/components/src/block/search/vl-search.component.cy.ts
+++ b/libs/components/src/block/search/vl-search.component.cy.ts
@@ -1,0 +1,31 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { html } from 'lit';
+import { VlSearchComponent } from './vl-search.component';
+
+registerWebComponents([VlSearchComponent]);
+
+describe('cypress-component - block components - vl-search', () => {
+    beforeEach(() => {
+        // private static enkel op compile-time; reset de "warn once"-vlag voor test-isolatie
+        (VlSearchComponent as unknown as { deprecationWarningShown: boolean }).deprecationWarningShown = false;
+    });
+
+    it('should mount', () => {
+        cy.mount(html` <vl-search></vl-search>`);
+
+        cy.get('vl-search').shadow().find('.vl-search');
+    });
+
+    it('should warn once that the component is deprecated', () => {
+        cy.spy(console, 'warn').as('warn');
+
+        cy.mount(html` <vl-search></vl-search>`);
+
+        cy.get('@warn').should('have.been.calledOnce');
+        cy.get('@warn').should(
+            'have.been.calledWith',
+            'vl-search is deprecated en wordt verwijderd in v3. Bouw een zoekformulier met de input-group' +
+                ' (vl-input-field + vl-button met loading), zie het zoek-patroon onder Patronen/Zoeken.'
+        );
+    });
+});

--- a/libs/components/src/block/search/vl-search.component.ts
+++ b/libs/components/src/block/search/vl-search.component.ts
@@ -7,8 +7,14 @@ import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { inputFieldStyles, VlInputFieldComponent } from '../../form/input-field';
 import { vlSearchFluxStyles } from './vl-search.flux-css';
 
+/**
+ * @deprecated Wordt verwijderd in v3. Bouw een zoekformulier met de input-group
+ * (`vl-input-field` + `vl-button` met `loading`), zie het zoek-patroon onder Patronen/Zoeken.
+ */
 @webComponent('vl-search')
 export class VlSearchComponent extends BaseHTMLElement {
+    private static deprecationWarningShown = false;
+
     static {
         registerWebComponents([VlIconComponent, VlInputFieldComponent]);
     }
@@ -82,6 +88,14 @@ export class VlSearchComponent extends BaseHTMLElement {
 
     connectedCallback() {
         super.connectedCallback();
+
+        if (!VlSearchComponent.deprecationWarningShown) {
+            console.warn(
+                'vl-search is deprecated en wordt verwijderd in v3. Bouw een zoekformulier met de input-group' +
+                    ' (vl-input-field + vl-button met loading), zie het zoek-patroon onder Patronen/Zoeken.'
+            );
+            VlSearchComponent.deprecationWarningShown = true;
+        }
 
         if (!this._isInline && !this._isBlock) {
             this.setAttribute('block', ''); // default to block if none set

--- a/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
@@ -265,7 +265,13 @@ export const buildWTConfigComponentsBlock: WTConfigArray = [
     ),
     buildWTConfig('vl-rich-data-field', null, null, '/docs/components-block-rich-data-table--documentatie'),
     buildWTConfig('vl-rich-data-sorter', null, null, '/docs/components-block-rich-data-table--documentatie'),
-    buildWTConfig('vl-search', null, null, '/docs/components-block-search--documentatie'),
+    buildWTConfig(
+        'vl-search',
+        null,
+        '../../libs/components/src/block/search/stories/vl-search.stories-doc.mdx',
+        '/docs/components-block-search--documentatie',
+        'Deprecated en wordt verwijderd in v3. Bouw een zoekformulier met de input-group (vl-input-field + vl-button met loading).'
+    ),
     buildWTConfig(
         'vl-share-button',
         shareButtonArgTypes,


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-270
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC386

## Samenvatting
`vl-search` wordt gemarkeerd als deprecated (verwijderd in v3) maar blijft functioneel werken. Als alternatief komt er een nieuw Storybook-patroon onder `Patronen/Zoeken` dat toont hoe je met de `input-group` een zoekformulier bouwt dat feedback geeft terwijl de zoekopdracht loopt, zodat gebruikers bij trage backends niet meermaals op de zoekknop klikken.

## Wijzigingen
- Nieuw patroon `Patronen/Zoeken/loading state`: een zoekformulier opgebouwd met de `input-group` (`vl-input-field` + `vl-button`) binnen een `<form role="search">`, dat de `loading`-state van `vl-button` aanstuurt en het resultaat aankondigt via een `aria-live`-regio, inclusief reset zodra het resultaat binnen is.
- Het patroon dekt ook dubbele zoekopdrachten af: een herhaalde submit (bv. Enter in het zoekveld) tijdens het laden start geen tweede zoekopdracht.
- WCAG-richtlijnen gedocumenteerd in het patroon: `role="search"`-landmark, `aria-busy` tijdens het zoeken en status messages via een `aria-live`-regio (WCAG 4.1.3).
- `vl-search` gedeprecate conform `vl-share-buttons`: JSDoc `@deprecated`, eenmalige console-waarschuwing en een `Deprecated`-banner in de Storybook-docs met verwijzing naar het patroon.
- IDE-tooling en planning bijgewerkt: `deprecated`-vlag voor `vl-search` in de web-types en een `Search`-rij in de v2→v3-migratietabel.

## Backwards compatibility
Additieve wijziging met deprecated path: `vl-search` is gemarkeerd als deprecated (blijft functioneel werken), het nieuwe alternatief is het zoek-patroon met `input-group` + `vl-button.loading`, en de component wordt effectief verwijderd in v3.

## Succescriteria
- [x] Nieuw Storybook-patroon onder categorie `Patronen/Zoeken`, opgebouwd met de `input-group` binnen `<form role="search">` — `zoeken-loading-state.stories.ts` + `.mdx`.
- [x] Patroon demonstreert de lopende-zoekopdracht-state via `vl-button` `loading` (knop geblokkeerd, `aria-busy`) inclusief reset naar de normale state zodra het resultaat binnen is.
- [x] WCAG-overwegingen gedocumenteerd in de patroon-MDX — search landmark, `aria-busy`, `aria-live`-regio voor resultaten.
- [x] `vl-search` gedeprecate conform `vl-share-buttons` (JSDoc, console-warning, docs-banner, web-types-vlag, migratietabel); component blijft functioneel.
- [x] Werk staat als één gesquashte commit op de feature-branch (ontwikkeld als patroon + deprecatie).
