### PR TITLE
fix: FLUX-657 - consumer-fat-lib - vl-accessibility in main wrappen tegen dubbele banner landmark

### DIFF
--- a/apps/consumer/src/app-fat-lib/html/compliance.html.js
+++ b/apps/consumer/src/app-fat-lib/html/compliance.html.js
@@ -1,6 +1,8 @@
 export const complianceHtml = (importType, packageName) => `
     <vl-header development simple identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"></vl-header>
     <vl-footer development identifier="0337f8dc-3266-4e7a-8f4a-95fd65189e5b"></vl-footer>
-    <vl-title type="h2">vl-accessibility - ${importType} - ${packageName}</vl-title>
-    <vl-accessibility></vl-accessibility>
+    <main>
+        <vl-title type="h2">vl-accessibility - ${importType} - ${packageName}</vl-title>
+        <vl-accessibility></vl-accessibility>
+    </main>
 `;


### PR DESCRIPTION
De globale vl-header rendert sinds FLUX-657 een banner landmark. De functional-header binnen vl-accessibility deed dat ook, waardoor de toegankelijkheids-pagina twee banners had. Door vl-accessibility in een <main> te plaatsen verliest de interne <header> zijn impliciete banner-role en blijft vl-header de enige banner.