### PR TITLE
fix: FLUX-666 - vl-search-filter, vl-rich-data, vl-rich-data-table - footer-knoppen layout verbetering

### DIFF
--- a/libs/components/src/block/rich-data-table/stories/vl-rich-data-table.stories.ts
+++ b/libs/components/src/block/rich-data-table/stories/vl-rich-data-table.stories.ts
@@ -193,8 +193,10 @@ const TemplateFilter = story(
                             </div>
                         </section>
                         <footer>
-                            <vl-button type="submit" custom-css="button {flex:1}">Zoeken</vl-button>
-                            <vl-button type="reset" custom-css="button {flex:1}" secondary>Reset</vl-button>
+                            <div class="vl-group vl-group--wrap">
+                                <vl-button type="submit">Zoeken</vl-button>
+                                <vl-button type="reset" secondary>Reset</vl-button>
+                            </div>
                         </footer>
                     </form>
                 </vl-search-filter>
@@ -280,8 +282,10 @@ const TemplateFilterPaging = story(
                             </div>
                         </section>
                         <footer>
-                            <vl-button type="submit" custom-css="button {flex:1}">Zoeken</vl-button>
-                            <vl-button type="reset" custom-css="button {flex:1}" secondary>Reset</vl-button>
+                            <div class="vl-group vl-group--wrap">
+                                <vl-button type="submit">Zoeken</vl-button>
+                                <vl-button type="reset" secondary>Reset</vl-button>
+                            </div>
                         </footer>
                     </form>
                 </vl-search-filter>

--- a/libs/components/src/block/rich-data/stories/vl-rich-data.stories.ts
+++ b/libs/components/src/block/rich-data/stories/vl-rich-data.stories.ts
@@ -74,8 +74,10 @@ const pagerTemplate = ({filterClosable, filterClosed, filterMaxWidth}: typeof ri
                         </div>
                     </section>
                     <footer>
-                        <vl-button type="submit" custom-css="button {flex:1}">Zoeken</vl-button>
-                        <vl-button type="reset" custom-css="button {flex:1}" secondary>Reset</vl-button>
+                        <div class="vl-group vl-group--wrap">
+                            <vl-button type="submit">Zoeken</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
                     </footer>
                 </form>
             </vl-search-filter>

--- a/libs/components/src/block/search-filter/stories/vl-search-filter.stories.ts
+++ b/libs/components/src/block/search-filter/stories/vl-search-filter.stories.ts
@@ -109,8 +109,10 @@ const searchFilterTemplate = story(
                     </section>
                 </div>
                 <footer>
-                    <vl-button type="submit">Zoeken</vl-button>
-                    <vl-button type="reset" secondary>Reset</vl-button>
+                    <div class="vl-group vl-group--wrap">
+                        <vl-button type="submit">Zoeken</vl-button>
+                        <vl-button type="reset" secondary>Reset</vl-button>
+                    </div>
                 </footer>
             </form>
         </vl-search-filter>


### PR DESCRIPTION
footer-knoppen in vl-group--wrap zodat ze niet langer tegen elkaar plakken

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-666
