### PR TITLE
feat: FLUX-657 - vl-header - banner landmark herkenbaar voor screenreaders

### DIFF
--- a/libs/components/src/block/cascader/stories/vl-cascader.stories-doc.mdx
+++ b/libs/components/src/block/cascader/stories/vl-cascader.stories-doc.mdx
@@ -166,6 +166,17 @@ Om dit op te lossen, dien je Custom CSS toe te voegen (die dan wel zal werken op
 de cascader). [Hier vind je meer uitleg over Custom CSS toevoegen](/docs/recepten-css-styling--documentatie#custom-css)
 
 
+## Toegankelijkheid
+
+<FluxAlert type="info">
+{`
+    Plaats deze component binnen een \`<main>\`, \`<section>\`, \`<article>\` of \`<aside>\`, zodat
+    de interne \`<header>\` geen impliciete banner-role krijgt. De banner-role is voorbehouden voor
+    de globale \`<vl-header>\` en moet uniek zijn per pagina.
+`}
+</FluxAlert>
+
+
 ## Referenties
 
 ### Digitaal Vlaanderen

--- a/libs/components/src/block/content-header/stories/vl-content-header.stories-doc.mdx
+++ b/libs/components/src/block/content-header/stories/vl-content-header.stories-doc.mdx
@@ -30,6 +30,17 @@ import { VlContentHeaderComponent } from '@domg-wc/components/block';
 <ArgTypes of={VlContentHeaderStories.ContentHeaderDefault} />
 
 
+## Toegankelijkheid
+
+<FluxAlert type="info">
+{`
+    Plaats deze component binnen een \`<main>\`, \`<section>\`, \`<article>\` of \`<aside>\`, zodat
+    de interne \`<header>\` geen impliciete banner-role krijgt. De banner-role is voorbehouden voor
+    de globale \`<vl-header>\` en moet uniek zijn per pagina.
+`}
+</FluxAlert>
+
+
 ## Referenties
 
 ### Digitaal Vlaanderen

--- a/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
+++ b/libs/components/src/block/functional-header/stories/vl-functional-header.stories-doc.mdx
@@ -121,6 +121,14 @@ bij focus.
 
 Meer info vind je in de [documentatie over toegankelijke navigatie: "Blokken omzeilen"](/docs/richtlijnen-toegankelijkheid-aanpak-2-bedienbaar-2-4-navigeerbaar--documentatie#blokken-omzeilen).
 
+<FluxAlert type="info">
+{`
+    Plaats deze component binnen een \`<main>\`, \`<section>\`, \`<article>\` of \`<aside>\`, zodat
+    de interne \`<header>\` geen impliciete banner-role krijgt. De banner-role is voorbehouden voor
+    de globale \`<vl-header>\` en moet uniek zijn per pagina.
+`}
+</FluxAlert>
+
 
 ## Referenties
 

--- a/libs/components/src/block/wizard/stories/vl-wizard.stories-doc.mdx
+++ b/libs/components/src/block/wizard/stories/vl-wizard.stories-doc.mdx
@@ -32,3 +32,4 @@ import { VlWizard } from '@domg-wc/components/block';
 ## Configuratie
 
 <ArgTypes of={VlWizardStories.WizardDefault} />
+

--- a/libs/components/src/compliance/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/header/vl-header.component.cy.ts
@@ -30,6 +30,11 @@ describe('cypress-component - compliance components - vl-header', () => {
         cy.get('#header__container').should('have.css', 'min-height', '43px');
     });
 
+    it('should wrap the global header in a <header> element so screenreaders pick it up as banner landmark', () => {
+        cy.get('#header__container').should('have.prop', 'tagName', 'HEADER');
+        cy.get('header[id="header__container"]').should('have.length', 1);
+    });
+
     it('should dispatch ready event when ready', () => {
         // Mogelijke flaky test aangezien het event afgevuurd kan worden vooraleer de eventListener is toegevoegd.
         cy.createStubForEvent('vl-header', 'ready');

--- a/libs/components/src/compliance/header/vl-header.component.ts
+++ b/libs/components/src/compliance/header/vl-header.component.ts
@@ -152,7 +152,7 @@ export class VlHeader extends BaseLitElement {
     private injectHeaderContainer() {
         (document.querySelector('body') || document.body).insertAdjacentHTML(
             'afterbegin',
-            '<div id="header__container"><div id="header"></div></div>'
+            '<header id="header__container"><div id="header"></div></header>'
         );
         document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerContainerStyles.styleSheet!];
     }

--- a/libs/components/src/compliance/next/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.cy.ts
@@ -41,6 +41,11 @@ describe('cypress-component - compliance components - vl-header-next', () => {
         it('should render with fixed height', () => {
             cy.get('#header__container').should('have.css', 'min-height', '43px');
         });
+
+        it('should wrap the global header in a <header> element so screenreaders pick it up as banner landmark', () => {
+            cy.get('#header__container').should('have.prop', 'tagName', 'HEADER');
+            cy.get('header[id="header__container"]').should('have.length', 1);
+        });
     });
 
     describe('ready event', () => {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-657
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC392

`vl-header` injecteerde `<div id="header__container">` als wrapper, en de burgerprofiel-widget rendert intern `<header role="presentation">`. Resultaat: **geen enkel `banner` landmark** in de DOM.

Screenreaders gebruiken landmarks om snel te navigeren ("ga naar banner / main / nav / footer"). Geen banner = de globale Vlaanderen-header werd genegeerd in landmark-navigatie. Toepassingen zoals voortoets en pasberekening sloegen daarin de bocht.

WCAG 2.1 success criterion 1.3.1 (Info & Relationships) en 2.4.1 (Bypass Blocks) verwachten dat de globale site-header als banner herkenbaar is, daarom moest het opgelost worden.

Bonus reden: `vl-content-header` (en andere shadow-DOM headers) werden door browsers wél als banner gezien → conflict-risico met meerdere banners op één pagina zodra de globale ook correct geannoteerd zou worden. Vandaar de docs op de sibling-componenten.