### PR TITLE
feat: FLUX-471 - vl-header, vl-header-next - skip-to-content link (WCAG 2.4.1)

### DIFF
--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -33,6 +33,7 @@ export {
     SKIP_TO_CONTENT_MISSING_ID_WARNING,
     createSkipToContentLink,
 } from './util/skip-link';
+export { getStickyOffsetTop, scrollIntoViewBelowSticky } from './util/sticky-scroll';
 export {
     awaitScript,
     awaitUntil,

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -29,6 +29,11 @@ export { type VL } from './models/vl.model';
 export { GlobalStyles } from './styles/global-styles';
 export { onChildListChange } from './util/mutation-utils';
 export {
+    SKIP_TO_CONTENT_LINK_TEXT,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
+    createSkipToContentLink,
+} from './util/skip-link';
+export {
     awaitScript,
     awaitUntil,
     debounce,

--- a/libs/common/src/util/anchor-navigation.cy.ts
+++ b/libs/common/src/util/anchor-navigation.cy.ts
@@ -33,6 +33,29 @@ describe('cypress-component - common - anchor-navigation utility', () => {
         cy.window().its('location.hash').should('eq', '');
     });
 
+    it('should scroll the target below a fixed page header instead of behind it', () => {
+        cy.mount(html`
+            <vl-typography>
+                <div style="height: 800px"></div>
+                <h2 id="doel">Doel</h2>
+                <div style="height: 1500px"></div>
+            </vl-typography>
+            <div style="position: fixed; top: 0; left: 0; right: 0; height: 60px; background: #05c"></div>
+        `);
+
+        cy.then(() => {
+            expect(navigateToAnchor('#doel')).to.equal(true);
+        });
+
+        // vl-typography rendert de inhoud in zijn shadow root; dat is de kopie die effectief gescrold wordt.
+        cy.get('vl-typography')
+            .shadow()
+            .find('#doel')
+            .then(([doel]) => {
+                expect(doel.getBoundingClientRect().top).to.be.closeTo(60, 1);
+            });
+    });
+
     it('should update the hash via navigateToAnchor() when updateHash is enabled', () => {
         cy.mount(html`
             <vl-typography>

--- a/libs/common/src/util/anchor-navigation.ts
+++ b/libs/common/src/util/anchor-navigation.ts
@@ -1,3 +1,4 @@
+import { scrollIntoViewBelowSticky } from './sticky-scroll';
 import { findDeepestElementThroughShadowRoot } from './utils';
 
 /**
@@ -17,8 +18,9 @@ declare global {
 
 /**
  * Navigeert naar een same-page anchor en zoekt het doel pagina-breed door alle (open) shadow roots
- * én de light DOM. Bij een treffer wordt er gescrold, de focus mee verplaatst (WCAG 2.4.3) en
- * optioneel de URL-hash bijgewerkt.
+ * én de light DOM. Bij een treffer wordt er gescrold - onder eventuele sticky of fixed page chrome,
+ * zie {@link scrollIntoViewBelowSticky} - de focus mee verplaatst (WCAG 2.4.3) en optioneel de
+ * URL-hash bijgewerkt.
  *
  * @param hash - de hash of het id van het doel (met of zonder leidende `#`)
  * @param options.updateHash - of de URL-hash bijgewerkt mag worden via `history.pushState` (default false).
@@ -37,7 +39,7 @@ export const navigateToAnchor = (hash: string, { updateHash = false }: { updateH
         return false;
     }
 
-    target.scrollIntoView();
+    scrollIntoViewBelowSticky(target);
 
     // Verplaats focus naar het doel zodat toetsenbord-/screenreader-context meeschuift (WCAG 2.4.3).
     if (target.tabIndex < 0) {

--- a/libs/common/src/util/skip-link.ts
+++ b/libs/common/src/util/skip-link.ts
@@ -1,0 +1,32 @@
+import { navigateToAnchor } from './anchor-navigation';
+
+export const SKIP_TO_CONTENT_LINK_TEXT = 'Ga meteen naar de inhoud';
+
+export const SKIP_TO_CONTENT_MISSING_ID_WARNING = [
+    'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
+    'Gebruik hiervoor de ID van de eerste heading van de content.',
+    '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)',
+] as const;
+
+/**
+ * Bouwt een `<a class="vl-skip-link">` waarmee toetsenbordgebruikers het header-blok kunnen overslaan
+ * (WCAG 2.4.1). De link is visueel verborgen tot hij focus krijgt (zie `vlAccessibilityStyles`) en
+ * verplaatst bij activatie de focus en de scroll naar het doel-element - pagina-breed gezocht, ook
+ * diep in shadow roots. Bestaat het doel niet, dan doet de link niets.
+ */
+export const createSkipToContentLink = (skipToContentId: string): HTMLAnchorElement => {
+    const href = `${skipToContentId.startsWith('#') ? '' : '#'}${skipToContentId}`;
+
+    const skipLink = document.createElement('a');
+    skipLink.setAttribute('href', href);
+    skipLink.classList.add('vl-skip-link');
+    skipLink.textContent = SKIP_TO_CONTENT_LINK_TEXT;
+
+    skipLink.addEventListener('click', (event: MouseEvent) => {
+        // navigateToAnchor onderdrukt de native sprong niet zelf; doe dat hier zodat focus + scroll de enige actie zijn.
+        event.preventDefault();
+        navigateToAnchor(href);
+    });
+
+    return skipLink;
+};

--- a/libs/common/src/util/sticky-scroll.cy.ts
+++ b/libs/common/src/util/sticky-scroll.cy.ts
@@ -1,0 +1,160 @@
+import { html } from 'lit';
+import { getStickyOffsetTop, scrollIntoViewBelowSticky } from './sticky-scroll';
+
+const FIXED_HEADER_HEIGHT = 60;
+const STICKY_BAR_HEIGHT = 40;
+
+// Een component met de fixed balk in zijn shadow root, zoals de header-widget die vl-header inlaadt.
+class StickyScrollTestHeader extends HTMLElement {
+    connectedCallback() {
+        if (this.shadowRoot) {
+            return;
+        }
+        this.attachShadow({ mode: 'open' }).innerHTML =
+            `<div style="position: fixed; top: 0; left: 0; right: 0; height: ${FIXED_HEADER_HEIGHT}px; background: #05c;"></div>`;
+    }
+}
+
+if (!customElements.get('vl-sticky-scroll-test-header')) {
+    customElements.define('vl-sticky-scroll-test-header', StickyScrollTestHeader);
+}
+
+const fixedHeader = (height = FIXED_HEADER_HEIGHT) =>
+    html`<div
+        data-cy="fixed-header"
+        style="position: fixed; top: 0; left: 0; right: 0; height: ${height}px; background: #05c;"
+    ></div>`;
+
+// Een tweede balk die net onder de fixed header blijft plakken - zoals een sticky vl-functional-header
+// onder de globale header.
+const stickyBar = () =>
+    html`<div
+        data-cy="sticky-bar"
+        style="position: sticky; top: ${FIXED_HEADER_HEIGHT}px; height: ${STICKY_BAR_HEIGHT}px; background: #fa0;"
+    ></div>`;
+
+// Genoeg inhoud voor en na het doel zodat het altijd tot bovenaan de viewport gescrold kan worden.
+const contentWithTarget = () => html`
+    <div style="height: 800px"></div>
+    <h2 data-cy="doel" id="doel">Doel</h2>
+    <div style="height: 1500px"></div>
+`;
+
+const getTarget = () => Cypress.$('[data-cy=doel]')[0] as HTMLElement;
+
+const getTargetTop = () => getTarget().getBoundingClientRect().top;
+
+describe('cypress-component - common - sticky-scroll utility - getStickyOffsetTop()', () => {
+    beforeEach(() => {
+        cy.viewport(800, 600);
+        cy.window().then((win) => win.scrollTo(0, 0));
+    });
+
+    it('should return 0 when there is no sticky or fixed page chrome', () => {
+        cy.mount(html`<div>${contentWithTarget()}</div>`);
+
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(0));
+    });
+
+    it('should measure the height of a fixed header at the top of the viewport', () => {
+        cy.mount(html`<div>${fixedHeader()}${contentWithTarget()}</div>`);
+
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(FIXED_HEADER_HEIGHT));
+    });
+
+    it('should measure stacked chrome (a sticky bar below a fixed header) as one whole', () => {
+        cy.mount(html`<div>${fixedHeader()}${stickyBar()}${contentWithTarget()}</div>`);
+
+        // De sticky balk klikt vast onder de fixed header zodra er gescrold wordt.
+        cy.window().then((win) => win.scrollTo(0, 500));
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(FIXED_HEADER_HEIGHT + STICKY_BAR_HEIGHT));
+    });
+
+    it('should measure chrome that sits inside a shadow root', () => {
+        cy.mount(html`
+            <div>
+                <vl-sticky-scroll-test-header></vl-sticky-scroll-test-header>
+                ${contentWithTarget()}
+            </div>
+        `);
+
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(FIXED_HEADER_HEIGHT));
+    });
+
+    it('should ignore sticky content in another column than the target', () => {
+        cy.mount(html`
+            <div>
+                <div
+                    data-cy="side"
+                    style="position: sticky; top: 0; float: left; width: 200px; height: 400px; background: #ddd;"
+                ></div>
+                <div style="margin-left: 300px">${contentWithTarget()}</div>
+            </div>
+        `);
+
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(0));
+    });
+
+    it('should never claim more than half of the viewport height', () => {
+        cy.mount(html`<div>${fixedHeader(500)}${contentWithTarget()}</div>`);
+
+        cy.then(() => expect(getStickyOffsetTop(getTarget())).to.equal(300));
+    });
+});
+
+describe('cypress-component - common - sticky-scroll utility - scrollIntoViewBelowSticky()', () => {
+    beforeEach(() => {
+        cy.viewport(800, 600);
+        cy.window().then((win) => win.scrollTo(0, 0));
+    });
+
+    it('should scroll the target below the fixed header instead of behind it', () => {
+        cy.mount(html`<div>${fixedHeader()}${contentWithTarget()}</div>`);
+
+        cy.then(() => {
+            scrollIntoViewBelowSticky(getTarget());
+
+            expect(getTargetTop()).to.be.closeTo(FIXED_HEADER_HEIGHT, 1);
+            expect(getTarget().style.scrollMarginTop).to.equal(`${FIXED_HEADER_HEIGHT}px`);
+        });
+    });
+
+    it('should scroll the target below stacked chrome', () => {
+        cy.mount(html`<div>${fixedHeader()}${stickyBar()}${contentWithTarget()}</div>`);
+
+        cy.then(() => {
+            scrollIntoViewBelowSticky(getTarget());
+
+            expect(getTargetTop()).to.be.closeTo(FIXED_HEADER_HEIGHT + STICKY_BAR_HEIGHT, 1);
+        });
+    });
+
+    it('should scroll the target to the top of the viewport when there is no chrome to avoid', () => {
+        cy.mount(html`<div>${contentWithTarget()}</div>`);
+
+        cy.then(() => {
+            scrollIntoViewBelowSticky(getTarget());
+
+            expect(getTargetTop()).to.be.closeTo(0, 1);
+            expect(getTarget().style.scrollMarginTop).to.equal('');
+        });
+    });
+
+    it('should leave a scroll-margin-top set by the consumer untouched', () => {
+        cy.mount(html`
+            <div>
+                ${fixedHeader()}
+                <div style="height: 800px"></div>
+                <h2 data-cy="doel" id="doel" style="scroll-margin-top: 100px">Doel</h2>
+                <div style="height: 1500px"></div>
+            </div>
+        `);
+
+        cy.then(() => {
+            scrollIntoViewBelowSticky(getTarget());
+
+            expect(getTargetTop()).to.be.closeTo(100, 1);
+            expect(getTarget().style.scrollMarginTop).to.equal('100px');
+        });
+    });
+});

--- a/libs/common/src/util/sticky-scroll.ts
+++ b/libs/common/src/util/sticky-scroll.ts
@@ -1,0 +1,123 @@
+/**
+ * Maximum aantal sticky/fixed lagen dat bovenaan de viewport op elkaar gestapeld gemeten wordt
+ * (bv. de globale header met daaronder een sticky functional header).
+ */
+const MAX_STICKY_LAYERS = 4;
+
+/**
+ * Bovengrens voor de gemeten sticky hoogte, als fractie van de viewporthoogte. Beschermt tegen
+ * schermvullende overlays (modals, cookiebanners) die het doel anders volledig uit beeld zouden duwen.
+ */
+const MAX_STICKY_OFFSET_RATIO = 0.5;
+
+/**
+ * Zoekt de elementen op een punt in de viewport, ook diep in (open) shadow roots. `elementsFromPoint`
+ * op het document stopt namelijk bij de host van een shadow root, terwijl de sticky balk zelf vaak
+ * net binnen die shadow root zit.
+ */
+const elementsFromPointThroughShadowRoot = (x: number, y: number): Element[] => {
+    const elements: Element[] = [];
+
+    const visit = (root: Document | ShadowRoot) => {
+        // Niet elke browser implementeert elementsFromPoint op een shadow root; dan meten we gewoon
+        // verder met wat de light DOM oplevert.
+        if (typeof root.elementsFromPoint !== 'function') {
+            return;
+        }
+
+        root.elementsFromPoint(x, y).forEach((element) => {
+            // Vanuit een shadow root worden ook de elementen erbuiten teruggegeven (geretarget naar de
+            // host); die zijn hier al gezien, dus de check voorkomt meteen ook eindeloze recursie.
+            if (elements.includes(element)) {
+                return;
+            }
+            elements.push(element);
+            if (element.shadowRoot) {
+                visit(element.shadowRoot);
+            }
+        });
+    };
+
+    visit(document);
+
+    return elements;
+};
+
+/**
+ * De onderkant (in viewportcoordinaten) waar een element bovenaan blijft plakken, of 0 wanneer het
+ * element niet meeschuift.
+ */
+const getStuckBottom = (element: Element): number => {
+    const style = getComputedStyle(element);
+    if (style.position !== 'fixed' && style.position !== 'sticky') {
+        return 0;
+    }
+
+    const { top, height } = element.getBoundingClientRect();
+    if (height <= 0) {
+        return 0;
+    }
+
+    // Een sticky element klikt vast op zijn eigen `top`-offset: zolang er niet ver genoeg gescrold is
+    // staat het lager dan die positie, dus rekenen we met de vastgeklikte positie i.p.v. de huidige.
+    const stickyTop = style.position === 'sticky' ? parseFloat(style.top) : NaN;
+
+    return (Number.isNaN(stickyTop) ? top : stickyTop) + height;
+};
+
+/**
+ * Meet hoeveel pixels bovenaan de viewport afgedekt worden door sticky of fixed page chrome (de
+ * globale header, een sticky functional header, ...) ter hoogte van `target`.
+ *
+ * Er wordt gemeten in de kolom van het doel zelf, zodat een sticky zijkolom naast de inhoud (bv. een
+ * side-navigation) niet meegeteld wordt. Vanaf de bovenrand wordt laag per laag naar beneden gekeken
+ * zolang er chrome op elkaar gestapeld staat.
+ *
+ * @param target - het element dat straks in beeld gescrold wordt
+ * @return de hoogte in pixels van de chrome bovenaan de viewport (0 als er geen is)
+ */
+export const getStickyOffsetTop = (target: HTMLElement): number => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = document.documentElement.clientHeight;
+
+    const { left, width } = target.getBoundingClientRect();
+    const centerX = width > 0 ? left + width / 2 : viewportWidth / 2;
+    const x = Math.min(Math.max(centerX, 1), viewportWidth - 1);
+    const maxOffset = viewportHeight * MAX_STICKY_OFFSET_RATIO;
+
+    let offset = 0;
+    for (let layer = 0; layer < MAX_STICKY_LAYERS && offset < maxOffset; layer++) {
+        const nextOffset = Math.max(0, ...elementsFromPointThroughShadowRoot(x, offset + 1).map(getStuckBottom));
+        if (nextOffset <= offset) {
+            break;
+        }
+        offset = nextOffset;
+    }
+
+    return Math.min(offset, maxOffset);
+};
+
+/**
+ * Scrolt een element in beeld en houdt daarbij rekening met sticky of fixed page chrome bovenaan de
+ * viewport: een gewone `scrollIntoView()` legt het doel tegen de bovenrand en dus achter die chrome.
+ *
+ * Er wordt eerst gescrold en pas daarna gemeten - zo staat de chrome in zijn definitieve (vastgeklikte)
+ * positie. Dekt ze het doel af, dan krijgt het doel een `scroll-margin-top` en wordt er opnieuw
+ * gescrold. Die `scroll-margin-top` blijft staan zodat ook latere (native) scrolls naar het element,
+ * bv. via de URL-hash, eronder uitkomen.
+ *
+ * @param target - het element dat in beeld gescrold wordt
+ */
+export const scrollIntoViewBelowSticky = (target: HTMLElement): void => {
+    target.scrollIntoView();
+
+    const offset = getStickyOffsetTop(target);
+    // Zit het doel al onder de chrome (bv. omdat de consumer zelf al een scroll-margin-top zette),
+    // dan is er niets te corrigeren.
+    if (offset <= 0 || target.getBoundingClientRect().top >= offset) {
+        return;
+    }
+
+    target.style.scrollMarginTop = `${offset}px`;
+    target.scrollIntoView();
+};

--- a/libs/components/src/block/functional-header/vl-functional-header.component.ts
+++ b/libs/components/src/block/functional-header/vl-functional-header.component.ts
@@ -1,9 +1,11 @@
 import {
     BaseHTMLElement,
+    createSkipToContentLink,
     findDeepestElementThroughShadowRoot,
     GlobalStyles,
     MARGINS,
     registerWebComponents,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
     webComponent,
 } from '@domg-wc/common';
 import { VlLinkComponent } from '@domg-wc/components/atom';
@@ -205,35 +207,9 @@ export class VlFunctionalHeaderComponent extends BaseHTMLElement {
         }
 
         if (this.hasAttribute('skip-to-content-id')) {
-            const skipToContentId = this.getAttribute('skip-to-content-id')!;
-            const targetId = `${skipToContentId.startsWith('#') ? '' : '#'}${skipToContentId}`;
-
-            const skipLink = document.createElement('a');
-            skipLink.setAttribute('href', targetId);
-            skipLink.classList.add('vl-skip-link');
-            skipLink.textContent = 'Ga meteen naar de inhoud';
-
-            skipLink.addEventListener('click', (e: MouseEvent) => {
-                e.preventDefault();
-                const target =
-                    document.querySelector<HTMLElement>(targetId) ||
-                    (findDeepestElementThroughShadowRoot(document.body, targetId) as HTMLElement);
-                const hasTabIndex = target.hasAttribute('tabindex');
-                if (!hasTabIndex) {
-                    target.setAttribute('tabindex', '-1');
-                }
-                target.focus();
-                target.scrollIntoView();
-            });
-
-            this._headerElement?.prepend(skipLink);
+            this._headerElement?.prepend(createSkipToContentLink(this.getAttribute('skip-to-content-id')!));
         } else {
-            console.warn(
-                'vl-functional-header -',
-                'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
-                'Gebruik hiervoor de ID van de eerste heading van de content.',
-                '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)'
-            );
+            console.warn('vl-functional-header -', ...SKIP_TO_CONTENT_MISSING_ID_WARNING);
         }
 
         this._updateStickyOffsetTop();

--- a/libs/components/src/compliance/header/stories/vl-header.stories-arg.ts
+++ b/libs/components/src/compliance/header/stories/vl-header.stories-arg.ts
@@ -105,6 +105,17 @@ export const headerArgTypes: ArgTypes<HeaderArgs> = {
             defaultValue: { summary: headerArgs.switchCapacityUrl },
         },
     },
+    skipToContentId: {
+        name: 'skip-to-content-id',
+        description:
+            'De id van het content-element waarnaar de skip-link de focus verplaatst (WCAG 2.4.1). Zonder waarde' +
+            ' wordt er geen skip-link gerenderd. Gebruik de id van de eerste heading van de pagina-inhoud.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.skipToContentId },
+        },
+    },
     rejectLogout: {
         name: 'reject-logout',
         description:

--- a/libs/components/src/compliance/header/stories/vl-header.stories.ts
+++ b/libs/components/src/compliance/header/stories/vl-header.stories.ts
@@ -37,6 +37,7 @@ export const HeaderDefault = story(
         simple,
         switchCapacityUrl,
         rejectLogout,
+        skipToContentId,
         logoutCallback,
         applicationLinks,
         onReady,
@@ -53,6 +54,7 @@ export const HeaderDefault = story(
                 ?skeleton=${skeleton}
                 switch-capacity-url=${switchCapacityUrl}
                 ?reject-logout=${rejectLogout}
+                skip-to-content-id=${skipToContentId}
                 .logoutCallback=${logoutCallback}
                 .applicationLinks=${applicationLinks}
                 @ready=${onReady}

--- a/libs/components/src/compliance/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/header/vl-header.component.cy.ts
@@ -144,6 +144,83 @@ describe('cypress-component - compliance components - vl-header - skeleton', () 
     });
 });
 
