### PR TITLE
feat: FLUX-658 - vl-composite-input-next - form-control voor samengestelde velden

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -13,6 +13,7 @@ import { VlDatepickerComponent } from '@domg-wc/components/form';
 import { VlFormCrossValidationComponent } from '@domg-wc/integrations/form';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import './composite-input-showcase.component';
 
 @customElement('app-component')
 export class AppComponent extends LitElement {
@@ -41,6 +42,7 @@ export class AppComponent extends LitElement {
                     identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
                 ></vl-header>
                 <main slot="main">
+                    <composite-input-showcase></composite-input-showcase>
                     <section class="vl-section">
                         <div class="vl-content-block vl-content-block--full-width">
                             <vl-title type="h2">Cross-validatie voorbeeld</vl-title>

--- a/apps/playground-lit/src/app/composite-input-showcase.component.ts
+++ b/apps/playground-lit/src/app/composite-input-showcase.component.ts
@@ -1,0 +1,184 @@
+import { registerWebComponents } from '@domg-wc/common';
+import {
+    VlFormMessageComponent,
+    VlInputFieldComponent,
+} from '@domg-wc/components/form';
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+const BELGIUM_LON = [2.5, 6.5] as const;
+const BELGIUM_LAT = [49.5, 51.6] as const;
+
+const inBelgium = ({ 'geo-lon': lon, 'geo-lat': lat }: CompositeValues): string | null => {
+    const longitude = parseFloat(lon);
+    const latitude = parseFloat(lat);
+    if (
+        longitude < BELGIUM_LON[0] ||
+        longitude > BELGIUM_LON[1] ||
+        latitude < BELGIUM_LAT[0] ||
+        latitude > BELGIUM_LAT[1]
+    ) {
+        return `(lon=${lon}, lat=${lat}) ligt buiten België`;
+    }
+    return null;
+};
+
+@customElement('composite-input-showcase')
+export class CompositeInputShowcase extends LitElement {
+    static {
+        registerWebComponents([VlCompositeInputComponent, VlInputFieldComponent, VlFormMessageComponent]);
+    }
+
+    @state() private submittedA: Record<string, FormDataEntryValue> | null = null;
+    @state() private submittedB: Record<string, FormDataEntryValue> | null = null;
+
+    protected createRenderRoot() {
+        return this;
+    }
+
+    private onSubmit = (which: 'A' | 'B') => (event: SubmitEvent) => {
+        event.preventDefault();
+        const form = event.target as HTMLFormElement;
+        const data: Record<string, FormDataEntryValue> = {};
+        new FormData(form).forEach((v, k) => (data[k] = v));
+        if (which === 'A') this.submittedA = data;
+        else this.submittedB = data;
+    };
+
+    private onReset = (which: 'A' | 'B') => () => {
+        if (which === 'A') this.submittedA = null;
+        else this.submittedB = null;
+    };
+
+    private renderEcho(data: Record<string, FormDataEntryValue> | null) {
+        if (!data) return '';
+        return html`<pre style="margin-top:1rem;background:#f3f5f6;padding:.75rem;">
+${JSON.stringify(data, null, 2)}</pre
+        >`;
+    }
+
+    render() {
+        return html`
+            <div style="padding: 2rem; display:flex; flex-direction:column; gap:2rem;">
+                <h1 class="vl-h1">Samengesteld invoerveld (vl-composite-input-next)</h1>
+                <section aria-labelledby="showcase-a-title">
+                    <h2 id="showcase-a-title" class="vl-h2">vl-composite-input-next: kind-name = sleutel (0-100)</h2>
+                    <p>
+                        De kinderen dienen zichzelf in via hun <code>name</code> (<code>coords-x</code> +
+                        <code>coords-y</code>); de composite bezit geen waarde, ze valideert cross-veld en bewaakt
+                        <code>required</code> over alle velden. Elk kind draagt een <code>name</code> (FormData- én
+                        validator-sleutel) plus zijn eigen <code>min</code>/<code>max</code>; het <code>id</code> dient
+                        enkel als <code>vl-form-message[for]</code>-doelwit. De composite heeft geen <code>name</code>,
+                        enkel een <code>id</code>.
+                    </p>
+
+                    <form
+                        @submit=${this.onSubmit('A')}
+                        @reset=${this.onReset('A')}
+                        style="padding:1.5rem;border:1px solid #cbd2da;border-radius:4px;display:flex;flex-direction:column;gap:.75rem;"
+                    >
+                        <vl-input-field id="label-a" name="label" label="Label" required></vl-input-field>
+                        <vl-form-message for="label-a" state="valueMissing">
+                            Label is verplicht.
+                        </vl-form-message>
+
+                        <vl-composite-input-next id="coords" label="Coördinaten" required>
+                            <vl-input-field id="x" name="coords-x" label="X" type="number" min="0" max="100"></vl-input-field>
+                            <vl-input-field id="y" name="coords-y" label="Y" type="number" min="0" max="100"></vl-input-field>
+                        </vl-composite-input-next>
+
+                        <vl-form-message for="coords" state="valueMissing">
+                            Beide velden zijn verplicht.
+                        </vl-form-message>
+                        <vl-form-message for="x" state="rangeUnderflow">X moet minstens 0 zijn.</vl-form-message>
+                        <vl-form-message for="x" state="rangeOverflow">X mag maximaal 100 zijn.</vl-form-message>
+                        <vl-form-message for="y" state="rangeUnderflow">Y moet minstens 0 zijn.</vl-form-message>
+                        <vl-form-message for="y" state="rangeOverflow">Y mag maximaal 100 zijn.</vl-form-message>
+
+                        <div style="margin-top: 1rem; display:flex; gap:.5rem;">
+                            <button type="submit" class="vl-button">Verstuur</button>
+                            <button type="reset" class="vl-button vl-button--secondary">Reset</button>
+                        </div>
+                    </form>
+                    ${this.renderEcho(this.submittedA)}
+                </section>
+
+                <section aria-labelledby="showcase-b-title">
+                    <h2 id="showcase-b-title" class="vl-h2">vl-composite-input-next: custom validator (België)</h2>
+                    <p>
+                        Zelfde composite; de kinderen dienen zichzelf in als <code>geo-lon</code> + <code>geo-lat</code>
+                        (via hun <code>name</code>). De <code>.customValidator</code> op de composite leest de waarden
+                        per <code>name</code> (<code>geo-lon</code>, <code>geo-lat</code>) en geeft een dynamische
+                        foutboodschap wanneer het punt buiten België valt. Probeer <code>lon=4.35, lat=50.85</code>
+                        (Brussel): geldig. Daarna <code>lon=7.5, lat=48</code>.
+                    </p>
+
+                    <form
+                        @submit=${this.onSubmit('B')}
+                        @reset=${this.onReset('B')}
+                        style="padding:1.5rem;border:1px solid #cbd2da;border-radius:4px;display:flex;flex-direction:column;gap:.75rem;"
+                    >
+                        <vl-input-field id="label-b" name="place-name" label="Plaatsnaam" required></vl-input-field>
+                        <vl-form-message for="label-b" state="valueMissing">
+                            Plaatsnaam is verplicht.
+                        </vl-form-message>
+
+                        <vl-composite-input-next
+                            id="geo"
+                            label="Coördinaten (lon, lat)"
+                            required
+                            .customValidator=${inBelgium}
+                        >
+                            <vl-input-field
+                                id="lon"
+                                name="geo-lon"
+                                label="Longitude"
+                                type="number"
+                                min="-180"
+                                max="180"
+                            ></vl-input-field>
+                            <vl-input-field
+                                id="lat"
+                                name="geo-lat"
+                                label="Latitude"
+                                type="number"
+                                min="-90"
+                                max="90"
+                            ></vl-input-field>
+                        </vl-composite-input-next>
+
+                        <vl-form-message for="geo" state="valueMissing">
+                            Zowel longitude als latitude zijn verplicht.
+                        </vl-form-message>
+                        <vl-form-message for="geo" state="customError"></vl-form-message>
+                        <vl-form-message for="lon" state="rangeUnderflow"
+                            >Longitude moet minstens -180 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lon" state="rangeOverflow"
+                            >Longitude mag maximaal 180 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lat" state="rangeUnderflow"
+                            >Latitude moet minstens -90 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lat" state="rangeOverflow"
+                            >Latitude mag maximaal 90 zijn.</vl-form-message
+                        >
+
+                        <div style="margin-top: 1rem; display:flex; gap:.5rem;">
+                            <button type="submit" class="vl-button">Verstuur</button>
+                            <button type="reset" class="vl-button vl-button--secondary">Reset</button>
+                        </div>
+                    </form>
+                    ${this.renderEcho(this.submittedB)}
+                </section>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'composite-input-showcase': CompositeInputShowcase;
+    }
+}

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -155,6 +155,10 @@ const config: StorybookConfig = {
                 __dirname,
                 '../../../libs/components/src/compliance/index.ts',
             ),
+            '@domg-wc/components/form/next': path.resolve(
+                __dirname,
+                '../../../libs/components/src/form/next/index.ts',
+            ),
             '@domg-wc/components/form': path.resolve(__dirname, '../../../libs/components/src/form/index.ts'),
             '@domg-wc/integrations/form': path.resolve(__dirname, '../../../libs/integrations/src/form/index.ts'),
             '@domg-wc/integrations/map': path.resolve(__dirname, '../../../libs/integrations/src/map/index.ts'),

--- a/apps/storybook/docs/f_patronen/formulier/6_samengesteld-veld/formulier-samengesteld-veld.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/6_samengesteld-veld/formulier-samengesteld-veld.mdx
@@ -1,0 +1,121 @@
+import { Canvas, Meta, Source } from '@storybook/addon-docs/blocks';
+import * as formSamengesteldVeldStories from './formulier-samengesteld-veld.stories';
+import formSamengesteldVeldSource from '../../../../../../libs/integrations/src/form/composite-input/vl-form-composite-input.component.ts?raw';
+import formSamengesteldVeldEenheidSource from '../../../../../../libs/integrations/src/form/composite-input/vl-form-composite-input-eenheid.component.ts?raw';
+import formSamengesteldVeldDatumbereikSource from '../../../../../../libs/integrations/src/form/composite-input/vl-form-composite-input-datumbereik.component.ts?raw';
+import formSamengesteldVeldContactSource from '../../../../../../libs/integrations/src/form/composite-input/vl-form-composite-input-contact.component.ts?raw';
+
+<Meta of={formSamengesteldVeldStories} />
+
+# Formulier - Samengesteld veld
+
+> Bouwt verder op [Formulier - Validatie](/docs/patronen-formulier-validatie--documentatie),
+> [Formulier - Aangepaste Validatie](/docs/patronen-formulier-aangepaste-validatie--documentatie) en
+> [Formulier - Form Data](/docs/patronen-formulier-form-data--documentatie). De betekenis van de
+> validiteitsstaten en het koppelen van een `vl-form-message` staan daar beschreven; hier komt enkel
+> het samenstellen van meerdere velden tot één control aan bod.
+
+Soms vormen twee of meer velden **samen** één logische waarde: een coördinaat, een bedrag met
+munteenheid, een van/tot-bereik. Dan wil je dat ze samen als **één control** valideren: één
+gezamenlijke geldigheid en één foutboodschap per staat, terwijl elk veld wél zijn eigen waarde in
+het formulier indient.
+
+`vl-composite-input-next` is een **form-associated control uit de bibliotheek** (`@domg-wc/components/form/next`, via
+`ElementInternals`): hij leest zijn kinderen, controleert ze samen en toont de foutmelding voor het samengestelde veld.
+
+## Gebruik
+
+```js
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+```
+
+Je registreert de component zoals elke andere en plaatst je eigen form-controls, elk met een `name`, als kinderen. De
+regel die over de velden samen gaat, schrijf je zelf in de `customValidator`.
+
+Alle attributen, properties en events staan op de componentpagina
+[Form Composite Input](/docs/components-form-next-composite-input--documentatie).
+
+## Patroon
+
+- **N velden**: het patroon is niet beperkt tot twee. Elk bijkomend form-control met een eigen `name` doet automatisch
+  mee.
+- **Doorgeven**: `disabled` en `success` geeft de composite door aan haar kinderen. `error` niet: daarmee zet je de
+  composite zelf op ongeldig.
+- **`required`**: op de composite betekent het dat álle velden ingevuld moeten zijn, met één melding voor het
+  samengestelde veld. Wil je één veld apart verplicht maken, zet `required` dan op dat kind; dat veld toont dan zijn
+  eigen melding.
+
+In het voorbeeld hieronder vormen twee `vl-input-field` velden (longitude + latitude) één `required` control. Elk veld
+draagt zijn eigen `min`/`max`, en een eigen validator controleert of het punt binnen België ligt. Probeer
+`lon=4.35, lat=50.85` (Brussel, geldig), daarna `lon=7.5, lat=48` (buiten België).
+
+<Canvas of={formSamengesteldVeldStories.FormulierSamengesteldVeld} sourceState="none" />
+
+De kern, zonder de demo-omkadering:
+
+```html
+<!-- Elke melding wordt binnen de form opgezocht: composite, velden en meldingen moeten in dezelfde <form> staan,
+     anders verschijnt er niets. De validatie loopt bij het versturen. -->
+<form>
+    <vl-composite-input-next id="coordinaten" label="Coördinaten (lon, lat)" required>
+        <!-- name = sleutel in de FormData en in de validator; id = waar een vl-form-message naar verwijst -->
+        <vl-input-field id="lon" name="coordinaten-lon" label="Longitude" type="number" min="-180" max="180"></vl-input-field>
+        <vl-input-field id="lat" name="coordinaten-lat" label="Latitude" type="number" min="-90" max="90"></vl-input-field>
+    </vl-composite-input-next>
+
+    <!-- meldingen voor het samengestelde veld, op de composite; leeg gelaten = de composite vult de tekst zelf in -->
+    <vl-form-message for="coordinaten" state="valueMissing"></vl-form-message>
+    <vl-form-message for="coordinaten" state="customError"></vl-form-message>
+
+    <!-- melding per veld, op het kind, met eigen tekst per staat -->
+    <vl-form-message for="lon" state="rangeUnderflow">Longitude moet minstens -180 zijn.</vl-form-message>
+    <vl-form-message for="lon" state="rangeOverflow">Longitude mag maximaal 180 zijn.</vl-form-message>
+    <vl-form-message for="lat" state="rangeUnderflow">Latitude moet minstens -90 zijn.</vl-form-message>
+    <vl-form-message for="lat" state="rangeOverflow">Latitude mag maximaal 90 zijn.</vl-form-message>
+
+    <button type="submit">Verstuur</button>
+</form>
+```
+
+Dit levert de FormData-sleutels `coordinaten-lon` en `coordinaten-lat` op.
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formSamengesteldVeldSource} language="ts" dark={true} />
+</details>
+
+## Andere voorbeelden
+
+De `customValidator` krijgt de waarden als tekst, dus je zet ze zelf om naar wat je nodig hebt. Zo werkt dit met elk
+veld dat een `value` heeft.
+
+### Getal + eenheid (`vl-input-field` + `vl-select`)
+
+<Canvas of={formSamengesteldVeldStories.FormulierSamengesteldVeldEenheid} sourceState="none" />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formSamengesteldVeldEenheidSource} language="ts" dark={true} />
+</details>
+
+### Datumbereik (twee `vl-datepicker`)
+
+<Canvas of={formSamengesteldVeldStories.FormulierSamengesteldVeldDatumbereik} sourceState="none" />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formSamengesteldVeldDatumbereikSource} language="ts" dark={true} />
+</details>
+
+### Contactmethode (`vl-select` + `vl-input-field`)
+
+<Canvas of={formSamengesteldVeldStories.FormulierSamengesteldVeldContact} sourceState="none" />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formSamengesteldVeldContactSource} language="ts" dark={true} />
+</details>
+
+## Toegankelijkheid
+
+- Zet een `label` op de composite én op elk kind, zodat schermlezers elk veld kunnen benoemen.

--- a/apps/storybook/docs/f_patronen/formulier/6_samengesteld-veld/formulier-samengesteld-veld.stories.ts
+++ b/apps/storybook/docs/f_patronen/formulier/6_samengesteld-veld/formulier-samengesteld-veld.stories.ts
@@ -1,0 +1,35 @@
+import { html } from 'lit';
+import { Meta, StoryFn } from '@storybook/web-components-vite';
+import { registerWebComponents } from '@domg-wc/common';
+import {
+    VlFormCompositeInputComponent,
+    VlFormCompositeInputEenheidComponent,
+    VlFormCompositeInputDatumbereikComponent,
+    VlFormCompositeInputContactComponent,
+} from '@domg-wc/integrations/form';
+
+registerWebComponents([
+    VlFormCompositeInputComponent,
+    VlFormCompositeInputEenheidComponent,
+    VlFormCompositeInputDatumbereikComponent,
+    VlFormCompositeInputContactComponent,
+]);
+
+export default {
+    title: 'Patronen/Formulier/samengesteld veld',
+} as Meta;
+
+export const FormulierSamengesteldVeld: StoryFn = () => html`<vl-form-composite-input></vl-form-composite-input>`;
+FormulierSamengesteldVeld.storyName = 'formulier - samengesteld veld';
+
+export const FormulierSamengesteldVeldEenheid: StoryFn = () =>
+    html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`;
+FormulierSamengesteldVeldEenheid.storyName = 'formulier - samengesteld veld - getal + eenheid (vl-select)';
+
+export const FormulierSamengesteldVeldDatumbereik: StoryFn = () =>
+    html`<vl-form-composite-input-datumbereik></vl-form-composite-input-datumbereik>`;
+FormulierSamengesteldVeldDatumbereik.storyName = 'formulier - samengesteld veld - datumbereik (vl-datepicker)';
+
+export const FormulierSamengesteldVeldContact: StoryFn = () =>
+    html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`;
+FormulierSamengesteldVeldContact.storyName = 'formulier - samengesteld veld - contactmethode';

--- a/libs/components/src/atom/atom.web-types.json
+++ b/libs/components/src/atom/atom.web-types.json
@@ -221,7 +221,7 @@
                         },
                         {
                             "name": "label",
-                            "description": "Vult het aria-label attribuut van de link in. Geef een duidelijke omschrijving mee van waar de link naartoe leidt. bv \"Ga naar Vlaanderen.be (opent in een nieuw venster)",
+                            "description": "Vult het aria-label attribuut van de link in en vervangt zo de volledige voorgelezen linktekst. Geef een duidelijke omschrijving mee van waar de link naartoe leidt.<br/>Bij een externe link wordt de automatische melding \"(opent in een nieuw venster)\" dan niet toegevoegd; neem die vermelding zelf op in het label, bv. \"Ga naar Vlaanderen.be (opent in een nieuw venster)\".",
                             "default": ""
                         },
                         {
@@ -251,7 +251,7 @@
                         },
                         {
                             "name": "external",
-                            "description": "Opent de link in een nieuw tabblad.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.",
+                            "description": "Opent de link in een nieuw tabblad.<br/>Voegt voor schermlezers automatisch de visueel verborgen tekst \"(opent in een nieuw venster)\" toe, tenzij het `label`-attribuut gezet is.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.",
                             "default": "false"
                         },
                         {

--- a/libs/components/src/block/block.web-types.json
+++ b/libs/components/src/block/block.web-types.json
@@ -280,6 +280,12 @@
                                 "description": "Gebruik deze property wanneer je een statische lijst van items wilt gebruiken.",
                                 "type": "array",
                                 "default": ""
+                            },
+                            {
+                                "name": "itemTemplate",
+                                "description": "Gebruik deze property om zelf te bepalen hoe de inhoud van een suggestie gerenderd wordt. De functie krijgt het volledige item mee en geeft een lit `TemplateResult` terug. Wordt deze property ingesteld, dan valt `caption-format` weg voor de suggesties.\n\nKan niet aangepast worden in Storybook.",
+                                "type": "function",
+                                "default": "undefined"
                             }
                         ],
                         "events": [
@@ -364,6 +370,7 @@
                 },
                 {
                     "name": "vl-description-data",
+                    "description": "Gebruik de `description-data` component om label / waarde-paren als een samenhangende lijst weer te geven, bijvoorbeeld\nde metadata van een publicatie. De paren worden als een `<dl>` met `<dt>` en `<dd>` gerenderd, zodat een schermlezer\nelk paar als term en definitie aankondigt.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-block-description-data-description-data--documentatie",
                     "attributes": [
                         {

--- a/libs/components/src/form/form.web-types.json
+++ b/libs/components/src/form/form.web-types.json
@@ -115,6 +115,89 @@
                     }
                 },
                 {
+                    "name": "vl-composite-input-next",
+                    "description": "Gebruik de `vl-composite-input-next` component wanneer twee of meer velden samen één logische waarde vormen: een coördinaat,\neen bedrag met munteenheid, een van/tot-bereik.\n\nDe component leest de velden die je erin plaatst, controleert ze samen en draagt de foutmelding voor het samengestelde\nveld. Elk veld dient wel zijn eigen waarde in onder zijn eigen `name`; de composite heeft zelf geen waarde.\n\nZie [Formulier - Samengesteld veld](/docs/patronen-formulier-samengesteld-veld--documentatie) voor het volledige\npatroon, met uitgewerkte voorbeelden.",
+                    "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-next-composite-input--documentatie",
+                    "attributes": [
+                        {
+                            "name": "custom-css",
+                            "description": "Custom CSS string.<br>Wordt toegevoegd aan de adoptedStyleSheets in de shadow DOM van de component.",
+                            "default": ""
+                        },
+                        {
+                            "name": "id",
+                            "description": "Het id van het veld.",
+                            "default": ""
+                        },
+                        {
+                            "name": "name",
+                            "description": "De naam van het veld.",
+                            "default": ""
+                        },
+                        {
+                            "name": "label",
+                            "description": "Vult het aria-label attribuut van het veld in.<br/>Kan gebruikt worden als er geen bijhorend label element of vl-form-label component is.",
+                            "default": ""
+                        },
+                        {
+                            "name": "required",
+                            "description": "Duidt aan dat het veld verplicht is.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "disabled",
+                            "description": "Beeldt de component in een disabled state af.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "error",
+                            "description": "Beeldt de component in een error state af.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "success",
+                            "description": "Beeldt de component in een success state af.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "blur-validation",
+                            "description": "Activeert on-blur validatie met live recovery.<br>Wanneer aan: het veld valideert op `focusout` zodra het focus had en weer verlaten wordt (ongeacht of de waarde gewijzigd is). Na de eerste foutmelding schakelt het veld over op live re-validatie tijdens typen, tot de waarde geldig is. Submit blijft de definitieve check.<br>Cascade: je kan dit ook in één keer voor alle form controls onder een form inschakelen door `blur-validation` of `data-blur-validation` op het `<form>` element te zetten. Een veld met het eigen attribuut blijft daarnaast los werken.<br>Default: `false` (gedrag van vóór deze feature, validatie enkel op submit).",
+                            "default": "false"
+                        }
+                    ],
+                    "slots": [
+                        {
+                            "name": "default slot (vereist)",
+                            "description": "De velden die samen het samengestelde veld vormen. Geef elk veld een eigen <code>name</code>.",
+                            "default": ""
+                        }
+                    ],
+                    "js": {
+                        "properties": [
+                            {
+                                "name": "customValidator",
+                                "description": "Functie die de velden samen controleert.<br>Krijgt de waarden per <code>name</code> van elk kind en geeft een string terug om af te keuren, of null wanneer alles in orde is.",
+                                "type": "CompositeCustomValidator",
+                                "default": ""
+                            }
+                        ],
+                        "events": [
+                            {
+                                "name": "vl-reset",
+                                "description": "Event dat afgevuurd wordt wanneer het veld gereset wordt."
+                            },
+                            {
+                                "name": "vl-change",
+                                "description": "Event dat afgevuurd wordt wanneer een van de velden een andere waarde krijgt."
+                            },
+                            {
+                                "name": "vl-valid",
+                                "description": "Event dat afgevuurd wordt wanneer het samengestelde veld geldig is."
+                            }
+                        ]
+                    }
+                },
+                {
                     "name": "vl-datepicker",
                     "description": "Gebruik de `datepicker` component om de gebruiker op een gebruiksvriendelijke manier een datum of tijd te laten selecteren.<br/>\nZie het [form demo](/docs/patronen-formulier-demo--documentatie) voorbeeld voor het gebruik binnen een form.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v2/DOMG-WC-VERSION/storybook/?path=/docs/components-form-datepicker--documentatie",

--- a/libs/components/src/form/next/composite-input/index.ts
+++ b/libs/components/src/form/next/composite-input/index.ts
@@ -1,0 +1,2 @@
+export { VlCompositeInputComponent } from './vl-composite-input.component';
+export type { CompositeCustomValidator, CompositeValues } from './validators';

--- a/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-arg.ts
+++ b/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-arg.ts
@@ -1,0 +1,56 @@
+import { CATEGORIES, TYPES } from '@resources/utils-storybook';
+import { ArgTypes } from '@storybook/web-components-vite';
+import { action } from 'storybook/actions';
+import { formControlArgs, formControlArgTypes } from '../../../form-control/stories/form-control.stories-arg';
+
+type CompositeInputArgs = typeof formControlArgs & {
+    customValidator: string;
+    defaultSlot: string;
+    onVlChange: () => void;
+    onVlValid: () => void;
+};
+
+export const compositeInputArgs: CompositeInputArgs = {
+    ...formControlArgs,
+    customValidator: '',
+    defaultSlot: '',
+    onVlChange: action('vl-change'),
+    onVlValid: action('vl-valid'),
+};
+
+export const compositeInputArgTypes: ArgTypes<CompositeInputArgs> = {
+    ...formControlArgTypes,
+    customValidator: {
+        name: 'customValidator',
+        description:
+            'Functie die de velden samen controleert.<br>Krijgt de waarden per <code>name</code> van elk kind en geeft een string terug om af te keuren, of null wanneer alles in orde is.',
+        table: {
+            type: { summary: 'CompositeCustomValidator' },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: String(compositeInputArgs.customValidator) },
+        },
+    },
+    defaultSlot: {
+        name: 'default slot (vereist)',
+        description: 'De velden die samen het samengestelde veld vormen. Geef elk veld een eigen <code>name</code>.',
+        table: {
+            type: { summary: TYPES.HTML },
+            category: CATEGORIES.SLOTS,
+            defaultValue: { summary: String(compositeInputArgs.defaultSlot) },
+        },
+    },
+    onVlChange: {
+        name: 'vl-change',
+        description: 'Event dat afgevuurd wordt wanneer een van de velden een andere waarde krijgt.',
+        table: {
+            category: CATEGORIES.EVENTS,
+        },
+    },
+    onVlValid: {
+        name: 'vl-valid',
+        description: 'Event dat afgevuurd wordt wanneer het samengestelde veld geldig is.',
+        table: {
+            category: CATEGORIES.EVENTS,
+        },
+    },
+};

--- a/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-doc.mdx
+++ b/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-doc.mdx
@@ -1,0 +1,50 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlCompositeInputStories from './vl-composite-input.stories';
+
+# Form Composite Input (next)
+
+<FluxComponentMetaData id="components-form-next-composite-input" />
+
+## Doel
+
+Gebruik de `vl-composite-input-next` component wanneer twee of meer velden samen één logische waarde vormen: een coördinaat,
+een bedrag met munteenheid, een van/tot-bereik.
+
+De component leest de velden die je erin plaatst, controleert ze samen en draagt de foutmelding voor het samengestelde
+veld. Elk veld dient wel zijn eigen waarde in onder zijn eigen `name`; de composite heeft zelf geen waarde.
+
+Zie [Formulier - Samengesteld veld](/docs/patronen-formulier-samengesteld-veld--documentatie) voor het volledige
+patroon, met uitgewerkte voorbeelden.
+
+## Voorbeeld
+
+```js
+import { VlCompositeInputComponent } from '@domg-wc/components/form/next';
+```
+
+```html
+<vl-composite-input-next id="coordinaten" label="Coördinaten (lon, lat)" required>
+    <vl-input-field id="lon" name="coordinaten-lon" label="Longitude" type="number"></vl-input-field>
+    <vl-input-field id="lat" name="coordinaten-lat" label="Latitude" type="number"></vl-input-field>
+</vl-composite-input-next>
+```
+
+<Canvas of={VlCompositeInputStories.CompositeInputDefault} />
+
+## Configuratie
+
+<ArgTypes of={VlCompositeInputStories.CompositeInputDefault} />
+
+## Validatie
+
+- `required` geldt over alle velden samen en levert `valueMissing` op.
+- De `customValidator` krijgt de waarden per `name` van elk kind en levert `customError` op. Hij loopt pas wanneer alle
+  velden ingevuld zijn.
+- Laat je een `vl-form-message` leeg, dan vult de composite de tekst zelf in: bij `valueMissing` met een opsomming van
+  de nog lege velden, bij `customError` met de tekst uit je validator.
+- Constraints die maar over één veld gaan (`min`, `max`, `pattern`, ...) horen op dat veld zelf, met een eigen
+  `vl-form-message` die naar het `id` van dat veld verwijst.
+
+## Toegankelijkheid
+
+Zet een `label` op de composite én op elk veld erin, zodat schermlezers elk veld kunnen benoemen.

--- a/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories.ts
+++ b/libs/components/src/form/next/composite-input/stories/vl-composite-input.stories.ts
@@ -1,0 +1,66 @@
+import { registerWebComponents } from '@domg-wc/common';
+import { story } from '@resources/utils-storybook';
+import { Meta } from '@storybook/web-components-vite';
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { VlFormMessageComponent } from '../../../form-message';
+import { VlInputFieldComponent } from '../../../input-field';
+import { VlCompositeInputComponent } from '../vl-composite-input.component';
+import { CompositeValues } from '../validators';
+import { compositeInputArgs, compositeInputArgTypes } from './vl-composite-input.stories-arg';
+import compositeInputDocs from './vl-composite-input.stories-doc.mdx';
+
+registerWebComponents([VlCompositeInputComponent, VlInputFieldComponent, VlFormMessageComponent]);
+
+const inBelgium = ({ 'coordinaten-lon': lon, 'coordinaten-lat': lat }: CompositeValues): string | null => {
+    const longitude = parseFloat(lon);
+    const latitude = parseFloat(lat);
+    if (longitude < 2.5 || longitude > 6.5 || latitude < 49.5 || latitude > 51.6) {
+        return `(lon=${lon}, lat=${lat}) ligt buiten België`;
+    }
+    return null;
+};
+
+export default {
+    id: 'components-form-next-composite-input',
+    title: 'Components - Form/next/composite-input',
+    tags: ['autodocs'],
+    args: compositeInputArgs,
+    argTypes: compositeInputArgTypes,
+    parameters: {
+        docs: {
+            page: compositeInputDocs,
+        },
+    },
+} as Meta<typeof compositeInputArgs>;
+
+export const CompositeInputDefault = story(
+    compositeInputArgs,
+    ({ id, label, required, disabled, success, defaultSlot }) => html`
+        <form>
+            <vl-composite-input
+                id=${id}
+                label=${label}
+                ?required=${required}
+                ?disabled=${disabled}
+                ?success=${success}
+                .customValidator=${inBelgium}
+            >
+                ${unsafeHTML(defaultSlot)}
+            </vl-composite-input>
+            <vl-form-message for=${id} state="valueMissing"></vl-form-message>
+            <vl-form-message for=${id} state="customError"></vl-form-message>
+            <button type="submit" class="vl-button">Verstuur</button>
+        </form>
+    `
+);
+CompositeInputDefault.storyName = 'vl-composite-input-next - default';
+CompositeInputDefault.args = {
+    id: 'coordinaten',
+    label: 'Coördinaten (lon, lat)',
+    required: true,
+    defaultSlot: `
+        <vl-input-field id="lon" name="coordinaten-lon" label="Longitude" type="number"></vl-input-field>
+        <vl-input-field id="lat" name="coordinaten-lat" label="Latitude" type="number"></vl-input-field>
+    `,
+};

--- a/libs/components/src/form/next/composite-input/validators.ts
+++ b/libs/components/src/form/next/composite-input/validators.ts
@@ -1,0 +1,72 @@
+import { Validator } from '@open-wc/form-control';
+
+export type CompositeValues = Record<string, string>;
+
+export type CompositeCustomValidator = (values: CompositeValues) => string | null | undefined;
+
+export type SlottableValueElement = HTMLElement & { value?: string };
+
+type CompositeInstance = HTMLElement & {
+    required: boolean;
+    error: boolean;
+    customValidator?: CompositeCustomValidator;
+};
+
+export const keyFor = (field: Element): string | null => field.getAttribute('name') || null;
+
+export const slottedFields = (instance: HTMLElement): SlottableValueElement[] =>
+    Array.from(instance.children).filter((el): el is SlottableValueElement => 'value' in el && !!el.getAttribute('name'));
+
+const rawValue = (field: SlottableValueElement): string => field.value ?? '';
+
+const labelFor = (field: SlottableValueElement): string =>
+    field.getAttribute('label') || field.getAttribute('name') || '';
+
+const opsomming = (delen: string[]): string =>
+    delen.length > 1 ? `${delen.slice(0, -1).join(', ')} en ${delen[delen.length - 1]}` : delen[0];
+
+export const slotValues = (instance: HTMLElement): CompositeValues => {
+    const values: CompositeValues = {};
+    for (const field of slottedFields(instance)) {
+        const key = keyFor(field);
+        if (key) values[key] = rawValue(field);
+    }
+    return values;
+};
+
+export const requiredAllValidator: Validator = {
+    attribute: 'required',
+    key: 'valueMissing',
+    message(instance: CompositeInstance): string {
+        const ontbrekend = slottedFields(instance)
+            .filter((field) => rawValue(field) === '')
+            .map(labelFor)
+            .filter((label) => label !== '');
+        return ontbrekend.length > 0 ? `Gelieve ${opsomming(ontbrekend)} in te vullen.` : 'Alle velden zijn verplicht.';
+    },
+    isValid(instance: CompositeInstance): boolean {
+        const required = instance.hasAttribute('required') || instance.required;
+        if (!required) return true;
+        const fields = slottedFields(instance);
+        return fields.length > 0 && fields.every((field) => rawValue(field) !== '');
+    },
+};
+
+export const customErrorValidator: Validator = {
+    attribute: 'error',
+    key: 'customError',
+    message(instance: CompositeInstance): string {
+        if (instance.error) return 'Dit veld bevat een fout.';
+        if (!instance.customValidator) return 'Ongeldige invoer.';
+        const result = instance.customValidator(slotValues(instance));
+        return typeof result === 'string' && result.length > 0 ? result : 'Ongeldige invoer.';
+    },
+    isValid(instance: CompositeInstance): boolean {
+        if (instance.error) return false;
+        if (!instance.customValidator) return true;
+        const fields = slottedFields(instance);
+        if (fields.length === 0 || fields.some((field) => rawValue(field) === '')) return true;
+        const result = instance.customValidator(slotValues(instance));
+        return result == null || result === '';
+    },
+};

--- a/libs/components/src/form/next/composite-input/vl-composite-input.component.cy.ts
+++ b/libs/components/src/form/next/composite-input/vl-composite-input.component.cy.ts
@@ -1,0 +1,71 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlInputFieldComponent } from '@domg-wc/components/form';
+import { VlCompositeInputComponent } from './vl-composite-input.component';
+import { CompositeValues } from './validators';
+
+registerWebComponents([VlCompositeInputComponent, VlInputFieldComponent]);
+
+const typeIn = (id: string, value: string) =>
+    cy.get(`vl-input-field#${id}`).shadow().find('input').clear().type(value).blur();
+
+const formKeys = (assert: (keys: string[]) => void) =>
+    cy.get('form').should(($form) => assert([...new FormData($form[0] as HTMLFormElement).keys()]));
+
+const formValid = (assert: (valid: boolean) => void) =>
+    cy.get('form').should(($form) => assert(($form[0] as HTMLFormElement).checkValidity()));
+
+describe('cypress-component - integrations - vl-composite-input (Mode A)', () => {
+    it('de kinderen submitten zichzelf onder hun eigen name; de composite voegt geen eigen sleutel toe', () => {
+        cy.mount(html`
+            <form>
+                <vl-composite-input-next id="geo" required>
+                    <vl-input-field id="lon" name="geo-lon"></vl-input-field>
+                    <vl-input-field id="lat" name="geo-lat"></vl-input-field>
+                </vl-composite-input-next>
+            </form>
+        `);
+        typeIn('lon', '4.35');
+        typeIn('lat', '50.85');
+
+        formKeys((keys) => {
+            expect(keys).to.include('geo-lon');
+            expect(keys).to.include('geo-lat');
+            expect(keys).to.not.include('geo');
+        });
+    });
+
+    it('required-all: de form is ongeldig bij onvolledige invoer en geldig zodra alle velden ingevuld zijn', () => {
+        cy.mount(html`
+            <form>
+                <vl-composite-input-next id="geo" required>
+                    <vl-input-field id="lon" name="geo-lon"></vl-input-field>
+                    <vl-input-field id="lat" name="geo-lat"></vl-input-field>
+                </vl-composite-input-next>
+            </form>
+        `);
+        typeIn('lon', '4.35');
+        formValid((valid) => expect(valid).to.be.false);
+
+        typeIn('lat', '50.85');
+        formValid((valid) => expect(valid).to.be.true);
+    });
+
+    it('customValidator maakt de composite ongeldig (customError) bij een foute combinatie', () => {
+        const teGroot = ({ 'geo-lon': lon }: CompositeValues): string | null => (parseFloat(lon) > 100 ? 'lon te groot' : null);
+        cy.mount(html`
+            <form>
+                <vl-composite-input-next id="geo" .customValidator=${teGroot}>
+                    <vl-input-field id="lon" name="geo-lon"></vl-input-field>
+                    <vl-input-field id="lat" name="geo-lat"></vl-input-field>
+                </vl-composite-input-next>
+            </form>
+        `);
+        typeIn('lon', '200');
+        typeIn('lat', '5');
+        formValid((valid) => expect(valid).to.be.false);
+
+        typeIn('lon', '5');
+        formValid((valid) => expect(valid).to.be.true);
+    });
+});

--- a/libs/components/src/form/next/composite-input/vl-composite-input.component.ts
+++ b/libs/components/src/form/next/composite-input/vl-composite-input.component.ts
@@ -1,0 +1,160 @@
+import { webComponent } from '@domg-wc/common';
+import { css, CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
+import { FormControl } from '../../form-control';
+import {
+    CompositeCustomValidator,
+    customErrorValidator,
+    requiredAllValidator,
+    SlottableValueElement,
+    slotValues,
+    slottedFields,
+} from './validators';
+
+type SlottedElement = SlottableValueElement & { validationTarget?: HTMLElement };
+
+const PROPAGATED_ATTRIBUTES = ['disabled', 'success'] as const;
+
+@webComponent('vl-composite-input-next')
+export class VlCompositeInputComponent extends FormControl {
+    customValidator?: CompositeCustomValidator;
+
+    protected override submitFormOnEnter = false;
+
+    private lastDetailJson: string | undefined;
+
+    static formControlValidators = [requiredAllValidator, customErrorValidator];
+
+    static get properties(): PropertyDeclarations {
+        return {
+            customValidator: { attribute: false },
+        };
+    }
+
+    static get styles(): CSSResult[] {
+        return [
+            css`
+                fieldset {
+                    border: 0;
+                    padding: 0;
+                    margin: 0;
+                    display: flex;
+                    gap: 0.5rem;
+                    align-items: center;
+                }
+
+                .vl-u-visually-hidden {
+                    position: absolute !important;
+                    height: 1px;
+                    width: 1px;
+                    overflow: hidden;
+                    clip: rect(1px, 1px, 1px, 1px);
+                    margin: -1px;
+                    padding: 0;
+                    border: 0;
+                    left: 0;
+                    top: 0;
+                }
+            `,
+        ];
+    }
+
+    get validationTarget(): HTMLElement | undefined | null {
+        const field = slottedFields(this)[0] as SlottedElement | undefined;
+        return field?.validationTarget ?? field;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('vl-change', this.onChildEvent);
+        this.addEventListener('vl-reset', this.onChildReset);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this.removeEventListener('vl-change', this.onChildEvent);
+        this.removeEventListener('vl-reset', this.onChildReset);
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+
+        if (changedProperties.has('customValidator')) {
+            this.syncFields();
+        }
+
+        PROPAGATED_ATTRIBUTES.forEach((attribute) => {
+            if (changedProperties.has(attribute)) {
+                this.propagateAttribute(attribute, this[attribute], changedProperties.get(attribute) === true);
+            }
+        });
+    }
+
+    firstUpdated() {
+        this.syncFields();
+    }
+
+    render(): TemplateResult {
+        return html`
+            <fieldset part="fieldset">
+                <legend class="vl-u-visually-hidden">${this.label || 'Samengesteld invoerveld'}</legend>
+                <slot @slotchange=${this.onSlotChange}></slot>
+            </fieldset>
+        `;
+    }
+
+    private onSlotChange = () => {
+        this.propagateState();
+        this.syncFields();
+    };
+
+    private onChildEvent = (event: Event) => {
+        if (event.target === this) return;
+        this.syncFields();
+    };
+
+    private onChildReset = (event: Event) => {
+        if (event.target === this) return;
+        queueMicrotask(() => {
+            if (this.isConnected) this.syncFields();
+        });
+    };
+
+    private syncFields() {
+        const detail = slotValues(this);
+        this.setValue(null);
+
+        const detailJson = JSON.stringify(detail);
+        if (this.lastDetailJson !== undefined && this.lastDetailJson !== detailJson) {
+            this.dispatchEvent(new CustomEvent('vl-change', { composed: true, bubbles: true, detail }));
+            this.dispatchEventIfValid(detail);
+        }
+        this.lastDetailJson = detailJson;
+
+        this.requestUpdate();
+    }
+
+    private propagateState() {
+        PROPAGATED_ATTRIBUTES.forEach((attribute) => {
+            if (this[attribute]) {
+                this.propagateAttribute(attribute, true);
+            }
+        });
+    }
+
+    private propagateAttribute(attribute: string, present: boolean, wasPresent = true) {
+        if (!present && !wasPresent) {
+            return;
+        }
+        this.eachChild((el) => (present ? el.setAttribute(attribute, '') : el.removeAttribute(attribute)));
+    }
+
+    private eachChild(fn: (el: SlottedElement) => void) {
+        (slottedFields(this) as SlottedElement[]).forEach(fn);
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-composite-input-next': VlCompositeInputComponent;
+    }
+}

--- a/libs/components/src/form/next/index.ts
+++ b/libs/components/src/form/next/index.ts
@@ -1,0 +1,5 @@
+export {
+    VlCompositeInputComponent,
+    type CompositeCustomValidator,
+    type CompositeValues,
+} from './composite-input';

--- a/libs/integrations/src/form/composite-input/index.ts
+++ b/libs/integrations/src/form/composite-input/index.ts
@@ -1,0 +1,4 @@
+export { VlFormCompositeInputComponent } from './vl-form-composite-input.component';
+export { VlFormCompositeInputEenheidComponent } from './vl-form-composite-input-eenheid.component';
+export { VlFormCompositeInputDatumbereikComponent } from './vl-form-composite-input-datumbereik.component';
+export { VlFormCompositeInputContactComponent } from './vl-form-composite-input-contact.component';

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-contact.component.cy.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-contact.component.cy.ts
@@ -1,0 +1,65 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCompositeInputContactComponent } from './vl-form-composite-input-contact.component';
+
+registerWebComponents([VlFormCompositeInputContactComponent]);
+
+const HOST = 'vl-form-composite-input-contact';
+
+const submit = () => cy.get(HOST).shadow().find('vl-button[type="submit"]').shadow().find('button').click('bottomLeft');
+
+const chooseMethod = (value: string) =>
+    cy
+        .get(HOST)
+        .shadow()
+        .find('vl-select#method')
+        .then(($s) => {
+            const el = $s[0] as HTMLElement & { value: string };
+            el.value = value;
+            el.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true }));
+        });
+
+const typeContact = (text: string) =>
+    cy.get(HOST).shadow().find('vl-input-field#value').shadow().find('input').clear().type(text);
+
+describe('cypress-component - integrations - vl-form-composite-input-contact', () => {
+    it('rendert de methode-select', () => {
+        cy.mount(html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`);
+        cy.get(HOST).shadow().find('vl-select#method');
+    });
+
+    it('toont een e-mailveld wanneer e-mail gekozen wordt', () => {
+        cy.mount(html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`);
+        chooseMethod('email');
+        cy.get(HOST).shadow().find('vl-input-field#value[type="email"]');
+    });
+
+    it('toont valueMissing wanneer de methode gekozen is maar het contactgegeven leeg blijft', () => {
+        cy.mount(html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`);
+        chooseMethod('email');
+        submit();
+        cy.get(HOST)
+            .shadow()
+            .find('vl-form-message[for="contact"][state="valueMissing"]')
+            .should('have.attr', 'show');
+    });
+
+    it('toont customError bij een ongeldig e-mailadres', () => {
+        cy.mount(html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`);
+        chooseMethod('email');
+        typeContact('geen-email');
+        submit();
+        cy.get(HOST).shadow().find('vl-form-message[state="customError"]').should('have.attr', 'show');
+    });
+
+    it('is geldig bij een correct e-mailadres en print de form data', () => {
+        cy.mount(html`<vl-form-composite-input-contact></vl-form-composite-input-contact>`);
+        chooseMethod('email');
+        typeContact('naam@voorbeeld.be');
+        submit();
+        cy.get(HOST).shadow().find('vl-form-message[state="customError"]').should('not.have.attr', 'show');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'contact-method');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'contact-value');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'naam@voorbeeld.be');
+    });
+});

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-contact.component.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-contact.component.ts
@@ -1,0 +1,182 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent, VlTextComponent } from '@domg-wc/components/atom';
+import {
+    parseFormData,
+    SelectOption,
+    VlFormLabelComponent,
+    VlFormMessageComponent,
+    VlInputFieldComponent,
+    VlSelectComponent,
+} from '@domg-wc/components/form';
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+import { css, CSSResult, html, LitElement, PropertyDeclarations, nothing } from 'lit';
+
+const METHODS: SelectOption[] = [
+    { value: 'email', label: 'E-mail' },
+    { value: 'tel', label: 'Telefoon' },
+];
+
+const EMAIL = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+const PHONE = /^[\d\s/().+-]{6,}$/;
+
+// Het eerste veld bepaalt welke regel op het tweede geldt: een e-mailadres of een telefoonnummer.
+// Het tweede veld verschijnt pas na die keuze; een veld dat later bijkomt telt automatisch mee in de validatie.
+const valideerContact = ({ 'contact-method': method, 'contact-value': value }: CompositeValues): string | null => {
+    if (!method || !value) return null;
+    if (method === 'email') return EMAIL.test(value) ? null : `'${value}' is geen geldig e-mailadres.`;
+    if (method === 'tel') return PHONE.test(value) ? null : `'${value}' is geen geldig telefoonnummer.`;
+    return null;
+};
+
+@webComponent('vl-form-composite-input-contact')
+export class VlFormCompositeInputContactComponent extends LitElement {
+    private method = '';
+    private contact = '';
+    private parsedFormData: Record<string, FormDataEntryValue> | null = null;
+
+    static {
+        registerWebComponents([
+            VlCompositeInputComponent,
+            VlSelectComponent,
+            VlInputFieldComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlButtonComponent,
+            VlTextComponent,
+        ]);
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            method: { type: String, state: true },
+            contact: { type: String, state: true },
+            parsedFormData: { type: Object, state: true },
+        };
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+
+                pre {
+                    font-size: 1rem;
+                }
+            `,
+        ];
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="contact" label="Contactgegeven *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-composite-input-next
+                            id="contact"
+                            label="Contactgegeven"
+                            required
+                            .customValidator=${valideerContact}
+                        >
+                            <vl-select
+                                id="method"
+                                name="contact-method"
+                                label="Contactmethode"
+                                placeholder="Kies een methode"
+                                .value=${this.method}
+                                .options=${METHODS}
+                                @vl-change=${this.onMethodChange}
+                            ></vl-select>
+                            ${this.method === 'email'
+                                ? html`<vl-input-field
+                                      id="value"
+                                      name="contact-value"
+                                      label="E-mailadres"
+                                      type="email"
+                                      placeholder="naam@voorbeeld.be"
+                                      .value=${this.contact}
+                                      @vl-input=${this.onContactInput}
+                                  ></vl-input-field>`
+                                : nothing}
+                            ${this.method === 'tel'
+                                ? html`<vl-input-field
+                                      id="value"
+                                      name="contact-value"
+                                      label="Telefoonnummer"
+                                      type="tel"
+                                      placeholder="+32 ..."
+                                      .value=${this.contact}
+                                      @vl-input=${this.onContactInput}
+                                  ></vl-input-field>`
+                                : nothing}
+                        </vl-composite-input-next>
+                        <vl-text annotation small
+                            >Kies eerst een methode; vul dan een geldig e-mailadres (naam@voorbeeld.be) of
+                            telefoonnummer in.</vl-text
+                        >
+                        <vl-form-message for="contact" state="valueMissing"
+                            >Kies een methode en vul het contactgegeven in.</vl-form-message
+                        >
+                        <vl-form-message for="contact" state="customError"></vl-form-message>
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                    ${this.parsedFormData
+                        ? html`
+                              <div class="vl-column vl-column--4">
+                                  <vl-form-label class="vl-form__label">Formulier data</vl-form-label>
+                              </div>
+                              <div class="vl-column vl-column--8">
+                                  <pre>${JSON.stringify(this.parsedFormData, null, 4)}</pre>
+                              </div>
+                          `
+                        : ''}
+                </div>
+            </form>
+        `;
+    }
+
+    private onMethodChange(event: CustomEvent) {
+        this.method = (event.target as HTMLElement & { value: string }).value;
+        this.contact = '';
+    }
+
+    private onContactInput(event: CustomEvent<{ value: string }>) {
+        this.contact = event.detail?.value ?? '';
+    }
+
+    private onSubmit(event: Event) {
+        event.preventDefault();
+        this.parsedFormData = parseFormData(event.target as HTMLFormElement) as Record<string, FormDataEntryValue>;
+    }
+
+    private onReset() {
+        this.method = '';
+        this.contact = '';
+        this.parsedFormData = null;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-form-composite-input-contact': VlFormCompositeInputContactComponent;
+    }
+}

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-datumbereik.component.cy.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-datumbereik.component.cy.ts
@@ -1,0 +1,55 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCompositeInputDatumbereikComponent } from './vl-form-composite-input-datumbereik.component';
+
+registerWebComponents([VlFormCompositeInputDatumbereikComponent]);
+
+const HOST = 'vl-form-composite-input-datumbereik';
+
+const submit = () => cy.get(HOST).shadow().find('vl-button[type="submit"]').shadow().find('button').click('bottomLeft');
+
+const setDate = (id: 'begin' | 'einde', iso: string) =>
+    cy
+        .get(HOST)
+        .shadow()
+        .find(`vl-datepicker#${id}`)
+        .then(($d) => {
+            const el = $d[0] as HTMLElement & { value: string };
+            el.setAttribute('value', iso);
+            el.value = iso;
+            el.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true }));
+        });
+
+const customError = () => cy.get(HOST).shadow().find('vl-form-message[state="customError"]');
+
+describe('cypress-component - integrations - vl-form-composite-input-datumbereik', () => {
+    it('rendert twee datepickers', () => {
+        cy.mount(html`<vl-form-composite-input-datumbereik></vl-form-composite-input-datumbereik>`);
+        cy.get(HOST).shadow().find('vl-datepicker#begin');
+        cy.get(HOST).shadow().find('vl-datepicker#einde');
+    });
+
+    it('leest de ISO-waarde van de datepicker uit', () => {
+        cy.mount(html`<vl-form-composite-input-datumbereik></vl-form-composite-input-datumbereik>`);
+        setDate('begin', '2026-12-25');
+        cy.get(HOST).shadow().find('vl-datepicker#begin').should('have.value', '2026-12-25');
+    });
+
+    it('toont customError wanneer de begindatum na de einddatum ligt', () => {
+        cy.mount(html`<vl-form-composite-input-datumbereik></vl-form-composite-input-datumbereik>`);
+        setDate('begin', '2026-12-26');
+        setDate('einde', '2026-12-25');
+        submit();
+        customError().should('have.attr', 'show');
+    });
+
+    it('is geldig bij begindatum voor einddatum en print de form data', () => {
+        cy.mount(html`<vl-form-composite-input-datumbereik></vl-form-composite-input-datumbereik>`);
+        setDate('begin', '2026-12-25');
+        setDate('einde', '2026-12-26');
+        submit();
+        customError().should('not.have.attr', 'show');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'periode-begin');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'periode-einde');
+    });
+});

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-datumbereik.component.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-datumbereik.component.ts
@@ -1,0 +1,141 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent, VlTextComponent } from '@domg-wc/components/atom';
+import {
+    parseFormData,
+    VlDatepickerComponent,
+    VlFormLabelComponent,
+    VlFormMessageComponent,
+} from '@domg-wc/components/form';
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+import { css, CSSResult, html, LitElement, PropertyDeclarations } from 'lit';
+
+// Elke datum is op zich geldig; enkel de volgorde kan fout zijn.
+// De datepickers geven hun waarde als ISO-datum, dus Date.parse volstaat om ze te vergelijken.
+const beginVoorEinde = ({ 'periode-begin': begin, 'periode-einde': einde }: CompositeValues): string | null => {
+    const beginTijd = Date.parse(begin);
+    const eindeTijd = Date.parse(einde);
+    if (Number.isNaN(beginTijd) || Number.isNaN(eindeTijd)) return null;
+    return beginTijd > eindeTijd ? 'De begindatum ligt na de einddatum.' : null;
+};
+
+@webComponent('vl-form-composite-input-datumbereik')
+export class VlFormCompositeInputDatumbereikComponent extends LitElement {
+    private parsedFormData: Record<string, FormDataEntryValue> | null = null;
+
+    static {
+        registerWebComponents([
+            VlCompositeInputComponent,
+            VlDatepickerComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlButtonComponent,
+            VlTextComponent,
+        ]);
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            parsedFormData: { type: Object, state: true },
+        };
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+
+                pre {
+                    font-size: 1rem;
+                }
+            `,
+        ];
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="periode" label="Periode *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-composite-input-next
+                            id="periode"
+                            label="Periode"
+                            required
+                            .customValidator=${beginVoorEinde}
+                        >
+                            <vl-datepicker
+                                id="begin"
+                                name="periode-begin"
+                                label="Begindatum"
+                                type="date"
+                                format="d-m-Y"
+                                anchor-positioning
+                            ></vl-datepicker>
+                            <vl-datepicker
+                                id="einde"
+                                name="periode-einde"
+                                label="Einddatum"
+                                type="date"
+                                format="d-m-Y"
+                                anchor-positioning
+                            ></vl-datepicker>
+                        </vl-composite-input-next>
+                        <vl-text annotation small
+                            >Kies een begin- en einddatum (dd-mm-jjjj). De begindatum mag niet na de einddatum
+                            liggen.</vl-text
+                        >
+                        <vl-form-message for="periode" state="valueMissing"
+                            >Begin- en einddatum zijn verplicht.</vl-form-message
+                        >
+                        <vl-form-message for="periode" state="customError"></vl-form-message>
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                    ${this.parsedFormData
+                        ? html`
+                              <div class="vl-column vl-column--4">
+                                  <vl-form-label class="vl-form__label">Formulier data</vl-form-label>
+                              </div>
+                              <div class="vl-column vl-column--8">
+                                  <pre>${JSON.stringify(this.parsedFormData, null, 4)}</pre>
+                              </div>
+                          `
+                        : ''}
+                </div>
+            </form>
+        `;
+    }
+
+    private onSubmit(event: Event) {
+        event.preventDefault();
+        this.parsedFormData = parseFormData(event.target as HTMLFormElement) as Record<string, FormDataEntryValue>;
+    }
+
+    private onReset() {
+        this.parsedFormData = null;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-form-composite-input-datumbereik': VlFormCompositeInputDatumbereikComponent;
+    }
+}

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-eenheid.component.cy.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-eenheid.component.cy.ts
@@ -1,0 +1,66 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCompositeInputEenheidComponent } from './vl-form-composite-input-eenheid.component';
+
+registerWebComponents([VlFormCompositeInputEenheidComponent]);
+
+const HOST = 'vl-form-composite-input-eenheid';
+
+const submit = () => cy.get(HOST).shadow().find('vl-button[type="submit"]').shadow().find('button').click('bottomLeft');
+
+const typeWaarde = (text: string) =>
+    cy.get(HOST).shadow().find('vl-input-field#waarde').shadow().find('input').clear().type(text);
+
+const kiesEenheid = (value: string) =>
+    cy
+        .get(HOST)
+        .shadow()
+        .find('vl-select#eenheid')
+        .then(($s) => {
+            const el = $s[0] as HTMLElement & { value: string };
+            el.value = value;
+            el.dispatchEvent(new CustomEvent('vl-change', { bubbles: true, composed: true }));
+        });
+
+const formMessage = (state: string) => cy.get(HOST).shadow().find(`vl-form-message[state="${state}"]`);
+
+describe('cypress-component - integrations - vl-form-composite-input-eenheid', () => {
+    it('rendert het getal- en het eenheidveld', () => {
+        cy.mount(html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`);
+        cy.get(HOST).shadow().find('vl-input-field#waarde');
+        cy.get(HOST).shadow().find('vl-select#eenheid');
+    });
+
+    it('toont valueMissing wanneer enkel het getal ingevuld is', () => {
+        cy.mount(html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`);
+        typeWaarde('50');
+        submit();
+        formMessage('valueMissing').should('have.attr', 'show');
+    });
+
+    it('toont customError wanneer de lengte buiten het bereik ligt', () => {
+        cy.mount(html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`);
+        typeWaarde('5000');
+        kiesEenheid('m');
+        submit();
+        formMessage('customError').should('have.attr', 'show');
+    });
+
+    it('rekent de eenheid mee: 5000 cm is wel geldig', () => {
+        cy.mount(html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`);
+        typeWaarde('5000');
+        kiesEenheid('cm');
+        submit();
+        formMessage('customError').should('not.have.attr', 'show');
+    });
+
+    it('is geldig voor 50 cm en print de form data met beide sleutels', () => {
+        cy.mount(html`<vl-form-composite-input-eenheid></vl-form-composite-input-eenheid>`);
+        typeWaarde('50');
+        kiesEenheid('cm');
+        submit();
+        formMessage('customError').should('not.have.attr', 'show');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'lengte-waarde');
+        cy.get(HOST).shadow().find('pre').should('contain.text', 'lengte-eenheid');
+    });
+});

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input-eenheid.component.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input-eenheid.component.ts
@@ -1,0 +1,162 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent, VlTextComponent } from '@domg-wc/components/atom';
+import {
+    parseFormData,
+    SelectOption,
+    VlFormLabelComponent,
+    VlFormMessageComponent,
+    VlInputFieldComponent,
+    VlSelectComponent,
+} from '@domg-wc/components/form';
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+import { css, CSSResult, html, LitElement, PropertyDeclarations } from 'lit';
+
+const EENHEDEN: SelectOption[] = [
+    { value: 'cm', label: 'centimeter (cm)' },
+    { value: 'dm', label: 'decimeter (dm)' },
+    { value: 'm', label: 'meter (m)' },
+];
+
+const METER_PER_EENHEID: Record<string, number> = { cm: 0.01, dm: 0.1, m: 1 };
+
+const MIN_METER = 0.01;
+const MAX_METER = 100;
+
+// Het getal alleen kan je niet nakijken: 50 is pas een lengte samen met zijn eenheid.
+// Daarom rekent deze validator beide waarden om naar meter en kijkt hij dan pas of ze binnen het bereik vallen.
+const binnenBereik = ({ 'lengte-waarde': waarde, 'lengte-eenheid': eenheid }: CompositeValues): string | null => {
+    const factor = METER_PER_EENHEID[eenheid];
+    const getal = parseFloat(waarde);
+
+    if (!factor || Number.isNaN(getal)) {
+        return null;
+    }
+
+    const meter = getal * factor;
+
+    if (meter < MIN_METER || meter > MAX_METER) {
+        return `${waarde} ${eenheid} is ${meter.toFixed(2)} m; de lengte moet tussen ${MIN_METER} m en ${MAX_METER} m liggen.`;
+    }
+
+    return null;
+};
+
+@webComponent('vl-form-composite-input-eenheid')
+export class VlFormCompositeInputEenheidComponent extends LitElement {
+    private parsedFormData: Record<string, FormDataEntryValue> | null = null;
+
+    static {
+        registerWebComponents([
+            VlCompositeInputComponent,
+            VlInputFieldComponent,
+            VlSelectComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlButtonComponent,
+            VlTextComponent,
+        ]);
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            parsedFormData: { type: Object, state: true },
+        };
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+
+                pre {
+                    font-size: 1rem;
+                }
+            `,
+        ];
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="lengte" label="Lengte *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-composite-input-next id="lengte" label="Lengte" required .customValidator=${binnenBereik}>
+                            <vl-input-field
+                                id="waarde"
+                                name="lengte-waarde"
+                                label="Waarde"
+                                type="number"
+                                min="0"
+                            ></vl-input-field>
+                            <vl-select
+                                id="eenheid"
+                                name="lengte-eenheid"
+                                label="Eenheid"
+                                placeholder="Kies een eenheid"
+                                .options=${EENHEDEN}
+                            ></vl-select>
+                        </vl-composite-input-next>
+                        <vl-text annotation small
+                            >Het getal betekent niets zonder de eenheid: samen vormen ze één lengte. Enkel lengtes
+                            tussen ${MIN_METER} m en ${MAX_METER} m zijn geldig, dus 5000 cm mag wel en 5000 m
+                            niet.</vl-text
+                        >
+                        <vl-form-message for="lengte" state="valueMissing"
+                            >Zowel de waarde als de eenheid zijn verplicht.</vl-form-message
+                        >
+                        <vl-form-message for="lengte" state="customError"></vl-form-message>
+                        <vl-form-message for="waarde" state="rangeUnderflow"
+                            >De waarde mag niet negatief zijn.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                    ${this.parsedFormData
+                        ? html`
+                              <div class="vl-column vl-column--4">
+                                  <vl-form-label class="vl-form__label">Formulier data</vl-form-label>
+                              </div>
+                              <div class="vl-column vl-column--8">
+                                  <pre>${JSON.stringify(this.parsedFormData, null, 4)}</pre>
+                              </div>
+                          `
+                        : ''}
+                </div>
+            </form>
+        `;
+    }
+
+    private onSubmit(event: Event) {
+        event.preventDefault();
+        this.parsedFormData = parseFormData(event.target as HTMLFormElement) as Record<string, FormDataEntryValue>;
+    }
+
+    private onReset() {
+        this.parsedFormData = null;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-form-composite-input-eenheid': VlFormCompositeInputEenheidComponent;
+    }
+}

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input.component.cy.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input.component.cy.ts
@@ -1,0 +1,131 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCompositeInputComponent } from './vl-form-composite-input.component';
+
+registerWebComponents([VlFormCompositeInputComponent]);
+
+const HOST = 'vl-form-composite-input';
+
+const submit = () => cy.get(HOST).shadow().find('vl-button[type="submit"]').shadow().find('button').click('bottomLeft');
+
+const reset = () => cy.get(HOST).shadow().find('vl-button[type="reset"]').shadow().find('button').click('bottomLeft');
+
+const typeIn = (id: 'lon' | 'lat', value: string) =>
+    cy.get(HOST).shadow().find(`vl-input-field#${id}`).shadow().find('input').clear().type(value);
+
+const formMessage = (state: string) => cy.get(HOST).shadow().find(`vl-form-message[state="${state}"]`);
+
+const childMessage = (forId: string, state: string) =>
+    cy.get(HOST).shadow().find(`vl-form-message[for="${forId}"][state="${state}"]`);
+
+const output = () => cy.get(HOST).shadow().find('pre');
+
+describe('cypress-component - integrations - vl-form-composite-input', () => {
+    it('rendert het samengestelde veld', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        cy.get(HOST).shadow().find('vl-composite-input-next');
+    });
+
+    it('toont valueMissing bij submit zonder invoer', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        submit();
+        formMessage('valueMissing').should('have.attr', 'show', '');
+    });
+
+    it('toont valueMissing wanneer maar één veld ingevuld is', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '4.35');
+        submit();
+        formMessage('valueMissing').should('have.attr', 'show', '');
+    });
+
+    it('benoemt enkel het ontbrekende veld in de valueMissing-boodschap', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '4.35');
+        submit();
+        formMessage('valueMissing')
+            .should('have.attr', 'validation-message')
+            .and('contain', 'Latitude')
+            .and('not.contain', 'Longitude');
+    });
+
+    it('benoemt beide velden wanneer niets ingevuld is', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        submit();
+        formMessage('valueMissing')
+            .should('have.attr', 'validation-message')
+            .and('contain', 'Longitude en Latitude');
+    });
+
+    it('toont rangeOverflow op het foute kindveld', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '200');
+        typeIn('lat', '50');
+        submit();
+        childMessage('lon', 'rangeOverflow').should('have.attr', 'show', '');
+        childMessage('lon', 'rangeOverflow').should('contain.text', 'Longitude mag maximaal 180');
+    });
+
+    it('toont de per-veld-fout en de cross-veld-fout tegelijk (customValidator blokkeert de range-fout niet)', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '200');
+        typeIn('lat', '50');
+        submit();
+        childMessage('lon', 'rangeOverflow').should('have.attr', 'show', '');
+        formMessage('customError').should('have.attr', 'show', '');
+    });
+
+    it('toont rangeUnderflow op het foute kindveld', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '-200');
+        typeIn('lat', '50');
+        submit();
+        childMessage('lon', 'rangeUnderflow').should('have.attr', 'show', '');
+        childMessage('lon', 'rangeUnderflow').should('contain.text', 'Longitude moet minstens -180');
+    });
+
+    it('toont customError wanneer het punt buiten België ligt', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '7.5');
+        typeIn('lat', '48');
+        submit();
+        formMessage('customError').should('have.attr', 'show', '');
+    });
+
+    it('is geldig voor een punt binnen België en print de form data met samengestelde sleutels', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '4.35');
+        typeIn('lat', '50.85');
+        submit();
+        formMessage('customError').should('not.have.attr', 'show', '');
+        formMessage('valueMissing').should('not.have.attr', 'show', '');
+        output().should('contain.text', 'coordinaten-lon');
+        output().should('contain.text', 'coordinaten-lat');
+    });
+
+    it('verstuurt maar één keer bij Enter in een kindveld', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '4.35');
+        typeIn('lat', '50.85');
+        cy.get(HOST)
+            .shadow()
+            .find('form')
+            .then(($form) => {
+                $form[0].addEventListener('submit', cy.spy().as('submitSpy'));
+            });
+        cy.get(HOST).shadow().find('vl-input-field#lat').shadow().find('input').type('{enter}');
+        cy.get('@submitSpy').should('have.been.calledOnce');
+    });
+
+    it('maakt de form data leeg bij reset', () => {
+        cy.mount(html`<vl-form-composite-input></vl-form-composite-input>`);
+        typeIn('lon', '4.35');
+        typeIn('lat', '50.85');
+        submit();
+        output().should('exist');
+        reset();
+        cy.get(HOST).shadow().find('pre').should('not.exist');
+        cy.get(HOST).shadow().find('vl-input-field#lon').shadow().find('input').should('have.value', '');
+        cy.get(HOST).shadow().find('vl-input-field#lat').shadow().find('input').should('have.value', '');
+    });
+});

