### PR TITLE
feat: FLUX-660 - vl-properties - shadow DOM synchroon + no-clone deprecaten

### DIFF
--- a/libs/common/src/util/mutation-utils.spec.ts
+++ b/libs/common/src/util/mutation-utils.spec.ts
@@ -15,4 +15,20 @@ describe('jest - common - mutation-utils', () => {
         await new Promise(process.nextTick);
         expect(changeList.length).toEqual(3);
     });
+
+    it('should detect in-place attribute changes when attributes is enabled', async () => {
+        const columnElement = buildDiv(null, 'column');
+        const changeList = [];
+        onChildListChange(
+            columnElement,
+            () => {
+                changeList.push('change');
+            },
+            { attributes: true }
+        );
+        columnElement.setAttribute('style', 'color: red');
+        // necessary to allow the MutationObserver in onChildListChange to do his job
+        await new Promise(process.nextTick);
+        expect(changeList.length).toEqual(1);
+    });
 });

--- a/libs/common/src/util/mutation-utils.ts
+++ b/libs/common/src/util/mutation-utils.ts
@@ -7,18 +7,24 @@
  * @return {MutationObserver} - de observer waarop een subscriptie gedaan werd, deze moet terug vrijgegeven worden via
  *                              een disconnect()
  * @param {Element} toObserve - het te observeren element
- * @param {(impactedNodes: NodeList) => void} changeCallback - de methode die aangeroepen wordt bij een mutatie
+ * @param {(impactedNodes?: NodeList) => void} changeCallback - de methode die aangeroepen wordt bij een mutatie
+ * @param {MutationObserverInit} options - de observer-opties; standaard enkel `childList`. Geef bv.
+ *                              `{ childList: true, subtree: true, characterData: true, attributes: true }` mee om
+ *                              ook in-place tekst- en attribuutwijzigingen diep in de subtree te detecteren.
  */
 export const onChildListChange = (
     toObserve: Element,
-    changeCallback: (impactedNodes: NodeList) => void
+    changeCallback: (impactedNodes?: NodeList) => void,
+    options: MutationObserverInit = { childList: true }
 ): MutationObserver => {
     const mutationObserver = new MutationObserver((mutations: MutationRecord[]) => {
         mutations.forEach((mutation: MutationRecord) => {
             if (mutation.addedNodes.length) changeCallback(mutation.addedNodes);
             if (mutation.removedNodes.length) changeCallback(mutation.removedNodes);
+            // characterData- en attributes-mutaties moeten de callback ook triggeren
+            if (mutation.type === 'characterData' || mutation.type === 'attributes') changeCallback();
         });
     });
-    mutationObserver.observe(toObserve, { childList: true });
+    mutationObserver.observe(toObserve, options);
     return mutationObserver;
 };

--- a/libs/components/src/block/properties/stories/vl-properties.stories-arg.ts
+++ b/libs/components/src/block/properties/stories/vl-properties.stories-arg.ts
@@ -20,17 +20,6 @@ export const propertiesArgTypes: ArgTypes<PropertiesArgs> = {
             defaultValue: { summary: String(propertiesArgs.labelWidth) },
         },
     },
