### PR TITLE
fix: FLUX-172 - vl-rich-data-table - streepje (indeterminate) in selectie-header terug zichtbaar

### DIFF
--- a/libs/components/src/block/rich-data-table/stories/vl-rich-data-table-selectable.stories-util.ts
+++ b/libs/components/src/block/rich-data-table/stories/vl-rich-data-table-selectable.stories-util.ts
@@ -27,6 +27,15 @@ export const selectableRichTableImplementation = (): SelectableRichTableImplemen
         return (getTable()?.data.data || []) as MyData;
     };
 
+    const syncHeaderCheckbox = (): void => {
+        const tableData = getTableData();
+        const allSelected = tableData.length > 0 && tableData.every((item) => item.selected);
+        const noneSelected = tableData.every((item) => !item.selected);
+
+        headerCheckbox.toggleAttribute('indeterminate', !allSelected && !noneSelected);
+        headerCheckbox.toggleAttribute('checked', allSelected);
+    };
+
     const applySelectionToAllRows = (selected: boolean): void => {
         headerCheckbox.removeAttribute('indeterminate');
         const table = getTable();
@@ -81,18 +90,7 @@ export const selectableRichTableImplementation = (): SelectableRichTableImplemen
             const rowData = tableData.find(({ name }) => name === rowName);
             if (rowData) rowData.selected = checked;
 
-            if (tableData.every((item) => item.selected)) {
-                headerCheckbox.setAttribute('checked', '');
-                getHeaderCheckboxInput().indeterminate = false;
-                return;
-            }
-            if (tableData.every((item) => !item.selected)) {
-                headerCheckbox.removeAttribute('checked');
-                getHeaderCheckboxInput().indeterminate = false;
-                return;
-            }
-
-            getHeaderCheckboxInput().indeterminate = true;
+            syncHeaderCheckbox();
         });
         td.appendChild(checkbox);
     };
@@ -106,7 +104,8 @@ export const selectableRichTableImplementation = (): SelectableRichTableImplemen
         td.appendChild(headerLabel);
         td.appendChild(headerCheckbox);
         requestAnimationFrame(() => {
-            headerCheckbox.addEventListener('vl-change', handleSelectAllToggle);
+            headerCheckbox.addEventListener('vl-input', handleSelectAllToggle);
+            syncHeaderCheckbox();
         });
         return td;
     };

--- a/libs/components/src/block/rich-data-table/vl-rich-data-table.component.cy.ts
+++ b/libs/components/src/block/rich-data-table/vl-rich-data-table.component.cy.ts
@@ -581,15 +581,25 @@ describe('cypress-component - block components - vl-rich-data-table - selectable
             checkActions();
         };
 
+        const syncHeaderCheckbox = () => {
+            const tableData = getTableData();
+            const allSelected = tableData.length > 0 && tableData.every((item: any) => item.selected);
+            const noneSelected = tableData.every((item: any) => !item.selected);
+
+            headerCheckbox.toggleAttribute('indeterminate', !allSelected && !noneSelected);
+            headerCheckbox.toggleAttribute('checked', allSelected);
+        };
+
         const headerTemplate = () => {
             headerCheckbox = document.createElement('vl-checkbox') as any;
             headerCheckbox.setAttribute('label', 'Selecteer alles');
             const td = document.createElement('td');
             td.appendChild(headerCheckbox);
             requestAnimationFrame(() => {
-                headerCheckbox.addEventListener('vl-change', (e: any) => {
+                headerCheckbox.addEventListener('vl-input', (e: any) => {
                     applySelectionToAllRows(e.detail.checked);
                 });
+                syncHeaderCheckbox();
             });
             return td;
         };
@@ -603,22 +613,7 @@ describe('cypress-component - block components - vl-rich-data-table - selectable
                 const rowData = tableData.find(({ name }: any) => name === rowName);
                 if (rowData) rowData.selected = e.detail.checked;
 
-                const allSelected = tableData.every((item: any) => item.selected);
-                const noneSelected = tableData.every((item: any) => !item.selected);
-                if (headerCheckbox?.shadowRoot) {
-                    const headerInput = headerCheckbox.shadowRoot.querySelector('input');
-                    if (headerInput) {
-                        if (allSelected) {
-                            headerCheckbox.setAttribute('checked', '');
-                            headerInput.indeterminate = false;
-                        } else if (noneSelected) {
-                            headerCheckbox.removeAttribute('checked');
-                            headerInput.indeterminate = false;
-                        } else {
-                            headerInput.indeterminate = true;
-                        }
-                    }
-                }
+                syncHeaderCheckbox();
                 checkActions();
             });
             td.appendChild(checkbox);


### PR DESCRIPTION
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC388

## Wat

De "selecteer alles"-checkbox bovenaan de selecteerbare `vl-rich-data-table` toont opnieuw een streepje (indeterminate) wanneer slechts een deel van de rijen geselecteerd is.

## Waarom

De selectable-voorbeeldcode zette `indeterminate` rechtstreeks op de interne `<input>` in de shadow-DOM van `vl-checkbox`. Dat werkte enkel zolang het streepje via de CSS `:indeterminate`-pseudoklasse op die input getekend werd. Sinds FLUX-172 (iconen via glyph-naam) wordt het streepje gerenderd via het publieke `indeterminate`-attribuut van `vl-checkbox`, waardoor het manipuleren van de interne input geen effect meer had.

## Hoe

- De header-state (alles / deels / niets geselecteerd) wordt nu gestuurd via het publieke `indeterminate`- en `checked`-attribuut op `vl-checkbox`, niet meer via shadow-DOM-internals.
- De "selecteer alles"-handler luistert op `vl-input` in plaats van `vl-change`. `vl-input` vuurt enkel bij echte gebruikersinteractie, zodat het programmatisch bijwerken van de header-state niet langer alle rijen mee toggelt.
- Dezelfde aanpak is doorgetrokken in de Cypress-test zodat voorbeeld en test gelijk lopen en op de publieke component-API steunen.

## Test

Alle 26 component-tests in `vl-rich-data-table.component.cy.ts` slagen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)