### PR TITLE
feat: FLUX-610 - cross-validatie - dependencySelectors via CrossValidationMixin met voorbeelden en docs

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -9,11 +9,8 @@ import {
 } from '@domg-wc/components/block';
 import { VlHeader } from '@domg-wc/components/compliance';
 import { VlFooter as VlFooterNext } from '@domg-wc/components/compliance/next';
-import {
-    VlDatepickerComponent,
-    VlFormLabelComponent,
-    VlInputFieldComponent,
-} from '@domg-wc/components/form';
+import { VlDatepickerComponent } from '@domg-wc/components/form';
+import { VlFormCrossValidationComponent } from '@domg-wc/integrations/form';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -30,8 +27,7 @@ export class AppComponent extends LitElement {
             VlInfoTile,
             VlPropertiesComponent,
             VlFooterNext,
-            VlFormLabelComponent,
-            VlInputFieldComponent,
+            VlFormCrossValidationComponent,
         ]);
     }
 
@@ -45,6 +41,13 @@ export class AppComponent extends LitElement {
                     identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb"
                 ></vl-header>
                 <main slot="main">
+                    <section class="vl-section">
+                        <div class="vl-content-block vl-content-block--full-width">
+                            <vl-title type="h2">Cross-validatie voorbeeld</vl-title>
+                            <vl-form-cross-validation></vl-form-cross-validation>
+                        </div>
+                    </section>
+
                     <section class="vl-section">
                         <div class="vl-content-block vl-content-block--full-width">
                             <vl-info-tile highlight-left>
@@ -122,15 +125,14 @@ export class AppComponent extends LitElement {
                             <vl-title type="h2">FLUX-595 — datepicker positioning bug repro</vl-title>
                             <p>
                                 Beide datepickers zitten in een identieke <code>transform + overflow:auto</code> parent
-                                — de exacte ancestor-conditie die de oude positioning-hack breekt. Klik op de
-                                kalender-knoppen om te vergelijken.
+                                — de exacte ancestor-conditie die de oude positioning-hack breekt.
+                                Klik op de kalender-knoppen om te vergelijken.
                             </p>
                             <div style="display: flex; gap: 20px; margin-top: 16px;">
                                 <div style="flex: 1; border: 2px dashed crimson; padding: 12px; background: #fffbe6;">
                                     <strong style="color: crimson;">A — inline-positioning (oude hack, bug)</strong>
                                     <p style="margin: 4px 0 8px; font-size: 13px; color: #666;">
-                                        getBoundingClientRect-hack — calendar landt op verkeerde plek / clipt door
-                                        overflow.
+                                        getBoundingClientRect-hack — calendar landt op verkeerde plek / clipt door overflow.
                                     </p>
                                     <div
                                         style="transform: translateX(0); overflow: auto; max-height: 180px;
@@ -181,28 +183,6 @@ export class AppComponent extends LitElement {
                                 >
                                     Download als verslag.txt
                                 </vl-button>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="vl-section">
-                        <div class="vl-content-block vl-content-block--full-width vl-stacked vl-stacked-medium">
-                            <vl-title type="h2" no-space-bottom
-                                >FLUX-659: vl-input-field met describedby attribuut</vl-title
-                            >
-                            <div>
-                                <vl-form-label for="waarde" label="Waarde"></vl-form-label>
-                                <div class="vl-group vl-group--align-center">
-                                    <vl-input-field
-                                        name="waarde"
-                                        id="waarde"
-                                        type="text"
-                                        label="Waarde"
-                                        describedby="eenheid"
-                                    ></vl-input-field>
-                                    <span aria-hidden="true">m</span>
-                                    <span class="vl-visually-hidden" id="eenheid">meter</span>
-                                </div>
                             </div>
                         </div>
                     </section>

--- a/apps/storybook/docs/f_patronen/formulier/1_demo/formulier-demo.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/1_demo/formulier-demo.mdx
@@ -12,6 +12,9 @@ import formDemoSource from '../../../../../../libs/integrations/src/form/demo/vl
 > Een uitgebreid voorbeeld over hoe je form data eenvoudiger kan parsen en gebruiken vind je
   op [Formulier - Form Data](/docs/patronen-formulier-form-data--documentatie).
 
+> Moet de validatie van een veld afhangen van de waarde van een ander veld? Bekijk dan
+  [Formulier - Cross-Validatie](/docs/patronen-formulier-cross-validatie--documentatie).
+
 Dit is een voorbeeld van hoe de form componenten in een form gebruikt kunnen worden.<br/>
 De submitted waarden worden in deze demo in de console gelogd.
 
@@ -57,7 +60,7 @@ Indien je meer controle nodig hebt kan je zelf de [FormData](https://developer.m
 
 <Canvas of={formDemoStories.FormulierDemo} sourceState='none'/>
 
-<details open>
+<details>
     <summary>Code</summary>
     <Source code={formDemoSource} language="ts" dark={true}/>
 </details>

--- a/apps/storybook/docs/f_patronen/formulier/2_validatie/formulier-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/2_validatie/formulier-validatie.mdx
@@ -11,6 +11,9 @@ import * as formValidationStories from './formulier-validatie.stories';
 > Een voorbeeld om custom validatie te schrijven vind je op
   [Formulier - Aangepaste Validatie](/docs/patronen-formulier-aangepaste-validatie--documentatie).
 
+> Een voorbeeld van cross-validatie (validatie afhankelijk van de waarde van een ander veld) vind je op
+  [Formulier - Cross-Validatie](/docs/patronen-formulier-cross-validatie--documentatie).
+
 De formulier componenten maken gebruik van open-wc's [form participation](https://github.com/open-wc/form-participation) om form validatie te bekomen met web
 components die gebruik maken van native HTML form elements.
 
@@ -33,7 +36,7 @@ controleert.
 Hieronder een overzicht van de gebruikte attributen van [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState#instance_properties) met hun betekenis en bijhorende
 [validation attributen](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation#validation-related_attributes):
 
-- `customError`: als je custom validatie instelt, [zie hier](/docs/patronen-formulier-aangepaste-validatie--documentatie) hoe je zelf een custom validator schrijft.
+- `customError`: als je custom validatie instelt, [zie hier](/docs/patronen-formulier-aangepaste-validatie--documentatie) hoe je zelf een custom validator schrijft. Voor validatie afhankelijk van een ander veld, [zie cross-validatie](/docs/patronen-formulier-cross-validatie--documentatie).
 - `patternMismatch`: als de waarde niet overeenkomt met het patroon dat is ingesteld door het `pattern` attribuut.
 - `rangeOverflow`: als de waarde hoger is dan de waarde die is gespecifieerd door het `max` attribuut.
 - `rangeUnderflow`: als de waarde lager is dan de waarde die is gespecifieerd door het `min` attribuut.

--- a/apps/storybook/docs/f_patronen/formulier/3_aangepaste-validatie/formulier-aangepaste-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/3_aangepaste-validatie/formulier-aangepaste-validatie.mdx
@@ -7,7 +7,10 @@ import formCustomValidationSource from '../../../../../../libs/integrations/src/
 # Formulier - Aangepaste Validatie
 
 > Meer informatie over validatie binnen de formulier componenten vind je op
-  [Formulier - Validatie](/docs/patronen-formulier-validatie--documentatie)
+  [Formulier - Validatie](/docs/patronen-formulier-validatie--documentatie).
+
+> Moet je validatie afhankelijk maken van de waarde van een ander veld? Bekijk dan
+  [Formulier - Cross-Validatie](/docs/patronen-formulier-cross-validatie--documentatie).
 
 Om gebruik te maken van custom validatie moet je een nieuwe component maken die overerft van één van onze form
 controls.<br/>
@@ -27,7 +30,7 @@ Bij het toevoegen van een 2de custom validator zal de eerste custom validator ov
 
 <Canvas of={formCustomValidationStories.FormulierAangepasteValidatie} sourceState='none' />
 
-<details open>
+<details>
     <summary>Code</summary>
     <Source code={formCustomValidationSource} language="ts" dark={true} />
 </details>

--- a/apps/storybook/docs/f_patronen/formulier/3b_cross-validatie/formulier-cross-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/3b_cross-validatie/formulier-cross-validatie.mdx
@@ -1,0 +1,138 @@
+import { Canvas, Meta, Source } from '@storybook/addon-docs/blocks';
+import * as formCrossValidationStories from './formulier-cross-validatie.stories';
+import formCrossValidationSource from '../../../../../../libs/integrations/src/form/cross-validation/vl-form-cross-validation.component?raw';
+import formCrossValidationMatchSource from '../../../../../../libs/integrations/src/form/cross-validation/vl-form-cross-validation-match.component?raw';
+import formCrossValidationConditionalSource from '../../../../../../libs/integrations/src/form/cross-validation/vl-form-cross-validation-conditional.component?raw';
+
+<Meta of={formCrossValidationStories} />
+
+# Formulier - Cross-Validatie
+
+> Bouwt verder op [Formulier - Validatie](/docs/patronen-formulier-validatie--documentatie) en
+> [Formulier - Aangepaste Validatie](/docs/patronen-formulier-aangepaste-validatie--documentatie). Hoe je een custom
+> validator schrijft en een `vl-form-message` koppelt staat daar beschreven; hier komt enkel de afhankelijkheid van een
+> **ander veld** aan bod.
+
+Soms hangt de geldigheid van een veld af van de waarde van een ander veld in hetzelfde formulier: een code die enkel
+bij een bepaalde procedure geldt, een bevestigingsveld dat moet overeenkomen, een veld dat enkel verplicht is bij een
+bepaalde keuze.
+
+`CrossValidationMixin` is een mixin **uit de bibliotheek** (`@domg-wc/components/form`): hij luistert naar wijzigingen
+op de velden waarvan je validator afhangt, en hervalideert je veld zodra een daarvan verandert.
+
+## Gebruik
+
+```ts
+import { CrossValidationMixin, type ValidatorWithDeps } from '@domg-wc/components/form';
+```
+
+Je schrijft een validator met `dependencySelectors`, en wrapt de form control waarop je hem toepast in de mixin. Het
+`instance` argument in de validator is het host element van die control: via `instance.form` bereik je het native
+`HTMLFormElement`, en dus elk ander veld via `querySelector`.
+
+Als voorbeeld een code-veld dat exact `ABC-123` moet zijn, maar enkel wanneer de procedure **Strikt** is.
+
+### 1. De validator
+
+```ts
+const crossFieldValidator: ValidatorWithDeps = {
+    key: 'customError',
+    message: `Bij de strikte procedure moet de code 'ABC-123' zijn.`,
+    dependencySelectors: ['#procedure'],
+    isValid(instance: HTMLElement, value: string): boolean {
+        if (!value) return true;
+
+        const form = (instance as HTMLElement & { form: HTMLFormElement | null }).form;
+        if (!form) return true;
+
+        const procedure = form.querySelector<HTMLElement & { value: string }>('#procedure')?.value;
+        return procedure !== 'strikt' || value === 'ABC-123';
+    },
+};
+```
+
+`ValidatorWithDeps` is de gewone `Validator` van `@open-wc/form-control`, uitgebreid met `dependencySelectors`. Typeer
+er zowel je validator als de `formControlValidators` array mee. Laat je de annotatie weg, dan leidt TypeScript het
+letterlijke object-type af in plaats van `Validator`, en faalt de override van de statische array met
+`TS2417: Class static side incorrectly extends base class static side`.
+
+### 2. Het component
+
+Net als bij [aangepaste validatie](/docs/patronen-formulier-aangepaste-validatie--documentatie) maak je per validator
+een nieuw component. Wrap de form control daarbij in de `CrossValidationMixin`.
+
+```ts
+import { webComponent } from '@domg-wc/common';
+import { CrossValidationMixin, VlInputFieldComponent, type ValidatorWithDeps } from '@domg-wc/components/form';
+
+@webComponent('vl-input-field-with-cross-validator')
+export class VlInputFieldWithCrossValidatorComponent extends CrossValidationMixin(VlInputFieldComponent) {
+    static override formControlValidators: ValidatorWithDeps[] = [
+        ...VlInputFieldComponent.formControlValidators,
+        crossFieldValidator,
+    ];
+}
+```
+
+### 3. De foutmelding
+
+Gebruik het nieuwe component in plaats van `vl-input-field`, met de foutmelding in een `vl-form-message` met
+`state="customError"`.
+
+```html
+<vl-select id="procedure" name="procedure" ...></vl-select>
+
+<vl-input-field-with-cross-validator id="code" name="code" block required></vl-input-field-with-cross-validator>
+<vl-form-message for="code" state="customError">
+    Bij de strikte procedure moet de code 'ABC-123' zijn.
+</vl-form-message>
+```
+
+## Aandachtspunten
+
+- **Combineer met een gewone custom validatie in één `isValid`.** Er is maar één `customError` per form control
+  beschikbaar, dus twee losse validators op hetzelfde veld gaan niet. Zie
+  [Formulier - Aangepaste Validatie](/docs/patronen-formulier-aangepaste-validatie--documentatie) voor de reden.
+- **Submit-validatie.** De foutmelding verschijnt bij het verzenden en verdwijnt zodra het veld terug geldig wordt, ook
+  wanneer dat door een wijziging in een afhankelijk veld komt. Er wordt bewust geen valid-boodschap getoond. Wil je
+  validatie al tijdens het invullen tonen, combineer dit dan met het `blur-validation` attribuut, zie
+  [Formulier - Blur-validatie](/docs/patronen-formulier-blur-validatie--documentatie).
+
+## Voorbeelden
+
+De componenten hieronder zijn geen bibliotheekcode: het zijn patronen die je overneemt in je eigen project.
+
+Kies **Strikt** en verzend een willekeurige code: je krijgt een foutmelding. Wissel daarna naar **Standaard** en ze
+verdwijnt meteen, zonder opnieuw te verzenden. De ingediende form data wordt onderaan geprint via de
+[parseFormData](/docs/patronen-formulier-form-data--documentatie) helper.
+
+<Canvas of={formCrossValidationStories.FormulierCrossValidatie} sourceState='none' />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formCrossValidationSource} language="ts" dark={true} />
+</details>
+
+### Twee velden die moeten overeenkomen
+
+Een bevestigingsveld dat gelijk moet zijn aan het eerste veld, via `dependencySelectors: ['#email']`.
+
+<Canvas of={formCrossValidationStories.FormulierCrossValidatieMatch} sourceState='none' />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formCrossValidationMatchSource} language="ts" dark={true} />
+</details>
+
+### Conditioneel verplicht veld
+
+**Verduidelijking** is enkel verplicht wanneer de reden **Andere** is. Het veld heeft zelf geen `required` attribuut: de
+validator beslist op basis van het reden-veld en hervalideert via `dependencySelectors: ['#reden']`. Bij **Andere**
+markeert het label het veld als verplicht.
+
+<Canvas of={formCrossValidationStories.FormulierCrossValidatieConditional} sourceState='none' />
+
+<details>
+    <summary>Volledige demo-component</summary>
+    <Source code={formCrossValidationConditionalSource} language="ts" dark={true} />
+</details>

--- a/apps/storybook/docs/f_patronen/formulier/3b_cross-validatie/formulier-cross-validatie.stories.ts
+++ b/apps/storybook/docs/f_patronen/formulier/3b_cross-validatie/formulier-cross-validatie.stories.ts
@@ -1,0 +1,32 @@
+import { html } from 'lit';
+import { Meta } from '@storybook/web-components-vite';
+import { registerWebComponents } from '@domg-wc/common';
+import {
+    VlFormCrossValidationComponent,
+    VlFormCrossValidationConditionalComponent,
+    VlFormCrossValidationMatchComponent,
+} from '@domg-wc/integrations/form';
+
+registerWebComponents([
+    VlFormCrossValidationComponent,
+    VlFormCrossValidationMatchComponent,
+    VlFormCrossValidationConditionalComponent,
+]);
+
+export default {
+    title: 'Patronen/Formulier/cross-validatie',
+} as Meta;
+
+export const FormulierCrossValidatie = () => html`<vl-form-cross-validation></vl-form-cross-validation>`;
+
+FormulierCrossValidatie.storyName = 'formulier - cross-validatie';
+
+export const FormulierCrossValidatieMatch = () =>
+    html`<vl-form-cross-validation-match></vl-form-cross-validation-match>`;
+
+FormulierCrossValidatieMatch.storyName = 'formulier - cross-validatie - velden matchen';
+
+export const FormulierCrossValidatieConditional = () =>
+    html`<vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`;
+
+FormulierCrossValidatieConditional.storyName = 'formulier - cross-validatie - conditioneel verplicht';

--- a/libs/components/src/form/form-control/form-control.ts
+++ b/libs/components/src/form/form-control/form-control.ts
@@ -34,6 +34,8 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     // Voorkomt dat er per update-cyclus meerdere message-refreshes ingepland worden.
     private formMessageRefreshScheduled = false;
 
+    private blurValidationTimeout?: ReturnType<typeof setTimeout>;
+
     // Variables
     protected submitFormOnEnter = true;
     protected formMessageText: string | undefined | null;
@@ -99,7 +101,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
 
-        if (this.blurValidationEnabled) {
+        if (this.retainsValidationState) {
             // update error after programmatic value change (no vl-input fired).
             if (this.isInvalid && !changedProperties.has('isInvalid')) {
                 this.runValidation();
@@ -128,7 +130,18 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         );
     }
 
+    protected get retainsValidationState(): boolean {
+        return this.blurValidationEnabled;
+    }
+
+    protected revalidate(): void {
+        if (this.hasBeenValidated) {
+            this.runValidation();
+        }
+    }
+
     resetFormControl() {
+        clearTimeout(this.blurValidationTimeout);
         this.isInvalid = false;
         this.erroredOnce = false;
         this.hasBeenValidated = false;
@@ -169,6 +182,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
         }
 
         if (this.hasBeenValidated && this.validity.valid) {
+            this.isInvalid = false;
             this.showSuccessMessage();
         }
     }
@@ -194,7 +208,8 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
 
         // Defer to next tick so document.activeElement reflects the new focus target.
         // With delegatesFocus, activeElement is the host on internal shadow focus shifts.
-        setTimeout(() => {
+        clearTimeout(this.blurValidationTimeout);
+        this.blurValidationTimeout = setTimeout(() => {
             if (!this.isConnected) return;
             if (document.activeElement === this) return;
             this.runValidation();

--- a/libs/components/src/form/index.ts
+++ b/libs/components/src/form/index.ts
@@ -11,4 +11,4 @@ export { VlSelectRichComponent, type SelectRichOption, SelectRichPosition } from
 export { VlTextareaComponent } from './textarea';
 export { VlTextareaRichComponent } from './textarea-rich';
 export { VlUploadComponent } from './upload';
-export { parseFormData, setFormData } from './utils';
+export { parseFormData, setFormData, CrossValidationMixin, type ValidatorWithDeps } from './utils';

--- a/libs/components/src/form/utils/cross-validation.mixin.ts
+++ b/libs/components/src/form/utils/cross-validation.mixin.ts
@@ -1,0 +1,71 @@
+import { type FormValue, type Validator } from '@open-wc/form-control';
+import { FormControl } from '../form-control/form-control';
+
+export type ValidatorWithDeps = Validator & { dependencySelectors?: string[] };
+
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export const CrossValidationMixin = <T extends Constructor<FormControl>>(superClass: T) => {
+    abstract class CrossValidationElement extends superClass {
+        private cachedDependencySelectors?: string[];
+
+        private lastFormValue: FormValue = null;
+
+        private dependencyForm: HTMLFormElement | null = null;
+
+        formAssociatedCallback(form: HTMLFormElement | null): void {
+            super.formAssociatedCallback(form);
+
+            if (this.dependencyForm === form) {
+                return;
+            }
+
+            this.dependencyForm?.removeEventListener('vl-change', this.onDependencyChange);
+            this.dependencyForm = form;
+
+            if (form && this.dependencySelectors.length > 0) {
+                form.addEventListener('vl-change', this.onDependencyChange);
+            }
+        }
+
+        disconnectedCallback(): void {
+            super.disconnectedCallback();
+
+            this.dependencyForm?.removeEventListener('vl-change', this.onDependencyChange);
+            this.dependencyForm = null;
+        }
+
+        setValue(value: FormValue): void {
+            this.lastFormValue = value;
+            super.setValue(value);
+        }
+
+        protected get retainsValidationState(): boolean {
+            return super.retainsValidationState || this.dependencySelectors.length > 0;
+        }
+
+        private get dependencySelectors(): string[] {
+            if (this.cachedDependencySelectors === undefined) {
+                const validators = ((this.constructor as typeof FormControl).formControlValidators ??
+                    []) as ValidatorWithDeps[];
+                this.cachedDependencySelectors = validators.flatMap((validator) => validator.dependencySelectors ?? []);
+            }
+
+            return this.cachedDependencySelectors;
+        }
+
+        private onDependencyChange = (event: Event): void => {
+            const target = event.target as Element | null;
+            if (!target) {
+                return;
+            }
+
+            if (this.dependencySelectors.some((selector) => target.matches(selector))) {
+                this.setValue(this.lastFormValue);
+                this.revalidate();
+            }
+        };
+    }
+
+    return CrossValidationElement as unknown as Constructor<FormControl> & T;
+};

--- a/libs/components/src/form/utils/index.ts
+++ b/libs/components/src/form/utils/index.ts
@@ -1,2 +1,3 @@
 export { parseFormData } from './form-data-getter';
 export { setFormData } from './form-data-setter';
+export { CrossValidationMixin, type ValidatorWithDeps } from './cross-validation.mixin';

--- a/libs/integrations/src/form/cross-validation/index.ts
+++ b/libs/integrations/src/form/cross-validation/index.ts
@@ -1,0 +1,3 @@
+export { VlFormCrossValidationComponent } from './vl-form-cross-validation.component';
+export { VlFormCrossValidationMatchComponent } from './vl-form-cross-validation-match.component';
+export { VlFormCrossValidationConditionalComponent } from './vl-form-cross-validation-conditional.component';

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation-conditional.component.cy.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation-conditional.component.cy.ts
@@ -1,0 +1,137 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCrossValidationConditionalComponent } from './vl-form-cross-validation-conditional.component';
+
+registerWebComponents([VlFormCrossValidationConditionalComponent]);
+
+describe('cypress-component - integrations - vl-form-cross-validation-conditional', () => {
+    it('should render', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional').shadow();
+    });
+
+    it('should not require verduidelijking when reden is "verlenging"', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('verlenging');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-label[for="verduidelijking"]')
+            .should('have.attr', 'label', 'Verduidelijking');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-message[for="verduidelijking"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+
+    it('should mark verduidelijking as required when reden is "andere"', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-label[for="verduidelijking"]')
+            .should('have.attr', 'label', 'Verduidelijking');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('andere');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-label[for="verduidelijking"]')
+            .should('have.attr', 'label', 'Verduidelijking *');
+    });
+
+    it('should require verduidelijking when reden is "andere"', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('andere');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-message[for="verduidelijking"][state="customError"]')
+            .should('have.attr', 'show', '');
+    });
+
+    it('should accept a filled verduidelijking when reden is "andere"', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('andere');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-input-field-with-conditional-validator')
+            .shadow()
+            .find('input')
+            .type('Verbouwing van het terras');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-message[for="verduidelijking"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+
+    it('should revalidate verduidelijking live when reden changes', () => {
+        cy.mount(html` <vl-form-cross-validation-conditional></vl-form-cross-validation-conditional>`);
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('andere');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-message[for="verduidelijking"][state="customError"]')
+            .should('have.attr', 'show', '');
+
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-select#reden')
+            .shadow()
+            .find('select')
+            .select('verlenging');
+        cy.get('vl-form-cross-validation-conditional')
+            .shadow()
+            .find('vl-form-message[for="verduidelijking"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+});

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation-conditional.component.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation-conditional.component.ts
@@ -1,0 +1,148 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import {
+    VlFormMessageComponent,
+    VlFormLabelComponent,
+    VlInputFieldComponent,
+    VlSelectComponent,
+    type SelectOption,
+    CrossValidationMixin,
+    type ValidatorWithDeps,
+} from '@domg-wc/components/form';
+import { css, CSSResult, html, LitElement, PropertyDeclarations } from 'lit';
+
+@webComponent('vl-input-field-with-conditional-validator')
+export class VlInputFieldWithConditionalValidatorComponent extends CrossValidationMixin(VlInputFieldComponent) {
+    static override formControlValidators: ValidatorWithDeps[] = [
+        ...VlInputFieldComponent.formControlValidators,
+        {
+            key: 'customError',
+            message: 'Gelieve de reden te verduidelijken.',
+            dependencySelectors: ['#reden'],
+            isValid(instance: HTMLElement, value: string): boolean {
+                const form = (instance as HTMLElement & { form: HTMLFormElement | null }).form;
+                if (!form) return true;
+
+                const reden = form.querySelector<HTMLElement & { value: string }>('#reden')?.value;
+                if (reden !== 'andere') return true;
+
+                return !!value;
+            },
+        },
+    ];
+}
+
+@webComponent('vl-form-cross-validation-conditional')
+export class VlFormCrossValidationConditionalComponent extends LitElement {
+    private reden = '';
+
+    static {
+        registerWebComponents([
+            VlInputFieldWithConditionalValidatorComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlSelectComponent,
+            VlButtonComponent,
+        ]);
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+            `,
+        ];
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            reden: { type: String, state: true },
+        };
+    }
+
+    private redenOpties: SelectOption[] = [
+        { label: 'Verlenging', value: 'verlenging' },
+        { label: 'Andere', value: 'andere' },
+    ];
+
+    private get verduidelijkingVerplicht(): boolean {
+        return this.reden === 'andere';
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset} @vl-change=${this.onChange}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="reden" label="Reden aanvraag *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-select
+                            id="reden"
+                            name="reden"
+                            block
+                            required
+                            placeholder="Kies een reden"
+                            .options=${this.redenOpties}
+                        ></vl-select>
+                        <vl-form-message for="reden" state="valueMissing">Gelieve een reden te kiezen.</vl-form-message>
+                    </div>
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label
+                            for="verduidelijking"
+                            label=${this.verduidelijkingVerplicht ? 'Verduidelijking *' : 'Verduidelijking'}
+                            block
+                        ></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-input-field-with-conditional-validator
+                            id="verduidelijking"
+                            name="verduidelijking"
+                            block
+                        ></vl-input-field-with-conditional-validator>
+                        <vl-form-message for="verduidelijking" state="customError"
+                            >Gelieve de reden te verduidelijken.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        `;
+    }
+
+    private onSubmit(e: Event) {
+        e.preventDefault();
+    }
+
+    private onReset() {
+        this.reden = '';
+    }
+
+    private onChange() {
+        this.reden = this.shadowRoot?.querySelector<HTMLElement & { value: string }>('#reden')?.value ?? '';
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-input-field-with-conditional-validator': VlInputFieldWithConditionalValidatorComponent;
+        'vl-form-cross-validation-conditional': VlFormCrossValidationConditionalComponent;
+    }
+}

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation-match.component.cy.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation-match.component.cy.ts
@@ -1,0 +1,96 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCrossValidationMatchComponent } from './vl-form-cross-validation-match.component';
+
+registerWebComponents([VlFormCrossValidationMatchComponent]);
+
+describe('cypress-component - integrations - vl-form-cross-validation-match', () => {
+    it('should render', () => {
+        cy.mount(html` <vl-form-cross-validation-match></vl-form-cross-validation-match>`);
+
+        cy.get('vl-form-cross-validation-match').shadow();
+    });
+
+    it('should show valueMissing when submitting empty form', () => {
+        cy.mount(html` <vl-form-cross-validation-match></vl-form-cross-validation-match>`);
+
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-form-message[for="bevestig-email"][state="valueMissing"]')
+            .should('have.attr', 'show', '');
+    });
+
+    it('should show customError when the e-mail addresses do not match', () => {
+        cy.mount(html` <vl-form-cross-validation-match></vl-form-cross-validation-match>`);
+
+        cy.get('vl-form-cross-validation-match').shadow().find('#email').shadow().find('input').type('a@b.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-input-field-with-match-validator')
+            .shadow()
+            .find('input')
+            .type('x@y.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-form-message[for="bevestig-email"][state="customError"]')
+            .should('have.attr', 'show', '');
+    });
+
+    it('should accept matching e-mail addresses', () => {
+        cy.mount(html` <vl-form-cross-validation-match></vl-form-cross-validation-match>`);
+
+        cy.get('vl-form-cross-validation-match').shadow().find('#email').shadow().find('input').type('a@b.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-input-field-with-match-validator')
+            .shadow()
+            .find('input')
+            .type('a@b.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-form-message[for="bevestig-email"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+
+    it('should revalidate the confirmation field live when the e-mail changes', () => {
+        cy.mount(html` <vl-form-cross-validation-match></vl-form-cross-validation-match>`);
+
+        cy.get('vl-form-cross-validation-match').shadow().find('#email').shadow().find('input').type('a@b.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-input-field-with-match-validator')
+            .shadow()
+            .find('input')
+            .type('a@b.com');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+
+        cy.get('vl-form-cross-validation-match').shadow().find('#email').shadow().find('input').type('x');
+        cy.get('vl-form-cross-validation-match')
+            .shadow()
+            .find('vl-form-message[for="bevestig-email"][state="customError"]')
+            .should('have.attr', 'show', '');
+    });
+});

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation-match.component.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation-match.component.ts
@@ -1,0 +1,116 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import {
+    VlFormMessageComponent,
+    VlFormLabelComponent,
+    VlInputFieldComponent,
+    CrossValidationMixin,
+    type ValidatorWithDeps,
+} from '@domg-wc/components/form';
+import { css, CSSResult, html, LitElement } from 'lit';
+
+@webComponent('vl-input-field-with-match-validator')
+export class VlInputFieldWithMatchValidatorComponent extends CrossValidationMixin(VlInputFieldComponent) {
+    static override formControlValidators: ValidatorWithDeps[] = [
+        ...VlInputFieldComponent.formControlValidators,
+        {
+            key: 'customError',
+            message: 'De e-mailadressen komen niet overeen.',
+            dependencySelectors: ['#email'],
+            isValid(instance: HTMLElement, value: string): boolean {
+                if (!value) return true;
+
+                const form = (instance as HTMLElement & { form: HTMLFormElement | null }).form;
+                if (!form) return true;
+
+                const email = form.querySelector<HTMLElement & { value: string }>('#email')?.value;
+                return value === email;
+            },
+        },
+    ];
+}
+
+@webComponent('vl-form-cross-validation-match')
+export class VlFormCrossValidationMatchComponent extends LitElement {
+    static {
+        registerWebComponents([
+            VlInputFieldWithMatchValidatorComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlInputFieldComponent,
+            VlButtonComponent,
+        ]);
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+            `,
+        ];
+    }
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="email" label="E-mailadres *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-input-field id="email" name="email" block required></vl-input-field>
+                        <vl-form-message for="email" state="valueMissing"
+                            >Gelieve een e-mailadres in te vullen.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="bevestig-email" label="Bevestig e-mailadres *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-input-field-with-match-validator
+                            id="bevestig-email"
+                            name="bevestigEmail"
+                            block
+                            required
+                        ></vl-input-field-with-match-validator>
+                        <vl-form-message for="bevestig-email" state="valueMissing"
+                            >Gelieve het e-mailadres te bevestigen.</vl-form-message
+                        >
+                        <vl-form-message for="bevestig-email" state="customError"
+                            >De e-mailadressen komen niet overeen.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        `;
+    }
+
+    private onSubmit(e: Event) {
+        e.preventDefault();
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-input-field-with-match-validator': VlInputFieldWithMatchValidatorComponent;
+        'vl-form-cross-validation-match': VlFormCrossValidationMatchComponent;
+    }
+}

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation.component.cy.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation.component.cy.ts
@@ -1,0 +1,188 @@
+import { html } from 'lit';
+import { registerWebComponents } from '@domg-wc/common';
+import { VlFormCrossValidationComponent } from './vl-form-cross-validation.component';
+
+registerWebComponents([VlFormCrossValidationComponent]);
+
+describe('cypress-component - integrations - vl-form-cross-validation', () => {
+    it('should render', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation').shadow();
+    });
+
+    it('should show valueMissing when submitting empty form', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="valueMissing"]')
+            .should('have.attr', 'show', '');
+    });
+
+    it('should accept any code when procedure is "standaard"', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('standaard');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-input-field-with-cross-validator')
+            .shadow()
+            .find('input')
+            .type('willekeurige-code');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+
+    it('should show customError when procedure is "strikt" and code is not "ABC-123"', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('strikt');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-input-field-with-cross-validator')
+            .shadow()
+            .find('input')
+            .type('foute-code');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('have.attr', 'show', '');
+    });
+
+    it('should accept code "ABC-123" when procedure is "strikt"', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('strikt');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-input-field-with-cross-validator')
+            .shadow()
+            .find('input')
+            .type('ABC-123');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+    });
+
+    it('should print the submitted form data after a valid submit', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+        cy.get('vl-form-cross-validation').shadow().find('pre').should('not.exist');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('standaard');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-input-field-with-cross-validator')
+            .shadow()
+            .find('input')
+            .type('willekeurige-code');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('pre')
+            .should('exist')
+            .and('contain.text', 'procedure')
+            .and('contain.text', 'standaard')
+            .and('contain.text', 'willekeurige-code');
+    });
+
+    it('should revalidate code field live when the procedure changes', () => {
+        cy.mount(html` <vl-form-cross-validation></vl-form-cross-validation>`);
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('standaard');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-input-field-with-cross-validator')
+            .shadow()
+            .find('input')
+            .type('test');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-button[type="submit"]')
+            .shadow()
+            .find('button')
+            .click('bottomLeft');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('not.have.attr', 'show', '');
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('strikt');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('have.attr', 'show', '');
+
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-select#procedure')
+            .shadow()
+            .find('select')
+            .select('standaard');
+        cy.get('vl-form-cross-validation')
+            .shadow()
+            .find('vl-form-message[for="code"][state="customError"]')
+            .should('not.have.attr', 'show');
+    });
+});

--- a/libs/integrations/src/form/cross-validation/vl-form-cross-validation.component.ts
+++ b/libs/integrations/src/form/cross-validation/vl-form-cross-validation.component.ts
@@ -1,0 +1,154 @@
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { vlGridStyles, vlLegacyStyles } from '@domg-wc/styles';
+import { VlButtonComponent } from '@domg-wc/components/atom';
+import {
+    parseFormData,
+    VlFormMessageComponent,
+    VlFormLabelComponent,
+    VlInputFieldComponent,
+    VlSelectComponent,
+    type SelectOption,
+    CrossValidationMixin,
+    type ValidatorWithDeps,
+} from '@domg-wc/components/form';
+import { css, CSSResult, html, LitElement, PropertyDeclarations } from 'lit';
+
+@webComponent('vl-input-field-with-cross-validator')
+export class VlInputFieldWithCrossValidatorComponent extends CrossValidationMixin(VlInputFieldComponent) {
+    static override formControlValidators: ValidatorWithDeps[] = [
+        ...VlInputFieldComponent.formControlValidators,
+        {
+            key: 'customError',
+            message: `Bij de strikte procedure moet de code 'ABC-123' zijn.`,
+            dependencySelectors: ['#procedure'],
+            isValid(instance: HTMLElement, value: string): boolean {
+                if (!value) return true;
+
+                const form = (instance as HTMLElement & { form: HTMLFormElement | null }).form;
+                if (!form) return true;
+
+                const procedure = form.querySelector<HTMLElement & { value: string }>('#procedure')?.value;
+                return procedure !== 'strikt' || value === 'ABC-123';
+            },
+        },
+    ];
+}
+
+@webComponent('vl-form-cross-validation')
+export class VlFormCrossValidationComponent extends LitElement {
+    private formData: { [key: string]: FormDataEntryValue[] | File | string } | null = null;
+
+    static {
+        registerWebComponents([
+            VlInputFieldWithCrossValidatorComponent,
+            VlFormLabelComponent,
+            VlFormMessageComponent,
+            VlSelectComponent,
+            VlButtonComponent,
+        ]);
+    }
+
+    static override get styles(): (CSSResult | CSSResult[])[] {
+        return [
+            vlLegacyStyles,
+            vlGridStyles,
+            css`
+                form {
+                    margin-top: 1rem;
+                    max-width: 800px;
+                }
+
+                .form-buttons {
+                    vl-button:not(:last-child) {
+                        margin-right: 1.4rem;
+                    }
+                }
+
+                pre {
+                    margin-top: 1rem;
+                    padding: 0.75rem;
+                    background: #f5f5f5;
+                    border: 1px solid #ddd;
+                    border-radius: 4px;
+                    font-size: 0.875rem;
+                }
+            `,
+        ];
+    }
+
+    static override get properties(): PropertyDeclarations {
+        return {
+            formData: { state: true },
+        };
+    }
+
+    private procedureOpties: SelectOption[] = [
+        { label: 'Standaard', value: 'standaard' },
+        { label: 'Strikt (vereist code "ABC-123")', value: 'strikt' },
+    ];
+
+    override render() {
+        return html`
+            <form class="vl-form" @submit=${this.onSubmit} @reset=${this.onReset}>
+                <div class="vl-grid">
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="procedure" label="Procedure *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-select
+                            id="procedure"
+                            name="procedure"
+                            block
+                            required
+                            placeholder="Kies een procedure"
+                            .options=${this.procedureOpties}
+                        ></vl-select>
+                        <vl-form-message for="procedure" state="valueMissing"
+                            >Gelieve een procedure te kiezen.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--4">
+                        <vl-form-label for="code" label="Code *" block></vl-form-label>
+                    </div>
+                    <div class="vl-column vl-column--8">
+                        <vl-input-field-with-cross-validator
+                            id="code"
+                            name="code"
+                            block
+                            required
+                        ></vl-input-field-with-cross-validator>
+                        <vl-form-message for="code" state="valueMissing"
+                            >Gelieve een code in te vullen.</vl-form-message
+                        >
+                        <vl-form-message for="code" state="customError"
+                            >Bij de strikte procedure moet de code 'ABC-123' zijn.</vl-form-message
+                        >
+                    </div>
+                    <div class="vl-column vl-column--8 vl-column--start-5">
+                        <div class="form-buttons">
+                            <vl-button type="submit">Verstuur</vl-button>
+                            <vl-button type="reset" secondary>Reset</vl-button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+            ${this.formData ? html`<pre>${JSON.stringify(this.formData, null, 2)}</pre>` : ''}
+        `;
+    }
+
+    private onSubmit(e: Event) {
+        e.preventDefault();
+        this.formData = parseFormData(e.target as HTMLFormElement);
+    }
+
+    private onReset() {
+        this.formData = null;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-input-field-with-cross-validator': VlInputFieldWithCrossValidatorComponent;
+        'vl-form-cross-validation': VlFormCrossValidationComponent;
+    }
+}

--- a/libs/integrations/src/form/demo/vl-form-demo.component.cy.ts
+++ b/libs/integrations/src/form/demo/vl-form-demo.component.cy.ts
@@ -123,6 +123,31 @@ describe('cypress-component - integrations - vl-form-demo', () => {
         // */
     });
 
+    it('should validate individual form controls on blur', () => {
+        cy.mount(html`<vl-form-demo></vl-form-demo>`);
+        createStubForSubmitEvent();
+
+        getFormMessages().should('have.length', 0);
+
+        getNaamInput().find('input').focus().blur();
+        getFormMessages({ forAttr: 'naam', state: 'valueMissing' });
+        getFormMessages().should('have.length', 1);
+
+        getNaamInput().find('input').type('a').blur();
+        getFormMessages({ forAttr: 'naam', state: 'tooShort' });
+        getFormMessages().should('have.length', 1);
+
+        getNaamInput().find('input').clear().type('Spaas').blur();
+        getFormMessages({ forAttr: 'naam', state: 'valid' });
+        getFormMessages().should('have.length', 1);
+
+        getInteressesTextarea().find('textarea').focus().blur();
+        getFormMessages({ forAttr: 'interesses', state: 'valueMissing' });
+        getFormMessages().should('have.length', 2);
+
+        cy.get('@submit').should('not.have.been.called');
+    });
+
     it('should reset form', () => {
         cy.mount(html`<vl-form-demo></vl-form-demo>`);
 

--- a/libs/integrations/src/form/demo/vl-form-demo.component.ts
+++ b/libs/integrations/src/form/demo/vl-form-demo.component.ts
@@ -99,7 +99,12 @@ export class VlFormDemoComponent extends LitElement {
 
     override render() {
         return html`
-            <form id="form" class="vl-form" @submit=${this.onSubmit}>
+            <form
+                id="form"
+                class="vl-form"
+                blur-validation
+                @submit=${this.onSubmit}
+            >
                 <div class="vl-grid vl-stacked-small">
                     <div class="vl-column vl-column--4 vl-column--s-12">
                         <vl-form-label for="naam" label="Naam *"></vl-form-label>

--- a/libs/integrations/src/form/index.ts
+++ b/libs/integrations/src/form/index.ts
@@ -1,3 +1,8 @@
+export {
+    VlFormCrossValidationComponent,
+    VlFormCrossValidationConditionalComponent,
+    VlFormCrossValidationMatchComponent,
+} from './cross-validation';
 export { VlFormCustomValidationComponent } from './custom-validation';
 export { VlFormDemoComponent } from './demo';
 export { VlFormDataComponent } from './form-data';


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-610

Cross-validatie: een veld valideren tegen de waarde van een **ander** veld in hetzelfde formulier. De validator krijgt `dependencySelectors`, en de `CrossValidationMixin` hervalideert het veld zodra een van die velden wijzigt.

## Wat kan je afnemen

| | |
|---|---|
| `CrossValidationMixin` | echte API, importeerbaar uit `@domg-wc/components/form` (bron: `libs/components/src/form/utils`) |
| de drie voorbeelden in `libs/integrations` | referentiecode om over te nemen in je eigen project, geen publiceerbare componenten |

## Impact op gedeelde code

De logica zit in de mixin, niet in `FormControl`. Die base krijgt enkel twee generieke hooks (`retainsValidationState` en `revalidate`), samen +11/-1 op code die élke form control erft.

Daarnaast twee bugfixes op `form-control`:

- de error-state wordt gewist zodra het veld geldig wordt na een eerste validatie
- de blur-validation timeout wordt opgeruimd bij reset en herfocus

## Voorbeelden en docs

Drie patronen, elk met cypress component-tests: een afhankelijke waarde, twee velden die moeten overeenkomen, en een conditioneel verplicht veld. Gedocumenteerd onder Patronen/Formulier/cross-validatie.

## Review verwerkt

- `CrossValidationMixin` verhuisd naar `components/src/form/utils`, met een relatieve import naar `FormControl` en opgenomen in beide barrels
- `required-hint` uit deze PR gehaald, wordt via een apart ticket opgenomen