-    noClone: {
-        name: 'no-clone',
-        description:
-            'Default wordt de inhoud van label en data ge-cloned: van de Light DOM naar de shadow DOM,' +
-            ' met no-clone actief wordt de inhoud verplaatst.',
-        table: {
-            type: { summary: TYPES.BOOLEAN },
-            category: CATEGORIES.ATTRIBUTES,
-            defaultValue: { summary: String(propertiesArgs.noClone) },
-        },
-    },
     props: {
         name: 'props',
         description: 'De props in JSON formaat.',

--- a/libs/components/src/block/properties/vl-properties.builder.spec.ts
+++ b/libs/components/src/block/properties/vl-properties.builder.spec.ts
@@ -8,11 +8,11 @@ describe('jest - components - vl-properties', () => {
     });
 
     it('buildProperties should build empty properties for a null element', () => {
-        expect(buildProperties(null, true)).toEqual([]);
+        expect(buildProperties(null)).toEqual([]);
     });
 
     it('buildProperties should build empty properties for empty elements', () => {
-        expect(buildProperties([], true)).toEqual([]);
+        expect(buildProperties([])).toEqual([]);
     });
 
     it('buildProperties should build properties for an array of labels and data', () => {
@@ -21,7 +21,7 @@ describe('jest - components - vl-properties', () => {
         elements.push(buildData('Brussel'));
         elements.push(buildLabel('Postcode'));
         elements.push(buildData('1000'));
-        expect(buildProperties(elements, true)).toEqual([
+        expect(buildProperties(elements)).toEqual([
             {
                 items: [
                     {
@@ -45,7 +45,7 @@ describe('jest - components - vl-properties', () => {
         labelElement.setAttribute('style', 'color: red');
         const dataElement = buildSpan('Brussel');
         dataElement.setAttribute('style', 'color: blue');
-        expect(buildProperties(elements, true)).toEqual([
+        expect(buildProperties(elements)).toEqual([
             {
                 items: [
                     {
@@ -57,7 +57,7 @@ describe('jest - components - vl-properties', () => {
         ]);
     });
 
-    it('buildProperties should not clone when specified', () => {
+    it('buildProperties should clone the child nodes', () => {
         const elements: Element[] = [];
         // build and add label
         const labelElement = document.createElement('label');
@@ -71,16 +71,12 @@ describe('jest - components - vl-properties', () => {
         dataChild.setAttribute('style', 'color: blue');
         dataElement.appendChild(dataChild);
         elements.push(dataElement);
-        // the cloned label and data are equal but have a different reference
-        // the no-cloned label and data have the same reference
-        const clonedProperties = buildProperties(elements, true);
-        const noCloneProperties = buildProperties(elements, false);
+        // de ge-clonede label en data zijn gelijk maar hebben een andere referentie dan de light DOM nodes
+        const clonedProperties = buildProperties(elements);
         expect(clonedProperties[0].items[0].labels[0][0]).not.toBe(labelChild);
         expect(clonedProperties[0].items[0].labels[0][0]).toEqual(labelChild);
-        expect(noCloneProperties[0].items[0].labels[0][0]).toBe(labelChild);
         expect(clonedProperties[0].items[0].data[0][0]).not.toBe(dataChild);
         expect(clonedProperties[0].items[0].data[0][0]).toEqual(dataChild);
-        expect(noCloneProperties[0].items[0].data[0][0]).toBe(dataChild);
     });
 
     it('buildProperties should build properties for an array of columns', () => {
@@ -91,7 +87,7 @@ describe('jest - components - vl-properties', () => {
         column.appendChild(buildData('Brussel'));
         column.appendChild(buildLabel('Postcode'));
         column.appendChild(buildData('1000'));
-        expect(buildProperties(columns, true)).toEqual([
+        expect(buildProperties(columns)).toEqual([
             {
                 class: 'column',
                 items: [
@@ -119,7 +115,7 @@ describe('jest - components - vl-properties', () => {
         dataElement.appendChild(document.createTextNode('42'));
         dataElement.appendChild(document.createComment('?'));
 
-        const result = buildProperties([labelElement, dataElement], false);
+        const result = buildProperties([labelElement, dataElement]);
 
         expect(result).toHaveLength(1);
         const item = result[0].items[0];

--- a/libs/components/src/block/properties/vl-properties.builder.ts
+++ b/libs/components/src/block/properties/vl-properties.builder.ts
@@ -1,9 +1,8 @@
 import { Item, Props } from './vl-properties.model';
 
-const moveChildNodes = (childNodes: ChildNode[], clone: boolean): Node[] =>
-    clone ? childNodes.map((node) => node.cloneNode(true)) : childNodes;
+const cloneChildNodes = (childNodes: ChildNode[]): Node[] => childNodes.map((node) => node.cloneNode(true));
 
-const buildItems = (elements: Element[], clone: boolean): Item[] => {
+const buildItems = (elements: Element[]): Item[] => {
     const items: Item[] = [];
     let labels: Node[][] = [],
         data: Node[][] = [];
@@ -18,11 +17,11 @@ const buildItems = (elements: Element[], clone: boolean): Item[] => {
                     labels = [];
                     data = [];
                 }
-                labels.push(moveChildNodes([...element.childNodes], clone));
+                labels.push(cloneChildNodes([...element.childNodes]));
                 break;
             case 'data':
             case 'vl-property-data':
-                data.push(moveChildNodes([...element.childNodes], clone));
+                data.push(cloneChildNodes([...element.childNodes]));
                 break;
         }
     });
@@ -32,7 +31,7 @@ const buildItems = (elements: Element[], clone: boolean): Item[] => {
     return items;
 };
 
-export const buildProperties = (elements: Element[] | null, clone: boolean): Props => {
+export const buildProperties = (elements: Element[] | null): Props => {
     if (elements == null || elements.length == 0) {
         return [];
     }
@@ -40,10 +39,10 @@ export const buildProperties = (elements: Element[] | null, clone: boolean): Pro
         // er is een 'column' gedefinieerd: verwerk ze
         return elements.map((element: Element) => ({
             class: element.className,
-            items: buildItems([...element.children], clone),
+            items: buildItems([...element.children]),
         }));
     } else {
         // er is geen 'column' aanwezig, enkel labels en data
-        return [{ items: buildItems(elements, clone) }];
+        return [{ items: buildItems(elements) }];
     }
 };

--- a/libs/components/src/block/properties/vl-properties.component.cy.ts
+++ b/libs/components/src/block/properties/vl-properties.component.cy.ts
@@ -97,6 +97,42 @@ describe('cypress-component - block components - vl-properties', () => {
             });
     });
 
+    it('should update shadow DOM when a light DOM text node is mutated in-place', () => {
+        cy.mount(html`
+            <vl-properties>
+                <vl-property>Woonplaats</vl-property>
+                <vl-property-data><span>Brussel</span></vl-property-data>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').find('span').should('contain.text', 'Brussel');
+
+        cy.runTestFor<VlPropertiesComponent>('vl-properties', (component) => {
+            const textNode = component.querySelector('vl-property-data span')?.firstChild;
+            textNode!.textContent = 'Antwerpen';
+        });
+
+        cy.get('vl-properties').shadow().find('dd').find('span').should('contain.text', 'Antwerpen');
+    });
+
+    it('should update shadow DOM when a light DOM attribute is mutated in-place', () => {
+        cy.mount(html`
+            <vl-properties>
+                <vl-property>Woonplaats</vl-property>
+                <vl-property-data><span style="color: blue">Brussel</span></vl-property-data>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').find('span').should('have.attr', 'style', 'color: blue');
+
+        cy.runTestFor<VlPropertiesComponent>('vl-properties', (component) => {
+            const span = component.querySelector('vl-property-data span');
+            span!.setAttribute('style', 'color: red');
+        });
+
+        cy.get('vl-properties').shadow().find('dd').find('span').should('have.attr', 'style', 'color: red');
+    });
+
     it("should contain a shadow DOM with dt's and dd's with inner html", () => {
         cy.mount(propertiesHtmlEnrichedTemplate);
 
@@ -213,5 +249,51 @@ describe('cypress-component - block components - vl-properties', () => {
         cy.mount(defaultPropertiesTemplate);
 
         cy.get('vl-properties').shadow().find('dl').should('have.css', 'padding-bottom', '20px');
+    });
+
+    describe('deprecated no-clone attribute', () => {
+        beforeEach(() => {
+            // private static enkel op compile-time; reset de "warn once"-vlag voor test-isolatie
+            (
+                VlPropertiesComponent as unknown as { noCloneDeprecationWarningShown: boolean }
+            ).noCloneDeprecationWarningShown = false;
+        });
+
+        it('should warn once that no-clone is deprecated when it is used', () => {
+            cy.spy(console, 'warn').as('warn');
+
+            cy.mount(html`
+                <vl-properties no-clone>
+                    <vl-property>Woonplaats</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                </vl-properties>
+            `);
+
+            cy.get('@warn').should('have.been.calledOnce');
+            cy.get('@warn').should(
+                'have.been.calledWith',
+                'Het no-clone attribuut van vl-properties is niet meer nodig en deprecated, het wordt verwijderd in v3'
+            );
+        });
+
+        it('should not warn when no-clone is not used', () => {
+            cy.spy(console, 'warn').as('warn');
+
+            cy.mount(defaultPropertiesTemplate);
+
+            cy.get('@warn').should('not.have.been.called');
+        });
+
+        it('should still render content when the deprecated no-clone attribute is used', () => {
+            cy.mount(html`
+                <vl-properties no-clone>
+                    <vl-property>Woonplaats</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                </vl-properties>
+            `);
+
+            cy.get('vl-properties').shadow().find('dt').should('contain.text', 'Woonplaats');
+            cy.get('vl-properties').shadow().find('dd').should('contain.text', 'Brussel');
+        });
     });
 });

--- a/libs/components/src/block/properties/vl-properties.component.ts
+++ b/libs/components/src/block/properties/vl-properties.component.ts
@@ -12,8 +12,13 @@ export class VlPropertiesComponent extends BaseLitElement {
     private aggregatedProps: Props = propertiesDefaults.props;
     private labelWidth: number = propertiesDefaults.labelWidth;
     private labelWidthSheet: CSSStyleSheet = new CSSStyleSheet();
+    /**
+     * @deprecated Wordt verwijderd in v3 - de component houdt tegenwoordig zijn shadow DOM
+     * automatisch synchroon na wijzigingen in de light DOM (tekst en attributen).
+     */
     private noClone: boolean = false;
     private mutationObserverList: MutationObserver[] = [];
+    private static noCloneDeprecationWarningShown = false;
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [vlResetStyles, vlLegacyStyles, propertiesStyles];
@@ -64,6 +69,13 @@ export class VlPropertiesComponent extends BaseLitElement {
         if (changedProperties.has('labelWidth') && this.labelWidth) {
             this.labelWidthSheet.replace(labelWidthPercentage(this.labelWidth).toString());
         }
+
+        if (changedProperties.has('noClone') && this.noClone && !VlPropertiesComponent.noCloneDeprecationWarningShown) {
+            console.warn(
+                `Het no-clone attribuut van ${this.localName} is niet meer nodig en deprecated, het wordt verwijderd in v3`,
+            );
+            VlPropertiesComponent.noCloneDeprecationWarningShown = true;
+        }
     }
 
     disconnectedCallback() {
@@ -95,7 +107,8 @@ export class VlPropertiesComponent extends BaseLitElement {
     }
 
     private buildInternalProperties() {
-        this.aggregatedProps = [...this.attributeProps, ...buildProperties([...this.children], !this.noClone)];
+        // de inhoud wordt altijd ge-cloned zodat de shadow DOM synchroon blijft met de light DOM
+        this.aggregatedProps = [...this.attributeProps, ...buildProperties([...this.children])];
     }
 
     private disconnectMutationObservers() {
@@ -104,29 +117,16 @@ export class VlPropertiesComponent extends BaseLitElement {
     }
 
     private observeLightPropertiesChange() {
-        // verwijder alle bestaande mutation observers
         this.disconnectMutationObservers();
-        // altijd de vl-properties zelf observeren
+        // ondersteuning voor alle mogelijke mutaties - om de shadow-dom in-sync te houden met de light-dom
         this.mutationObserverList = [
-            ...this.mutationObserverList,
-            onChildListChange(this, (change: any) => {
-                this.buildInternalProperties();
-                // er kan een extra div toegevoegd zijn, deze heeft dan ook een mutation observer nodig
-                this.observeLightPropertiesChange();
+            onChildListChange(this, () => this.buildInternalProperties(), {
+                childList: true,
+                subtree: true,
+                characterData: true,
+                attributes: true,
             }),
         ];
-        // als de directe kinderen div's zijn deze ook observeren
-        if (this.children.length > 0 && this.children[0].localName === 'div') {
-            [...this.children].forEach(
-                (element) =>
-                    (this.mutationObserverList = [
-                        ...this.mutationObserverList,
-                        onChildListChange(element, (change: any) => {
-                            this.buildInternalProperties();
-                        }),
-                    ])
-            );
-        }
     }
 }
 

--- a/libs/components/src/block/properties/vl-properties.defaults.ts
+++ b/libs/components/src/block/properties/vl-properties.defaults.ts
@@ -2,7 +2,6 @@ import { Props } from './vl-properties.model';
 
 export const propertiesDefaults = {
     labelWidth: 25,
-    noClone: false,
     props: [] as Props,
     noPaddingBottom: false,
 } as const;

--- a/libs/components/src/block/search-result/vl-search-result.component.cy.ts
+++ b/libs/components/src/block/search-result/vl-search-result.component.cy.ts
@@ -98,4 +98,66 @@ describe('cypress-component - block components - vl-search-result', () => {
             .first()
             .should('contain.text', 'Vlaanderenkiest.be');
     });
+
+    it('should update properties shadow DOM when a light DOM text node is mutated in-place', () => {
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-properties')
+            .shadow()
+            .find('dd')
+            .first()
+            .should('contain.text', 'Verkiezingsresultaten op Vlaanderenkiest.be...');
+
+        cy.get('vl-search-result').then(($searchResult) => {
+            const textNode = $searchResult[0].shadowRoot?.querySelector(
+                'vl-search-result-properties vl-property-data'
+            )?.firstChild;
+            textNode!.textContent = 'Bijgewerkte verkiezingsresultaten';
+        });
+
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-properties')
+            .shadow()
+            .find('dd')
+            .first()
+            .should('contain.text', 'Bijgewerkte verkiezingsresultaten');
+    });
+
+    it('should update properties shadow DOM when a light DOM attribute is mutated in-place', () => {
+        // het mount-command ruimt enkel op tussen tests, niet binnen een test: de container leegmaken zodat de
+        // eigen mount hieronder niet naast de beforeEach-mount terechtkomt
+        cy.document().then((doc) => (doc.querySelector('[data-cy-root]')!.innerHTML = ''));
+        cy.mount(html`
+            <vl-search-result>
+                <vl-search-result-properties>
+                    <vl-property>Vlaanderenkiest.be</vl-property>
+                    <vl-property-data><span style="color: blue">Verkiezingsresultaten</span></vl-property-data>
+                </vl-search-result-properties>
+            </vl-search-result>
+        `);
+
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-properties')
+            .shadow()
+            .find('dd')
+            .first()
+            .find('span')
+            .should('have.attr', 'style', 'color: blue');
+
+        cy.get('vl-search-result').then(($searchResult) => {
+            const span = $searchResult[0].shadowRoot?.querySelector('vl-search-result-properties vl-property-data span');
+            span!.setAttribute('style', 'color: red');
+        });
+
+        cy.get('vl-search-result')
+            .shadow()
+            .find('vl-search-result-properties')
+            .shadow()
+            .find('dd')
+            .first()
+            .find('span')
+            .should('have.attr', 'style', 'color: red');
+    });
 });


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-660
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC387

## Samenvatting
`vl-properties` en de ervende `vl-search-result-properties` houden hun shadow DOM nu synchroon met de light DOM, óók wanneer de data na het renderen in-place wijzigt. Daardoor is de `no-clone`-workaround niet langer nodig en wordt het attribuut gedeprecate.

## Wijzigingen
- `vl-properties` detecteert nu álle in-place mutaties in de light DOM (toegevoegde/verwijderde nodes, tekstwijzigingen én attribuutwijzigingen op bestaande nodes) en herbouwt de shadow-render mee. Consumers hoeven `no-clone`/`keyed` niet langer toe te passen.
- `vl-search-result-properties` is via overerving meteen mee opgelost.
- De observer-logica in `vl-properties` is vereenvoudigd tot één observer over de volledige subtree (`childList + subtree + characterData + attributes`), wat dubbele her-builds voorkomt.
- De gedeelde `onChildListChange`-util is additief uitgebreid: een optionele observatie-scope, plus het triggeren van de callback voor `characterData`- en `attributes`-mutaties (die geen added/removed nodes dragen). Bestaande callers blijven ongewijzigd.
- `no-clone` is **deprecated** en wordt verwijderd in v3: `@deprecated` JSDoc, een eenmalige console-waarschuwing bij gebruik.
- Tests toegevoegd: Cypress voor in-place tekst- én attribuutmutatie (los én genest in `vl-search-result`) en voor de deprecation-waarschuwing; Jest voor de uitgebreide `onChildListChange`-util.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. `no-clone` gedeprecate - doet niets meer.

## Succescriteria
- [x] Shadow DOM toont dezelfde waarde als de light DOM bij in-place tekst- én attribuutmutatie — observer met `subtree + characterData + attributes` triggert een rebuild.
- [x] Consumers hebben geen `no-clone`/`keyed`-workaround meer nodig — fix zit in de basiscomponent.
- [x] Default clone-gedrag (light DOM blijft intact) behouden — rebuild raakt enkel de shadow-render, niet de light DOM.
- [x] `no-clone` gedeprecate met console-waarschuwing en docs - doet functioneel niets meer in v2.
- [x] Cypress component-test dekt tekst- en attribuutmutatie binnen `<data><span>…</span></data>` → shadow DOM bijgewerkt (los én genest in `vl-search-result`).