--- a/libs/integrations/src/form/composite-input/vl-form-composite-input.component.ts
+++ b/libs/integrations/src/form/composite-input/vl-form-composite-input.component.ts
@@ -1,0 +1,168 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent, VlTextComponent } from '@domg-wc/components/atom';
+import {
+    parseFormData,
+    VlFormMessageComponent,
+    VlFormLabelComponent,
+    VlInputFieldComponent,
+} from '@domg-wc/components/form';
+import { VlCompositeInputComponent, type CompositeValues } from '@domg-wc/components/form/next';
+import { css, CSSResult, html, LitElement, PropertyDeclarations } from 'lit';
+
+// Validator voor het samengestelde veld: krijgt per `name` van elk kind de waarde, als tekst.
+// Geef een string terug om af te keuren, die tekst wordt de foutmelding; geef null terug als alles in orde is.
+// Hij loopt pas wanneer alle velden ingevuld zijn: onvolledige invoer handelt `required` af.
+const inBelgium = ({ 'coordinaten-lon': lon, 'coordinaten-lat': lat }: CompositeValues): string | null => {
+    const longitude = parseFloat(lon);
+    const latitude = parseFloat(lat);
+    if (longitude < 2.5 || longitude > 6.5 || latitude < 49.5 || latitude > 51.6) {
+        return `(lon=${lon}, lat=${lat}) ligt buiten België`;
+    }
+    return null;
+};
+
+@webComponent('vl-form-composite-input')
+export class VlFormCompositeInputComponent extends LitElement {
+    private parsedFormData: Record<string, FormDataEntryValue> | null = null;
+
+    static {
+        registerWebComponents([
+            VlCompositeInputComponent,
+            VlInputFieldComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlButtonComponent,
+            VlTextComponent,
+        ]);
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            parsedFormData: { type: Object, state: true },
+        };
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+
+                pre {
+                    font-size: 1rem;
+                }
+            `,
+        ];
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="coordinaten" label="Coördinaten (lon, lat) *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <!-- De composite heeft geen name: ze dient zelf geen waarde in, ze valideert de velden samen.
+                             Haar id gebruik je in vl-form-label[for] en in de meldingen voor het samengestelde veld.
+                             required betekent hier dat alle velden ingevuld moeten zijn. -->
+                        <vl-composite-input-next
+                            id="coordinaten"
+                            label="Coördinaten (lon, lat)"
+                            required
+                            .customValidator=${inBelgium}
+                        >
+                            <!-- Een veld is een direct kind met een value en een name. Die name is de sleutel in de
+                                 FormData en in de validator hierboven; het id gebruik je enkel om er een eigen
+                                 vl-form-message aan te koppelen. Veldspecifieke constraints (hier min/max) zet je
+                                 op het kind, niet op de composite. -->
+                            <vl-input-field
+                                id="lon"
+                                name="coordinaten-lon"
+                                label="Longitude"
+                                type="number"
+                                min="-180"
+                                max="180"
+                            ></vl-input-field>
+                            <vl-input-field
+                                id="lat"
+                                name="coordinaten-lat"
+                                label="Latitude"
+                                type="number"
+                                min="-90"
+                                max="90"
+                            ></vl-input-field>
+                        </vl-composite-input-next>
+                        <vl-text annotation small
+                            >Vul de longitude en latitude in graden in (bv. Brussel: 4,35 en 50,85). Enkel punten
+                            binnen België zijn geldig.</vl-text
+                        >
+                        <!-- De meldingen voor het samengestelde veld hangen aan de composite. Laat je ze leeg, dan
+                             vult de composite ze zelf in: valueMissing met een opsomming van de nog lege velden (op
+                             basis van hun label), customError met de string uit de validator. Eigen tekst wint. -->
+                        <vl-form-message for="coordinaten" state="valueMissing"></vl-form-message>
+                        <vl-form-message for="coordinaten" state="customError"></vl-form-message>
+                        <!-- Een melding per veld verwijst naar het id van dat kind, met eigen tekst per staat. -->
+                        <vl-form-message for="lon" state="rangeUnderflow"
+                            >Longitude moet minstens -180 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lon" state="rangeOverflow"
+                            >Longitude mag maximaal 180 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lat" state="rangeUnderflow"
+                            >Latitude moet minstens -90 zijn.</vl-form-message
+                        >
+                        <vl-form-message for="lat" state="rangeOverflow"
+                            >Latitude mag maximaal 90 zijn.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                    ${this.parsedFormData
+                        ? html`
+                              <div class="vl-column vl-column--4">
+                                  <vl-form-label class="vl-form__label">Formulier data</vl-form-label>
+                              </div>
+                              <div class="vl-column vl-column--8">
+                                  <pre>${JSON.stringify(this.parsedFormData, null, 4)}</pre>
+                              </div>
+                          `
+                        : ''}
+                </div>
+            </form>
+        `;
+    }
+
+    // Bij een gewone submit valideert de browser eerst, dus hier is de invoer zeker volledig. Lees je elders zelf
+    // new FormData(form) uit, controleer dan eerst form.checkValidity(): de composite houdt onvolledige invoer tegen
+    // met validatie, ze laat de waarden wel in de FormData staan.
+    private onSubmit(event: Event) {
+        event.preventDefault();
+        this.parsedFormData = parseFormData(event.target as HTMLFormElement) as Record<string, FormDataEntryValue>;
+    }
+
+    private onReset() {
+        this.parsedFormData = null;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-form-composite-input': VlFormCompositeInputComponent;
+    }
+}

