### PR TITLE
fix: FLUX-766 - vl-search-filter - section in section

### DIFF
--- a/libs/components/src/block/search-filter/vl-search-filter.global.css.ts
+++ b/libs/components/src/block/search-filter/vl-search-filter.global.css.ts
@@ -7,7 +7,7 @@ export const searchFilterGlobalStyles: CSSResult = css`
         background-color: #e8ebee;
 
         /* enkel niet-geneste sections krijgen de scheidingslijn - een geneste section-in-section krijgt 1 lijn */
-        section:not(section section) {
+        & section:not(& section section) {
             padding-bottom: 2rem;
             margin-bottom: 2rem;
             border-bottom: 1px solid #cbd2da;


### PR DESCRIPTION
De section in een section css is enkel geldig voor geneste secties binnen de vl-search-filter

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-766
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC408