### PR TITLE
fix: FLUX-243 - vl-loader - beleefde laadstatus voor screenreaders

### DIFF
--- a/libs/components/src/block/loader/stories/vl-loader.stories-doc.mdx
+++ b/libs/components/src/block/loader/stories/vl-loader.stories-doc.mdx
@@ -1,0 +1,70 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlLoaderStories from './vl-loader.stories';
+
+# Loader
+
+<FluxComponentMetaData id="components-block-loader" />
+
+## Doel
+
+Gebruik `vl-loader` om aan te geven dat er iets aan het laden is. De component toont een animerende
+laadindicator met daaronder een informatieve tekst.
+
+## Voorbeeld
+
+```js
+import { VlLoaderComponent } from '@domg-wc/components/block';
+```
+
+```html
+<vl-loader></vl-loader>
+```
+
+<Canvas of={VlLoaderStories.loaderDefault} />
+
+## Configuratie
+
+<ArgTypes of={VlLoaderStories.loaderDefault} />
+
+## Varianten
+
+### Light
+
+Gebruik het attribuut `light` voor een alternatieve weergave op een donkere achtergrond.
+
+<Canvas of={VlLoaderStories.loaderLightWithoutText} />
+
+### Aangepaste inhoud
+
+Gebruik de slot om de standaardtekst te vervangen door eigen (opgemaakte) inhoud.
+
+<Canvas of={VlLoaderStories.loaderWithCustomContent} />
+
+## Toegankelijkheid
+
+De tekst van de loader staat in een `role="status"` live region. Daardoor kondigt een screenreader de
+laadstatus **beleefd** (`aria-live="polite"`) aan: de melding onderbreekt andere aankondigingen niet, maar
+wordt voorgelezen zodra de gebruiker even pauzeert.
+
+Een live region wordt echter enkel voorgelezen wanneer de screenreader een **wijziging** in de inhoud
+detecteert. Een `vl-loader` die je op het moment van laden in de DOM injecteert, wordt door de meeste
+screenreaders niet betrouwbaar aangekondigd — de inhoud was er immers "altijd al".
+
+Om de laadstatus wél betrouwbaar te laten voorlezen, hou je je aan dit patroon:
+
+1. Plaats de `vl-loader` **van bij het laden van de pagina** in de DOM, maar verborgen en zonder tekst.
+2. Zodra het laden begint, maak je de loader zichtbaar en vul je de tekst in (bv. `Pagina is aan het laden`).
+
+Het is de overgang van lege tekst naar tekst die de screenreader triggert om voor te lezen.
+
+```html
+<!-- Bij paginalaad: aanwezig, verborgen en zonder tekst -->
+<vl-loader hidden text=""></vl-loader>
+```
+
+```js
+// Zodra het laden start: zichtbaar maken en tekst invullen
+const loader = document.querySelector('vl-loader');
+loader.hidden = false;
+loader.setAttribute('text', 'Pagina is aan het laden');
+```

--- a/libs/components/src/block/loader/stories/vl-loader.stories.ts
+++ b/libs/components/src/block/loader/stories/vl-loader.stories.ts
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import '../vl-loader.component';
 import { loaderArgs, loaderArgTypes } from './vl-loader.stories-arg';
+import loaderDoc from './vl-loader.stories-doc.mdx';
 
 export default {
     id: 'components-block-loader',
@@ -9,6 +10,11 @@ export default {
     tags: ['autodocs'],
     args: loaderArgs,
     argTypes: loaderArgTypes,
+    parameters: {
+        docs: {
+            page: loaderDoc,
+        },
+    },
 } as Meta<typeof loaderArgs>;
 
 export const loaderDefault = ({ light, text, single }: typeof loaderArgs) => html`

--- a/libs/components/src/block/loader/vl-loader.component.cy.ts
+++ b/libs/components/src/block/loader/vl-loader.component.cy.ts
@@ -63,4 +63,11 @@ describe('cypress-component - block components - vl-loader', () => {
         cy.mount(html`<vl-loader single></vl-loader>`);
         cy.get('vl-loader').shadow().find('#text').should('have.class', 'vl-u-visually-hidden');
     });
+
+    it('should announce loading status politely with role="status" on the text element and no aria-busy', () => {
+        cy.mount(html`<vl-loader></vl-loader>`);
+        cy.get('vl-loader').shadow().find('#text').should('have.attr', 'role', 'status');
+        cy.get('vl-loader').shadow().find('.vl-loader').should('not.have.attr', 'role');
+        cy.get('vl-loader').shadow().find('.vl-loader').should('not.have.attr', 'aria-busy');
+    });
 });

--- a/libs/components/src/block/loader/vl-loader.component.ts
+++ b/libs/components/src/block/loader/vl-loader.component.ts
@@ -11,8 +11,8 @@ export class VlLoaderComponent extends BaseHTMLElement {
     constructor() {
         const html = `
             <div class="vl-u-align-center">
-                <div class="vl-loader" role="alert" aria-busy="true"></div>
-                <p id="text">
+                <div class="vl-loader"></div>
+                <p id="text" role="status">
                     <slot>
                         Pagina is aan het laden
                     </slot>


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-243
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC404

## Samenvatting
`vl-loader` kondigt de laadstatus nu beleefd aan bij screenreaders in plaats van andere meldingen te onderbreken. Voor consumers van de component verandert er niets aan de API.

## Wijzigingen
- `role="alert"` op de laadindicator vervangen door `role="status"`, zodat de aankondiging polite (`aria-live="polite"`) is en niet-onderbrekend.
- `aria-busy="true"` verwijderd van de laadindicator; dat attribuut hoort op een laadende container, niet op de indicator zelf.
- Cypress-test toegevoegd die de `role="status"` en de afwezigheid van `aria-busy` borgt tegen regressie.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `aria-busy="true"` verwijderd van het loader-element — verwijderd op de `.vl-loader`-div.
- [x] `role="alert"` vervangen door `role="status"` op datzelfde element — doorgevoerd.
- [x] Screenreader kondigt beleefd (polite) aan i.p.v. assertief — `role="status"` impliceert `aria-live="polite"`.
- [x] Reduced-motion-query blijft behouden — ongewijzigd gelaten.
- [x] Test borgt de nieuwe ARIA-rol — nieuwe Cypress-assertie op `role="status"` en geen `aria-busy`.