--- a/libs/integrations/src/form/index.ts
+++ b/libs/integrations/src/form/index.ts
@@ -1,4 +1,10 @@
 export {
+    VlFormCompositeInputComponent,
+    VlFormCompositeInputEenheidComponent,
+    VlFormCompositeInputDatumbereikComponent,
+    VlFormCompositeInputContactComponent,
+} from './composite-input';
+export {
     VlFormCrossValidationComponent,
     VlFormCrossValidationConditionalComponent,
     VlFormCrossValidationMatchComponent,

--- a/resources/generate-web-types/wt-config-build/components-form.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components-form.wt-config.ts
@@ -1,4 +1,5 @@
 import { checkboxArgTypes } from '../../../libs/components/src/form/checkbox/stories/vl-checkbox.stories-arg';
+import { compositeInputArgTypes } from '../../../libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-arg';
 import { datepickerArgTypes } from '../../../libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg';
 import { fieldsetArgTypes } from '../../../libs/components/src/form/fieldset/stories/vl-fieldset.stories-arg';
 import { formLabelArgTypes } from '../../../libs/components/src/form/form-label/stories/vl-form-label.stories-arg';
@@ -21,6 +22,12 @@ export const buildWTConfigComponentsForm: WTConfigArray = [
         checkboxArgTypes,
         '../../libs/components/src/form/checkbox/stories/vl-checkbox.stories-doc.mdx',
         '/docs/components-form-checkbox--documentatie'
+    ),
+    buildWTConfig(
+        'vl-composite-input-next',
+        compositeInputArgTypes,
+        '../../libs/components/src/form/next/composite-input/stories/vl-composite-input.stories-doc.mdx',
+        '/docs/components-form-next-composite-input--documentatie'
     ),
     buildWTConfig(
         'vl-datepicker',

--- a/resources/generate-web-types/wt-validate-completeness/compare-wc-wt-components-form.ts
+++ b/resources/generate-web-types/wt-validate-completeness/compare-wc-wt-components-form.ts
@@ -3,11 +3,21 @@ import { extractComponentsFormWTNames } from './extract-wt-names';
 
 const componentsFormWCNames = extractComponentsFormWCNames();
 const componentsFormWTNames = extractComponentsFormWTNames();
+const componentsFormWCMismatch = [
+    'vl-composite-input', // in next folder - naam komt niet overeen met bestandsnaam (WT is vl-composite-input-next)
+];
+const componentsFormWTMismatch = [
+    'vl-composite-input-next', // in next folder - naam komt niet overeen met bestandsnaam (WC is vl-composite-input)
+];
 
 export const componentsFormWCNameCount = componentsFormWCNames.length;
 export const componentsFormWTNameCount = componentsFormWTNames.length;
-export const componentsFormWCWithoutWT = componentsFormWCNames.filter((name) => !componentsFormWTNames.includes(name));
-export const componentsFormWTWithoutWC = componentsFormWTNames.filter((name) => !componentsFormWCNames.includes(name));
+export const componentsFormWCWithoutWT = componentsFormWCNames.filter(
+    (name) => !componentsFormWCMismatch.includes(name) && !componentsFormWTNames.includes(name)
+);
+export const componentsFormWTWithoutWC = componentsFormWTNames.filter(
+    (name) => !componentsFormWTMismatch.includes(name) && !componentsFormWCNames.includes(name)
+);
 
 // console.log('componentsForm - aantal web-components:', componentsFormWCNameCount);
 // console.log('componentsForm - aantal web-types:', componentsFormWTNameCount);

--- a/resources/generate-web-types/wt-validate-completeness/web-types-completeness.spec.ts
+++ b/resources/generate-web-types/wt-validate-completeness/web-types-completeness.spec.ts
@@ -47,8 +47,8 @@ describe('jest - generate-web-types - web-types-completeness', () => {
         expect(componentsComplianceWTWithoutWC).toStrictEqual([]);
     });
     it('components-form - valideer de volledigheid van de web-types', () => {
-        expect(componentsFormWCNameCount).toEqual(14);
-        expect(componentsFormWTNameCount).toEqual(14);
+        expect(componentsFormWCNameCount).toEqual(15);
+        expect(componentsFormWTNameCount).toEqual(15);
         expect(componentsFormWCWithoutWT).toStrictEqual([]);
         expect(componentsFormWTWithoutWC).toStrictEqual([]);
     });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,6 +39,9 @@
             "@domg-wc/components/form": [
                 "libs/components/src/form/index.ts"
             ],
+            "@domg-wc/components/form/next": [
+                "libs/components/src/form/next/index.ts"
+            ],
             "@domg-wc/integrations/form": [
                 "libs/integrations/src/form/index.ts"
             ],


### PR DESCRIPTION
## Wat

`vl-composite-input-next`: een form-associated control voor velden die samen één logische waarde vormen (coördinaat, getal + eenheid, van/tot-bereik). Eén gezamenlijke geldigheid en één foutmelding voor het geheel.

De kinderen dienen zichzelf in onder hun eigen `name`; die `name` is ook de sleutel in de validator. De composite heeft geen eigen waarde: ze valideert de velden samen via `required` (`valueMissing`) en een `customValidator` (`customError`). Laat je een `vl-form-message` leeg, dan vult ze de tekst zelf in.

Storybook: componentpagina onder **Components - Form / next / composite-input**, en de patroonpagina onder **Patronen / Formulier / samengesteld veld** met vier voorbeelden (coördinaten, getal + eenheid, datumbereik, contactmethode).

## Verificatie

`tsc` groen, cypress component-tests 29/29, `libs:web-types:validate` groen, `apps:storybook:build` groen.

## Variant

Op [`feature-v2/FLUX-658-composite-input-mixin`](https://github.com/milieuinfo/flux-web-components/tree/feature-v2/FLUX-658-composite-input-mixin) staat dezelfde uitwerking zonder gepubliceerde component. Het gedeelde gedrag zit daar in een `CompositeInputMixin` uit `@domg-wc/components/form`; de component zelf (tag en markup, een vijftigtal regels) registreer je in je eigen project. Zo is er geen tag en geen componentpagina die we moeten onderhouden.
