### PR TITLE
fix: FLUX-213 - vl-link - screenreadermelding bij externe links

### DIFF
--- a/libs/components/src/atom/link-style/vl-link-style.css.ts
+++ b/libs/components/src/atom/link-style/vl-link-style.css.ts
@@ -1,4 +1,4 @@
-import { vlFocusOutlineMixin, vlMediaScreenSmall } from '@domg-wc/styles';
+import { vlFocusOutlineMixin, vlMediaScreenSmall, vlVisuallyHiddenMixin } from '@domg-wc/styles';
 import { css, unsafeCSS } from 'lit';
 
 export const vlLinkStyles = (selector = 'a') => css`
@@ -103,6 +103,11 @@ export const vlLinkStyles = (selector = 'a') => css`
 
         &.error:visited .vl-icon.vl-icon--external {
             color: var(--vl-color--icon-subtle);
+        }
+
+        /* bij externe links: visueel verbergen, maar wel voorlezen door screenreaders */
+        .vl-link__new-window-hint {
+            ${vlVisuallyHiddenMixin()};
         }
 
         &.neutral {

--- a/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories-arg.ts
@@ -35,7 +35,7 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     label: {
         name: 'label',
         description:
-            'Vult het aria-label attribuut van de link in. Geef een duidelijke omschrijving mee van waar de link naartoe leidt. bv "Ga naar Vlaanderen.be (opent in een nieuw venster)',
+            'Vult het aria-label attribuut van de link in en vervangt zo de volledige voorgelezen linktekst. Geef een duidelijke omschrijving mee van waar de link naartoe leidt.<br/>Bij een externe link wordt de automatische melding "(opent in een nieuw venster)" dan niet toegevoegd; neem die vermelding zelf op in het label, bv. "Ga naar Vlaanderen.be (opent in een nieuw venster)".',
         table: {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
@@ -90,7 +90,8 @@ export const linkArgTypes: ArgTypes<LinkArgs> = {
     },
     external: {
         name: 'external',
-        description: 'Opent de link in een nieuw tabblad.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.',
+        description:
+            'Opent de link in een nieuw tabblad.<br/>Voegt voor schermlezers automatisch de visueel verborgen tekst "(opent in een nieuw venster)" toe, tenzij het `label`-attribuut gezet is.<br/>Werkt niet in combinatie met `button-as-link`-attribuut.',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
+++ b/libs/components/src/atom/link/stories/vl-link.stories-doc.mdx
@@ -49,7 +49,15 @@ import { VlLinkComponent } from '@domg-wc/components/atom';
 
 ### External
 
-Vul steeds het `label` attribuut in om duidelijk te maken dat de link in een nieuw venster opent.
+Een externe link opent in een nieuw tabblad en toont automatisch het external icoon na de linktekst.
+
+Voor schermlezers voegt de component automatisch de visueel verborgen tekst "(opent in een nieuw venster)" toe na de
+linktekst. Je hoeft dit dus niet zelf te voorzien. Het external icoon zelf is decoratief (`aria-hidden`) en wordt niet
+voorgelezen.
+
+Gebruik je het `label` attribuut, dan vervangt dat de volledige voorgelezen linktekst en wordt de automatische melding
+niet toegevoegd. Neem in dat geval zelf de vermelding op, bv.
+`label="Ga naar Vlaanderen.be (opent in een nieuw venster)"`.
 
 <Canvas of={VlLinkStories.LinkExternal} />
 
@@ -116,10 +124,13 @@ Zorg er steeds voor dat de link een duidelijke en beknopte tekstuele beschrijvin
 wordt bij het klikken op de link. Dit is belangrijk voor alle gebruikers, maar vooral voor gebruikers die schermlezers
 gebruiken.
 
-Zorg er bij externe links voor dat gebruikers weten dat de link in een nieuw venster opent. Dit kan je doen adhv het
-`external` attribuut en door dit expliciet te vermelden in de linktekst of door het `label` attribuut te gebruiken om
-een beschrijvende `aria-label` toe te voegen aan de link. Indien `label` gebruikt wordt, is dit de enige linktekst die
-door schermlezers wordt voorgelezen. Dus neem ook de zichtbare linktekst hierin op.
+Bij externe links (het `external` attribuut) meldt de component zelf aan schermlezers dat de link in een nieuw venster
+opent: na de linktekst wordt de visueel verborgen tekst "(opent in een nieuw venster)" voorgelezen. Je hoeft dit dus
+niet zelf te voorzien in de linktekst of via het `label` attribuut.
+
+Indien `label` gebruikt wordt, is dit de enige linktekst die door schermlezers wordt voorgelezen; de automatische
+melding wordt dan niet toegevoegd. Neem in dat geval zowel de zichtbare linktekst als de vermelding "(opent in een
+nieuw venster)" op in het label.
 
 Indien de link enkel een icoon bevat, is het verplicht om het `label` attribuut te gebruiken zodat een beschrijvende
 `aria-label` wordt toegevoegd aan de link.

--- a/libs/components/src/atom/link/stories/vl-link.stories.ts
+++ b/libs/components/src/atom/link/stories/vl-link.stories.ts
@@ -109,7 +109,6 @@ LinkExternal.args = {
     href: 'https://www.vlaanderen.be',
     defaultSlot: 'Vlaanderen',
     external: true,
-    label: 'Ga naar Vlaanderen.be (opent in een nieuw venster)',
 };
 
 export const LinkIcon = LinkTemplate.bind({});

--- a/libs/components/src/atom/link/vl-link.component.cy.ts
+++ b/libs/components/src/atom/link/vl-link.component.cy.ts
@@ -61,6 +61,45 @@ describe('cypress-component - atom components - vl-link', () => {
         cy.get('vl-link').shadow().find('a').should('have.attr', 'rel', 'noopener noreferrer nofollow');
     });
 
+    it('should announce the new window hint for external links', () => {
+        cy.mount(html`<vl-link external href="https://www.vlaanderen.be">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link')
+            .shadow()
+            .find('a .vl-link__new-window-hint')
+            .should('exist')
+            .should('contain.text', '(opent in een nieuw venster)');
+    });
+
+    it('should keep the external icon decorative next to the new window hint', () => {
+        cy.mount(html`<vl-link external href="https://www.vlaanderen.be">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('a .vl-icon--external').should('have.attr', 'aria-hidden', 'true');
+    });
+
+    it('should not announce the new window hint for non-external links', () => {
+        cy.mount(html`<vl-link href="https://www.vlaanderen.be">Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('a .vl-link__new-window-hint').should('not.exist');
+    });
+
+    it('should not announce the new window hint when a label is set', () => {
+        cy.mount(
+            html`<vl-link external href="https://www.vlaanderen.be" label="Ga naar Vlaanderen (opent in een nieuw venster)"
+                >Vlaanderen</vl-link
+            >`
+        );
+
+        cy.get('vl-link').shadow().find('a .vl-link__new-window-hint').should('not.exist');
+    });
+
+    it('should be accessible as an external link', () => {
+        cy.mount(html`<vl-link external href="https://www.vlaanderen.be">Vlaanderen</vl-link>`);
+        cy.injectAxe();
+
+        cy.checkA11y('vl-link');
+    });
+
     it('should set download without filename', () => {
         cy.mount(html`<vl-link download href="data:text/plain,demo">Download</vl-link>`);
 
@@ -202,6 +241,12 @@ describe('cypress-component - atom components - vl-link - button as link', () =>
 
         cy.get('vl-link').should('have.attr', 'external');
         cy.get('vl-link').shadow().find('button').should('not.have.attr', 'target');
+    });
+
+    it('should not announce the new window hint (button does not open a new window)', () => {
+        cy.mount(html`<vl-link button-as-link external>Vlaanderen</vl-link>`);
+
+        cy.get('vl-link').shadow().find('button .vl-link__new-window-hint').should('not.exist');
     });
 
     it('should set icon', () => {

--- a/libs/components/src/atom/link/vl-link.component.ts
+++ b/libs/components/src/atom/link/vl-link.component.ts
@@ -119,7 +119,9 @@ export class VlLinkComponent extends BaseLitElement {
         // Inline wrapper bij externe links: anders is het external icon een aparte
         // flex-child die bij wrappende tekst los rechts hangt i.p.v. na het laatste woord.
         return this.external
-            ? html`${before}<span class="vl-link__content"><slot></slot>${after}${this.renderExternalIcon()}</span>`
+            ? html`${before}<span class="vl-link__content"
+                      ><slot></slot>${after}${this.renderExternalIcon()}${this.renderNewWindowHint()}</span
+                  >`
             : html`${before}<slot></slot>${after}`;
     }
 
@@ -139,6 +141,15 @@ export class VlLinkComponent extends BaseLitElement {
 
     private renderExternalIcon(): TemplateResult {
         return html`<span class="vl-icon vl-icon--external vl-icon--after" part="icon" aria-hidden="true"></span>`;
+    }
+
+    private renderNewWindowHint(): TemplateResult | typeof nothing {
+        // een button-as-link opent geen nieuw venster
+        // een gezet label zet ook het aria-label en vervangt de volledige accessible name
+        //  -> de consumer bepaalt in dat geval zelf de bewoording
+        return !this.buttonAsLink && !this.label
+            ? html`<span class="vl-link__new-window-hint"> (opent in een nieuw venster)</span>`
+            : nothing;
     }
 }
 

--- a/libs/components/src/block/contact-card/stories/vl-contact-card.stories.ts
+++ b/libs/components/src/block/contact-card/stories/vl-contact-card.stories.ts
@@ -51,11 +51,7 @@ export const contactCardDefault = story(
                 </vl-property-data>
                 <vl-property>Website</vl-property>
                 <vl-property-data>
-                    <vl-link
-                        href="http://onderwijs.vlaanderen.be"
-                        external
-                        label="Ga naar onderwijs.vlaanderen.be (opent in een nieuw venster)"
-                    >
+                    <vl-link href="http://onderwijs.vlaanderen.be" external>
                         http://onderwijs.vlaanderen.be</vl-link
                     >
                 </vl-property-data>


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-213

## Samenvatting
Externe links kondigen voor screenreaders nu automatisch "(opent in een nieuw venster)" aan, zonder dat de zichtbare linktekst (bv. de URL) verloren gaat. De cue werkt over de hele library heen voor elke externe `vl-link`, dus consumers hoeven ze niet per link zelf toe te voegen.

## Wijzigingen
- Externe links krijgen een visueel-verborgen "(opent in een nieuw venster)"-tekst náást het decoratieve external-icoon, zodat de melding ook auditief beschikbaar is (WCAG 1.1.1).
- Het external-icoon blijft `aria-hidden="true"` en de zichtbare linktekst wordt aangevuld i.p.v. vervangen.
- Precedentie: een expliciet `label` blijft de accessible name bepalen, en een `button-as-link` (opent geen nieuw venster) krijgt geen cue — zo ontstaat er geen dubbele of onjuiste aankondiging.
- De `vl-contact-card` default-story is opgeschoond (redundant `label` verwijderd) zodat ze het automatische gedrag toont met behoud van de zichtbare URL.

## Backwards compatibility
Additieve wijziging zonder API-breaking change; enkel de screenreader-output van bestaande external links krijgt een extra zin (de bedoelde a11y-verbetering), een gezet `label` blijft voorrang houden.

## Succescriteria
- [x] Screenreader kondigt doel + "(opent in een nieuw venster)" aan zonder verlies van de zichtbare URL — sr-only span augmenteert de accessible name binnen de `<a>`.
- [x] External-icoon blijft `aria-hidden="true"` (decoratief) — ongewijzigd en met test geborgd.
- [x] Cue automatisch aanwezig zodra `external` gezet is (of gedocumenteerd) — geen consumer-actie nodig; bestaand `label` wint.
- [x] Contact-card default-story external website-link gaat door axe zonder 1.1.1-violation — gedekt via axe-audit op de external `vl-link` (contact-card is pure slot-layout).