+describe('cypress-component - compliance components - vl-header - skip-to-content-id', () => {
+    const identifier = '59188ff6-662b-45b9-b23a-964ad48c2bfb';
+
+    it('should not create a skip-link when skip-to-content-id is not set', () => {
+        cy.mount(html`
+            <body>
+                <vl-header development identifier="${identifier}"></vl-header>
+            </body>
+        `);
+
+        cy.get('#header__container').find('a.vl-skip-link').should('not.exist');
+    });
+
+    it('should warn the user when skip-to-content-id is not set', () => {
+        cy.spy(console, 'warn').as('warn');
+
+        cy.mount(html`
+            <body>
+                <vl-header development identifier="${identifier}"></vl-header>
+            </body>
+        `);
+
+        cy.get('@warn').should(
+            'have.been.calledWith',
+            'vl-header -',
+            'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
+            'Gebruik hiervoor de ID van de eerste heading van de content.',
+            '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)'
+        );
+    });
+
+    it('should create the skip-link as the first focusable element in the header', () => {
+        cy.mount(html`
+            <body>
+                <vl-header development identifier="${identifier}" skip-to-content-id="main-content"></vl-header>
+            </body>
+        `);
+
+        cy.get('#header__container')
+            .children()
+            .first()
+            .should('match', 'a[href="#main-content"].vl-skip-link')
+            .and('contain.text', 'Ga meteen naar de inhoud');
+    });
+
+    it('should show the skip-link on focus', () => {
+        cy.mount(html`
+            <body>
+                <vl-header development identifier="${identifier}" skip-to-content-id="main-content"></vl-header>
+            </body>
+        `);
+
+        cy.get('#header__container')
+            .find('a.vl-skip-link')
+            .then(([skipLink]) => {
+                expect(skipLink.getBoundingClientRect().width).to.equal(1);
+                expect(skipLink.getBoundingClientRect().height).to.equal(1);
+                skipLink.focus();
+                expect(skipLink.getBoundingClientRect().width).to.be.greaterThan(1);
+                expect(skipLink.getBoundingClientRect().height).to.be.greaterThan(1);
+            });
+    });
+
+    it('should move focus to the target element when the skip-link is activated', () => {
+        cy.mount(html`
+            <body>
+                <vl-header development identifier="${identifier}" skip-to-content-id="main-content"></vl-header>
+                <main id="main-content">Inhoud</main>
+            </body>
+        `);
+
+        cy.get('#header__container').find('a.vl-skip-link').click({ force: true });
+
+        cy.get('#main-content').should('have.attr', 'tabindex', '-1').and('have.focus');
+    });
+});
+
 describe('cypress-component - compliance components - vl-header - applicationLinks', () => {
     const mockApplicationLinks: ApplicationLink[] = [
         {

--- a/libs/components/src/compliance/header/vl-header.component.ts
+++ b/libs/components/src/compliance/header/vl-header.component.ts
@@ -1,11 +1,14 @@
 import {
     awaitScript,
     BaseLitElement,
+    createSkipToContentLink,
     legacyBreakpoint,
     legacyCore,
     registerWebComponents,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
     webComponentCustom,
 } from '@domg-wc/common';
+import { vlAccessibilityStyles } from '@domg-wc/styles';
 import { PropertyDeclarations } from 'lit';
 import { headerContainerStyles, headerSkeletonStyles } from './vl-header.component.flux-css';
 import { headerDefaults } from './vl-header.defaults';
@@ -51,6 +54,7 @@ export class VlHeader extends BaseLitElement {
     private switchCapacityUrl = headerDefaults.switchCapacityUrl;
     private simple = headerDefaults.simple;
     private skeleton = headerDefaults.skeleton;
+    private skipToContentId = headerDefaults.skipToContentId;
     private rejectLogout = headerDefaults.rejectLogout;
     // Variables
     private observer: MutationObserver | null = null;
@@ -73,6 +77,7 @@ export class VlHeader extends BaseLitElement {
             logoutUrl: { type: String, attribute: 'logout-url' },
             simple: { type: Boolean, attribute: 'simple' },
             skeleton: { type: Boolean, attribute: 'skeleton' },
+            skipToContentId: { type: String, attribute: 'skip-to-content-id' },
             switchCapacityUrl: { type: String, attribute: 'switch-capacity-url' },
             rejectLogout: { type: Boolean, attribute: 'reject-logout' },
             logoutCallback: { type: Function },
@@ -92,6 +97,7 @@ export class VlHeader extends BaseLitElement {
         super.connectedCallback();
 
         this.injectHeaderContainer();
+        this.injectSkipToContentLink();
 
         if (this.skeleton) {
             this.injectHeaderContainerSkeleton();
@@ -160,6 +166,24 @@ export class VlHeader extends BaseLitElement {
     private injectHeaderContainerSkeleton() {
         this.headerContainer?.insertAdjacentHTML('afterend', '<div id="header__skeleton"></div>');
         document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerSkeletonStyles.styleSheet!];
+    }
+
+    private injectSkipToContentLink() {
+        if (!this.skipToContentId) {
+            console.warn('vl-header -', ...SKIP_TO_CONTENT_MISSING_ID_WARNING);
+            return;
+        }
+
+        if (this.headerContainer?.querySelector('.vl-skip-link')) {
+            return;
+        }
+
+        const styleSheet = vlAccessibilityStyles.styleSheet!;
+        if (!document.adoptedStyleSheets.includes(styleSheet)) {
+            document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+        }
+
+        this.headerContainer?.prepend(createSkipToContentLink(this.skipToContentId));
     }
 
     private observeWidgetIsAdded() {

--- a/libs/components/src/compliance/header/vl-header.defaults.ts
+++ b/libs/components/src/compliance/header/vl-header.defaults.ts
@@ -10,6 +10,7 @@ export const headerDefaults = {
     switchCapacityUrl: '/sso/wissel_organisatie' as string,
     simple: false as boolean,
     skeleton: false as boolean,
+    skipToContentId: '' as string,
     rejectLogout: false as boolean,
     logoutCallback: null as ((reason: string) => Promise<boolean>) | null,
     applicationLinks: [] as ApplicationLink[],

--- a/libs/components/src/compliance/next/header/stories/vl-header.stories-arg.ts
+++ b/libs/components/src/compliance/next/header/stories/vl-header.stories-arg.ts
@@ -96,6 +96,17 @@ export const headerArgTypes: ArgTypes<HeaderArgs> = {
             defaultValue: { summary: headerArgs.switchCapacityUrl },
         },
     },
+    skipToContentId: {
+        name: 'skip-to-content-id',
+        description:
+            'De id van het content-element waarnaar de skip-link de focus verplaatst (WCAG 2.4.1). Zonder waarde' +
+            ' wordt er geen skip-link gerenderd. Gebruik de id van de eerste heading van de pagina-inhoud.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.skipToContentId },
+        },
+    },
     applicationLinks: {
         name: 'applicationLinks',
         description: 'De links die getoond worden in de header.<br/>Zie de documentatie pagina voor meer informatie.',

--- a/libs/components/src/compliance/next/header/stories/vl-header.stories.ts
+++ b/libs/components/src/compliance/next/header/stories/vl-header.stories.ts
@@ -34,6 +34,7 @@ export const HeaderDefault = story(
         skeleton,
         simple,
         switchCapacityUrl,
+        skipToContentId,
         applicationLinks,
         profileTokenUrl,
         idpDataUrl,
@@ -51,6 +52,7 @@ export const HeaderDefault = story(
                 ?simple=${simple}
                 ?skeleton=${skeleton}
                 switch-capacity-url=${switchCapacityUrl}
+                skip-to-content-id=${skipToContentId}
                 profile-token-url=${profileTokenUrl}
                 idp-data-url=${idpDataUrl}
                 .applicationLinks=${applicationLinks}

--- a/libs/components/src/compliance/next/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.cy.ts
@@ -371,6 +371,93 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             expect(config).to.include({ idpProfileToken: 'fresh-token' });
         });
     });
+
+    describe('skip-to-content-id', () => {
+        it('should not create a skip-link when skip-to-content-id is not set', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next development identifier="${identifier}"></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container').find('a.vl-skip-link').should('not.exist');
+        });
+
+        it('should warn the user when skip-to-content-id is not set', () => {
+            cy.spy(console, 'warn').as('warn');
+
+            cy.mount(html`
+                <body>
+                    <vl-header-next development identifier="${identifier}"></vl-header-next>
+                </body>
+            `);
+
+            cy.get('@warn').should(
+                'have.been.calledWith',
+                'vl-header-next -',
+                'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
+                'Gebruik hiervoor de ID van de eerste heading van de content.',
+                '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)'
+            );
+        });
+
+        it('should create the skip-link as the first focusable element in the header', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container')
+                .children()
+                .first()
+                .should('match', 'a[href="#main-content"].vl-skip-link')
+                .and('contain.text', 'Ga meteen naar de inhoud');
+        });
+
+        it('should show the skip-link on focus', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container')
+                .find('a.vl-skip-link')
+                .then(([skipLink]) => {
+                    expect(skipLink.getBoundingClientRect().width).to.equal(1);
+                    expect(skipLink.getBoundingClientRect().height).to.equal(1);
+                    skipLink.focus();
+                    expect(skipLink.getBoundingClientRect().width).to.be.greaterThan(1);
+                    expect(skipLink.getBoundingClientRect().height).to.be.greaterThan(1);
+                });
+        });
+
+        it('should move focus to the target element when the skip-link is activated', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                    <main id="main-content">Inhoud</main>
+                </body>
+            `);
+
+            cy.get('#header__container').find('a.vl-skip-link').click({ force: true });
+
+            cy.get('#main-content').should('have.attr', 'tabindex', '-1').and('have.focus');
+        });
+    });
 });
 
 const stubWidgetScriptMinimal = () => ({

--- a/libs/components/src/compliance/next/header/vl-header.component.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.ts
@@ -1,11 +1,14 @@
 import {
     awaitScript,
     BaseLitElement,
+    createSkipToContentLink,
     legacyBreakpoint,
     legacyCore,
     registerWebComponents,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
     webComponent,
 } from '@domg-wc/common';
+import { vlAccessibilityStyles } from '@domg-wc/styles';
 import {
     ApplicationMenuLink,
     GlobalHeaderClient,
@@ -40,6 +43,7 @@ export class VlHeader extends BaseLitElement {
     private switchCapacityUrl = headerDefaults.switchCapacityUrl;
     private simple = headerDefaults.simple;
     private skeleton = headerDefaults.skeleton;
+    private skipToContentId = headerDefaults.skipToContentId;
     private profileTokenUrl = headerDefaults.profileTokenUrl;
     private idpDataUrl = headerDefaults.idpDataUrl;
     private initialSessionConfigured = false;
@@ -60,6 +64,7 @@ export class VlHeader extends BaseLitElement {
             logoutUrl: { type: String, attribute: 'logout-url' },
             simple: { type: Boolean, attribute: 'simple' },
             skeleton: { type: Boolean, attribute: 'skeleton' },
+            skipToContentId: { type: String, attribute: 'skip-to-content-id' },
             switchCapacityUrl: { type: String, attribute: 'switch-capacity-url' },
             applicationLinks: { type: Array },
             profileTokenUrl: { type: String, attribute: 'profile-token-url' },
@@ -81,6 +86,7 @@ export class VlHeader extends BaseLitElement {
         super.connectedCallback();
 
         this.injectHeaderContainer();
+        this.injectSkipToContentLink();
 
         if (this.skeleton) {
             this.injectHeaderContainerSkeleton();
@@ -138,6 +144,24 @@ export class VlHeader extends BaseLitElement {
     private injectHeaderContainerSkeleton() {
         this.headerContainer?.insertAdjacentHTML('afterend', '<div id="header__skeleton"></div>');
         document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerSkeletonStyles.styleSheet!];
+    }
+
+    private injectSkipToContentLink() {
+        if (!this.skipToContentId) {
+            console.warn('vl-header-next -', ...SKIP_TO_CONTENT_MISSING_ID_WARNING);
+            return;
+        }
+
+        if (this.headerContainer?.querySelector('.vl-skip-link')) {
+            return;
+        }
+
+        const styleSheet = vlAccessibilityStyles.styleSheet!;
+        if (!document.adoptedStyleSheets.includes(styleSheet)) {
+            document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+        }
+
+        this.headerContainer?.prepend(createSkipToContentLink(this.skipToContentId));
     }
 
     private async isUserAuthenticated(): Promise<boolean> {

--- a/libs/components/src/compliance/next/header/vl-header.defaults.ts
+++ b/libs/components/src/compliance/next/header/vl-header.defaults.ts
@@ -9,6 +9,7 @@ export const headerDefaults = {
     switchCapacityUrl: '/sso/wissel_organisatie' as string,
     simple: false as boolean,
     skeleton: false as boolean,
+    skipToContentId: '' as string,
     applicationLinks: [] as ApplicationMenuLink[],
     profileTokenUrl: '/sso/papi_token' as string,
     idpDataUrl: '' as string,

--- a/libs/integrations/src/page-layout/page-layout-example.component.ts
+++ b/libs/integrations/src/page-layout/page-layout-example.component.ts
@@ -37,7 +37,12 @@ export class VlPageLayoutExample extends LitElement {
         return html`
             <main>
                 <vl-template>
-                    <vl-header slot="header" identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb" development></vl-header>
+                    <vl-header
+                        slot="header"
+                        skip-to-content-id="#main-content"
+                        identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
+                        development
+                    ></vl-header>
 
                     <div slot="main">
                         <vl-functional-header
@@ -58,13 +63,11 @@ export class VlPageLayoutExample extends LitElement {
                                         </vl-title>
                                         <vl-alert icon="info-circle">
                                             ${this.isFullWidth
-                                                ? html`<span slot="title"
-                                                          >Alternatieve volledige breedte layout</span
-                                                      >
-                                                      Dit is een layout voor applicaties die de volledige
-                                                      schermbreedte nodig hebben. Gebruik dit enkel wanneer de
-                                                      standaard layout niet mogelijk is, bijvoorbeeld in het geval
-                                                      van uitgebreide data tabellen.`
+                                                ? html`<span slot="title">Alternatieve volledige breedte layout</span>
+                                                      Dit is een layout voor applicaties die de volledige schermbreedte
+                                                      nodig hebben. Gebruik dit enkel wanneer de standaard layout niet
+                                                      mogelijk is, bijvoorbeeld in het geval van uitgebreide data
+                                                      tabellen.`
                                                 : html`<span slot="title">Standaard layout</span>Dit is de standaard
                                                       layout voor applicaties. Gebruik de alternatieve "Volledige
                                                       breedte" variant enkel indien deze layout te smal is om alle
@@ -72,24 +75,23 @@ export class VlPageLayoutExample extends LitElement {
                                         </vl-alert>
 
                                         <vl-paragraph>
-                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus
-                                            nisi, pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed
-                                            eros porta vulputate. Sed sodales, nisl in dapibus venenatis, tellus
-                                            arcu molestie nunc, non facilisis est ante non odio. Pellentesque nec
-                                            auctor justo. Proin ut risus et felis faucibus gravida. Fusce congue,
-                                            est vitae eleifend pulvinar, justo erat semper magna, ut efficitur metus
-                                            dui ut lacus. Mauris nisl nisi, semper et metus a, sagittis accumsan
-                                            arcu. Nulla ultrices lectus nunc, eu tristique justo tempor non.
-                                            Vestibulum lobortis pharetra bibendum.
+                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus nisi,
+                                            pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed eros porta
+                                            vulputate. Sed sodales, nisl in dapibus venenatis, tellus arcu molestie
+                                            nunc, non facilisis est ante non odio. Pellentesque nec auctor justo. Proin
+                                            ut risus et felis faucibus gravida. Fusce congue, est vitae eleifend
+                                            pulvinar, justo erat semper magna, ut efficitur metus dui ut lacus. Mauris
+                                            nisl nisi, semper et metus a, sagittis accumsan arcu. Nulla ultrices lectus
+                                            nunc, eu tristique justo tempor non. Vestibulum lobortis pharetra bibendum.
                                         </vl-paragraph>
 
                                         <vl-title type="h2" id="content-1">Content 1</vl-title>
                                         <vl-paragraph>
-                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus
-                                            nisi, pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed
-                                            eros porta vulputate. Sed sodales, nisl in dapibus venenatis, tellus
-                                            arcu molestie nunc, non facilisis est ante non odio. Pellentesque nec
-                                            auctor justo. Proin ut risus et felis faucibus gravida.
+                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus nisi,
+                                            pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed eros porta
+                                            vulputate. Sed sodales, nisl in dapibus venenatis, tellus arcu molestie
+                                            nunc, non facilisis est ante non odio. Pellentesque nec auctor justo. Proin
+                                            ut risus et felis faucibus gravida.
                                         </vl-paragraph>
 
                                         <vl-title type="h3" id="content-1-1">Content 1 - 1</vl-title>
@@ -100,8 +102,8 @@ export class VlPageLayoutExample extends LitElement {
 
                                         <vl-title type="h3" id="content-1-2">Content 1 - 2</vl-title>
                                         <vl-paragraph>
-                                            Mauris nisl nisi, semper et metus a, sagittis accumsan arcu. Nulla
-                                            ultrices lectus nunc, eu tristique justo tempor non.
+                                            Mauris nisl nisi, semper et metus a, sagittis accumsan arcu. Nulla ultrices
+                                            lectus nunc, eu tristique justo tempor non.
                                         </vl-paragraph>
 
                                         <vl-title type="h3" id="content-1-3">Content 1 - 3</vl-title>
@@ -118,10 +120,10 @@ export class VlPageLayoutExample extends LitElement {
 
                                         <vl-title type="h2" id="content-2">Content 2</vl-title>
                                         <vl-paragraph>
-                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus
-                                            nisi, pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed
-                                            eros porta vulputate. Sed sodales, nisl in dapibus venenatis, tellus
-                                            arcu molestie nunc, non facilisis est ante non odio.
+                                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec purus nisi,
+                                            pulvinar sed lacinia vel, placerat in dolor. In lacinia magna sed eros porta
+                                            vulputate. Sed sodales, nisl in dapibus venenatis, tellus arcu molestie
+                                            nunc, non facilisis est ante non odio.
                                         </vl-paragraph>
 
                                         <vl-title type="h3" id="content-2-1">Content 2 - 1</vl-title>
@@ -137,8 +139,8 @@ export class VlPageLayoutExample extends LitElement {
 
                                         <vl-title type="h3" id="content-2-3">Content 2 - 3</vl-title>
                                         <vl-paragraph>
-                                            Mauris nisl nisi, semper et metus a, sagittis accumsan arcu. Nulla
-                                            ultrices lectus nunc, eu tristique justo tempor non.
+                                            Mauris nisl nisi, semper et metus a, sagittis accumsan arcu. Nulla ultrices
+                                            lectus nunc, eu tristique justo tempor non.
                                         </vl-paragraph>
 
                                         <vl-title type="h3" id="content-2-4">Content 2 - 4</vl-title>


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-471

## Samenvatting
`vl-header` en `vl-header-next` krijgen een optioneel `skip-to-content-id` attribuut waarmee toetsenbordgebruikers het headerblok kunnen overslaan en meteen naar de pagina-inhoud springen (WCAG 2.4.1 — Blokken omzeilen). De skip-link styling wordt mee geïnjecteerd zodat consumers geen extra stylesheet moeten laden.

## Wijzigingen
- Nieuw optioneel `skip-to-content-id` attribuut op `vl-header` en `vl-header-next`: bij een gezette waarde verschijnt een `<a class="vl-skip-link">` als eerste focusbaar element van de header.
- De skip-link is visueel verborgen tot hij toetsenbord-focus krijgt; bij activering verplaatst hij focus én scroll naar het opgegeven content-element.
- De bijhorende accessibility-styling wordt automatisch mee geïnjecteerd, zodat de link werkt zonder dat de consumer extra stylesheets moet laden.
- Zonder `skip-to-content-id` wordt geen link gerenderd en volgt een console-waarschuwing met WCAG-referentie.
- De skip-link-logica staat nu in één gedeelde helper in `@domg-wc/common` die door `vl-header`, `vl-header-next` én `vl-functional-header` gebruikt wordt (gedragsbehoudende refactor van de functional-header).

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] `vl-header` (en `vl-header-next`) rendert een `<a class="vl-skip-link">` als eerste focusbaar element — als eerste kind van `#header__container` bij gezet `skip-to-content-id`.
- [x] Visueel verborgen tot toetsenbord-focus, dan zichtbaar — via de mee-geïnjecteerde `.vl-skip-link` styling.
- [x] Activeren verplaatst focus én scrollt naar het content-element — via de gedeelde `navigateToAnchor()`-util (tabindex-fallback, cross-shadow lookup).
- [x] Skip-link styling mee geïnjecteerd zonder extra stylesheet bij consumer — idempotent in `document.adoptedStyleSheets`.
- [x] axe/WCAG 2.4.1 faalt niet langer — de skip-link vervult het bypass-mechanisme zodra `skip-to-content-id` gezet is; de bestaande axe-test blijft groen.
