### PR TITLE
fix: FLUX-661 - vl-side-sheet, vl-tab-panel-next - focus-outline enkel bij toetsenbordnavigatie

### DIFF
--- a/libs/components/src/block/next/tabs/vl-tab-panel.flux-css.ts
+++ b/libs/components/src/block/next/tabs/vl-tab-panel.flux-css.ts
@@ -11,7 +11,7 @@ export const vlTabPanelFluxStyles: CSSResult = css`
         display: none;
     }
 
-    :host(:focus) {
+    :host(:focus-visible) {
         ${vlFocusOutlineMixin()};
     }
 `;

--- a/libs/components/src/block/side-sheet/vl-side-sheet.flux-css.ts
+++ b/libs/components/src/block/side-sheet/vl-side-sheet.flux-css.ts
@@ -20,7 +20,7 @@ export const vlSideSheetFluxStyles: CSSResult = css`
         background: white;
         overflow-y: auto;
 
-        &:focus {
+        &:focus-visible {
             ${vlFocusOutlineMixin()};
             outline-offset: -3px;
         }


### PR DESCRIPTION
Getest met de code van Sander die in de zip aan het ticket hangt. Deze fix lost het gemelde probleem inderdaad op.

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-661
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC391


## Samenvatting
De blauwe focus-outline rond een `vl-side-sheet` en een `vl-tab-panel-next` verschijnt niet langer wanneer die via klik of programmatisch geopend/geactiveerd wordt. Toetsenbord-gebruikers zien nog steeds een zichtbare focus-indicator. Het gedrag komt opnieuw overeen met Flux v1.

## Wijzigingen
- `vl-tab-panel-next`: outline-styling verschoven van `:focus` naar `:focus-visible`, zodat de rand enkel bij toetsenbordnavigatie verschijnt.
- `vl-side-sheet`: outline-styling op de container verschoven van `:focus` naar `:focus-visible`; de box-shadow-regels blijven ongewijzigd.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Geen blauwe outline rond `#vl-side-sheet` bij klik/programmatisch openen — outline staat nu op `:focus-visible`.
- [x] Geen blauwe outline rond `vl-tab-panel-next` bij klik/programmatische tab-activatie — outline staat nu op `:focus-visible`.
- [x] Toetsenbord-gebruiker behoudt een zichtbare focus-indicator op panel en side-sheet — `:focus-visible` matcht bij keyboard-navigatie (WCAG 2.4.7 behouden).
- [x] Gedrag komt overeen met Flux v1 — geen permanente container-outline na openen.
