### PR TITLE
feat: FLUX-742 - vl-datepicker - anchor-positioning standaard aan met inline-positioning opt-out

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -121,7 +121,7 @@ export class AppComponent extends LitElement {
                             </p>
                             <div style="display: flex; gap: 20px; margin-top: 16px;">
                                 <div style="flex: 1; border: 2px dashed crimson; padding: 12px; background: #fffbe6;">
-                                    <strong style="color: crimson;">A — default mode (bug)</strong>
+                                    <strong style="color: crimson;">A — inline-positioning (oude hack, bug)</strong>
                                     <p style="margin: 4px 0 8px; font-size: 13px; color: #666;">
                                         getBoundingClientRect-hack — calendar landt op verkeerde plek / clipt door overflow.
                                     </p>
@@ -130,12 +130,12 @@ export class AppComponent extends LitElement {
                                                border: 1px solid #ccc; padding: 10px;"
                                     >
                                         <div style="height: 60px;"></div>
-                                        <vl-datepicker label="Vanaf"></vl-datepicker>
+                                        <vl-datepicker label="Vanaf" inline-positioning></vl-datepicker>
                                         <div style="height: 400px;"></div>
                                     </div>
                                 </div>
                                 <div style="flex: 1; border: 2px dashed green; padding: 12px; background: #f0fff0;">
-                                    <strong style="color: green;">B — anchor-positioning opt-in (fix)</strong>
+                                    <strong style="color: green;">B — default (anchor-positioning, fix)</strong>
                                     <p style="margin: 4px 0 8px; font-size: 13px; color: #666;">
                                         Popover top-layer + CSS Anchor Positioning — ontsnapt aan ancestor context.
                                     </p>
@@ -144,7 +144,7 @@ export class AppComponent extends LitElement {
                                                border: 1px solid #ccc; padding: 10px;"
                                     >
                                         <div style="height: 60px;"></div>
-                                        <vl-datepicker label="Vanaf" anchor-positioning></vl-datepicker>
+                                        <vl-datepicker label="Vanaf"></vl-datepicker>
                                         <div style="height: 400px;"></div>
                                     </div>
                                 </div>

--- a/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
+++ b/apps/storybook/docs/d_planning/4_van-v2-naar-v3-beschikbaar.mdx
@@ -29,9 +29,10 @@ witte rij
 
 ### Datepicker
 
-In v2 is het `anchor-positioning` attribuut toegevoegd. In v3 wordt deze codepath de default
-en wordt de oude positionering verwijderd. Apps die `anchor-positioning` in v2 niet hebben gezet
-moeten na de v3 upgrade verifiëren dat hun datepicker correct rendert.
+In v2 is de anchor-positioning codepath (Popover API + CSS Anchor Positioning) de default geworden.
+Wie het oude gedrag nodig heeft kan terugvallen via het `inline-positioning` attribuut. In v3 wordt
+de oude positionering én het `inline-positioning` attribuut volledig verwijderd. Apps moeten na de
+upgrade verifiëren dat hun datepicker correct rendert.
 
 <table  style={{width: 100 + '%'}}>
     <tr>
@@ -44,9 +45,9 @@ moeten na de v3 upgrade verifiëren dat hun datepicker correct rendert.
     <tr>
         <td>[Datepicker](/docs/components-form-datepicker--documentatie)</td>
         <td>release v2.14.0</td>
-        <td>flatpickr getBoundingClientRect positionering</td>
         <td>Popover API + CSS Anchor Positioning</td>
-        <td><code>{`<vl-datepicker anchor-positioning>`}</code></td>
+        <td>Popover API + CSS Anchor Positioning (opt-out verwijderd)</td>
+        <td><code>{`<vl-datepicker inline-positioning>`}</code></td>
     </tr>
 </table>
 

--- a/libs/components/src/block/modal/stories/vl-modal.stories.ts
+++ b/libs/components/src/block/modal/stories/vl-modal.stories.ts
@@ -64,7 +64,7 @@ export const modalDefault = story(
                 ?focus-on-modal=${focusOnModal}
             >
                 <span slot="content">
-                    <vl-datepicker block label="Kies een datum" anchor-positioning></vl-datepicker>
+                    <vl-datepicker block label="Kies een datum"></vl-datepicker>
                     Lorem ipsum dolor sit amet.
                 </span>
                 <vl-button slot="button">Start aanvraag</vl-button>

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-arg.ts
@@ -10,7 +10,7 @@ type DatepickerArgs = typeof formControlArgs &
         onVlChange: () => void;
         onVlInput: () => void;
         onVlValid: () => void;
-        anchorPositioning: boolean;
+        inlinePositioning: boolean;
     };
 
 export const datepickerArgs: DatepickerArgs & { helperText?: string } = {
@@ -19,7 +19,7 @@ export const datepickerArgs: DatepickerArgs & { helperText?: string } = {
     onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlValid: action('vl-valid'),
-    anchorPositioning: false,
+    inlinePositioning: false,
     helperText: '',
 };
 
@@ -219,12 +219,13 @@ export const datepickerArgTypes: ArgTypes<DatepickerArgs> = {
         },
         control: false,
     },
-    anchorPositioning: {
-        name: 'anchor-positioning',
+    inlinePositioning: {
+        name: 'inline-positioning',
         description:
-            'Activeert CSS Anchor Positioning + Popover API voor de kalender positionering. ' +
-            'Dit zorgt ervoor dat de kalender correct wordt gepositioneerd in scrollbare containers ' +
-            'en niet wordt afgekapt door overflow of transform op ancestor-elementen (bijv. in een modal).',
+            'Schakelt terug naar de klassieke flatpickr-positionering: de kalender rendert inline in de ' +
+            'shadow DOM in plaats van de top-layer. Standaard (zonder dit attribuut) gebruikt de datepicker ' +
+            'CSS Anchor Positioning + Popover API, zodat de kalender niet wordt afgekapt door overflow of ' +
+            'transform op ancestor-elementen (bijv. in een modal).',
         table: {
             type: { summary: TYPES.BOOLEAN },
             category: CATEGORIES.ATTRIBUTES,

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories-doc.mdx
@@ -38,22 +38,25 @@ import { VlDatepickerComponent } from '@domg-wc/components/form';
 
 ## Positionering
 
-De datepicker kalender positioneert zichzelf automatisch. Indien de automatische positionering niet het gewenste
-resultaat oplevert, kan dit op drie manieren aangepast worden:
+De datepicker kalender positioneert zichzelf automatisch. Standaard rendert de kalender in de browser top-layer
+(via CSS Anchor Positioning + Popover API), zodat ancestor `transform`, `overflow` of `sticky` de positionering
+niet kan breken. Indien de automatische positionering niet het gewenste resultaat oplevert, kan dit op drie
+manieren aangepast worden:
 
 -   Het `position` attribuut: mogelijke waarden zijn: "auto" (default), "above", "below", "auto left", "auto center",
     "auto right", "above left", "above center", "above right", "below left", "below center", "below right".
 -   Het `static` attribuut: indien aanwezig wordt andere positionering genegeerd en wordt de kalender
     op een vaste plaats onder het datum invulveld getoond.
--   Het `anchor-positioning` attribuut: indien aanwezig rendert de kalender in de browser top-layer,
-    zodat ancestor `transform`, `overflow` of `sticky` de positionering niet kan breken.
+-   Het `inline-positioning` attribuut: schakelt terug naar de klassieke flatpickr-positionering, waarbij de
+    kalender inline in de shadow DOM rendert in plaats van de top-layer.
 
 ```html
-<vl-datepicker anchor-positioning></vl-datepicker>
+<vl-datepicker inline-positioning></vl-datepicker>
 ```
 
-> ⚠️ `anchor-positioning` wijzigt het render-model (top-layer ipv shadow DOM). Test grondig als
-> je app afhankelijk is van de huidige DOM-positie of stacking volgorde van de kalender.
+> ⚠️ `inline-positioning` valt terug op het oude render-model (shadow DOM ipv top-layer) en kan opnieuw
+> afgekapt worden door ancestor `overflow` of `transform`. Gebruik dit enkel als je app afhankelijk is van
+> de huidige DOM-positie of stacking volgorde van de kalender.
 
 
 ## Formaat

--- a/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
+++ b/libs/components/src/form/datepicker/stories/vl-datepicker.stories.ts
@@ -66,7 +66,7 @@ const DatepickerTemplate = story(
         onVlValid,
         position,
         isStatic,
-        anchorPositioning,
+        inlinePositioning,
         helperText,
     }: typeof datepickerArgs) => {
         return html`
@@ -104,7 +104,7 @@ const DatepickerTemplate = story(
                             @vl-valid=${onVlValid}
                             position=${position}
                             static=${isStatic}
-                            ?anchor-positioning=${anchorPositioning}
+                            ?inline-positioning=${inlinePositioning}
                         >
                         </vl-datepicker>
                     </div>

--- a/libs/components/src/form/datepicker/vl-datepicker-anchor-positioning-placement.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker-anchor-positioning-placement.component.cy.ts
@@ -52,7 +52,7 @@ describe('vl-datepicker - anchor-positioning placement', () => {
         it(`positioneert onder de knop bij position="${position}"`, () => {
             cy.mount(html`
                 <div style="margin-top: 200px; margin-left: 300px;">
-                    <vl-datepicker anchor-positioning position=${position}></vl-datepicker>
+                    <vl-datepicker position=${position}></vl-datepicker>
                 </div>
             `);
             openAndAssert((b, c) => {
@@ -73,7 +73,7 @@ describe('vl-datepicker - anchor-positioning placement', () => {
         it(`positioneert boven de knop bij position="${position}"`, () => {
             cy.mount(html`
                 <div style="margin-top: 400px; margin-left: 300px;">
-                    <vl-datepicker anchor-positioning position=${position}></vl-datepicker>
+                    <vl-datepicker position=${position}></vl-datepicker>
                 </div>
             `);
             openAndAssert((b, c) => {
@@ -87,7 +87,7 @@ describe('vl-datepicker - anchor-positioning placement', () => {
     it('flipt naar boven bij position="auto" met weinig ruimte onder', () => {
         cy.mount(html`
             <div style="margin-top: 620px; margin-left: 300px;">
-                <vl-datepicker anchor-positioning position="auto"></vl-datepicker>
+                <vl-datepicker position="auto"></vl-datepicker>
             </div>
         `);
         openAndAssert((b, c) => above(b, c));
@@ -98,7 +98,7 @@ describe('vl-datepicker - anchor-positioning placement', () => {
         cy.mount(html`
             <div style="transform: translateX(0); overflow: auto; max-height: 300px; padding: 80px; margin: 50px;">
                 <div style="height: 100px;"></div>
-                <vl-datepicker anchor-positioning></vl-datepicker>
+                <vl-datepicker></vl-datepicker>
                 <div style="height: 400px;"></div>
             </div>
         `);

--- a/libs/components/src/form/datepicker/vl-datepicker-anchor-positioning.component.cy.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker-anchor-positioning.component.cy.ts
@@ -16,23 +16,58 @@ describe('vl-datepicker - anchor-positioning (polyfill)', () => {
         return cy.get('vl-datepicker').shadow().find('.flatpickr-calendar');
     };
 
-    it('should render the calendar in the top-layer popover when anchor-positioning is set', () => {
-        cy.mount(html`<vl-datepicker anchor-positioning></vl-datepicker>`);
+    it('should render the calendar in the top-layer popover by default', () => {
+        cy.mount(html`<vl-datepicker></vl-datepicker>`);
 
         openCalendar().should('have.class', 'open').should('have.attr', 'popover', 'manual');
     });
 
-    it('should not use popover when anchor-positioning is not set', () => {
-        cy.mount(html`<vl-datepicker></vl-datepicker>`);
+    it('should not use popover when inline-positioning is set', () => {
+        cy.mount(html`<vl-datepicker inline-positioning></vl-datepicker>`);
 
         openCalendar().should('have.class', 'open').should('not.have.attr', 'popover');
     });
 
     positions.forEach((position) => {
-        it(`should activate the popover with anchor-positioning and position="${position}"`, () => {
-            cy.mount(html`<vl-datepicker anchor-positioning position=${position}></vl-datepicker>`);
+        it(`should activate the popover by default with position="${position}"`, () => {
+            cy.mount(html`<vl-datepicker position=${position}></vl-datepicker>`);
 
             openCalendar().should('have.class', 'open').should('have.attr', 'popover', 'manual');
+        });
+    });
+
+    describe('static heeft voorrang op de anchor-modus', () => {
+        it('should render a static calendar without popover under the default (anchor) mode', () => {
+            cy.mount(html`<vl-datepicker static value="2024-04-15"></vl-datepicker>`);
+
+            openCalendar().should(($cal) => {
+                expect($cal).to.have.class('open');
+                expect($cal).to.have.class('static');
+                expect($cal[0].hasAttribute('popover'), 'geen popover').to.be.false;
+                expect($cal[0].hasAttribute('style'), 'geen inline style').to.be.false;
+            });
+        });
+
+        it('should render a static calendar without popover when inline-positioning is also set', () => {
+            cy.mount(html`<vl-datepicker static inline-positioning value="2024-04-15"></vl-datepicker>`);
+
+            openCalendar().should(($cal) => {
+                expect($cal).to.have.class('open');
+                expect($cal).to.have.class('static');
+                expect($cal[0].hasAttribute('popover'), 'geen popover').to.be.false;
+                expect($cal[0].hasAttribute('style'), 'geen inline style').to.be.false;
+            });
+        });
+
+        ['above', 'below center', 'auto right'].forEach((position) => {
+            it(`should stay static and ignore position="${position}" (no popover)`, () => {
+                cy.mount(html`<vl-datepicker static position=${position} value="2024-04-15"></vl-datepicker>`);
+
+                openCalendar()
+                    .should('have.class', 'open')
+                    .should('have.class', 'static')
+                    .should('not.have.attr', 'popover');
+            });
         });
     });
 
@@ -43,7 +78,7 @@ describe('vl-datepicker - anchor-positioning (polyfill)', () => {
         it('should activate the popover when ancestor has transform', () => {
             cy.mount(html`
                 <div style="transform: translateX(0); padding: 100px;">
-                    <vl-datepicker anchor-positioning></vl-datepicker>
+                    <vl-datepicker></vl-datepicker>
                 </div>
             `);
 
@@ -54,7 +89,7 @@ describe('vl-datepicker - anchor-positioning (polyfill)', () => {
             cy.mount(html`
                 <div style="overflow: auto; max-height: 300px; padding: 80px;">
                     <div style="height: 100px;"></div>
-                    <vl-datepicker anchor-positioning></vl-datepicker>
+                    <vl-datepicker></vl-datepicker>
                     <div style="height: 400px;"></div>
                 </div>
             `);
@@ -69,7 +104,7 @@ describe('vl-datepicker - anchor-positioning (polyfill)', () => {
                            padding: 80px; margin: 50px;"
                 >
                     <div style="height: 100px;"></div>
-                    <vl-datepicker anchor-positioning></vl-datepicker>
+                    <vl-datepicker></vl-datepicker>
                     <div style="height: 400px;"></div>
                 </div>
             `);
@@ -92,7 +127,7 @@ describe('vl-datepicker - anchor-positioning (polyfill)', () => {
             cy.mount(html`
                 <vl-modal id="test-modal" title="Modal" size=${size} position=${modalPosition}>
                     <span slot="content">
-                        <vl-datepicker anchor-positioning></vl-datepicker>
+                        <vl-datepicker></vl-datepicker>
                     </span>
                 </vl-modal>
             `);

--- a/libs/components/src/form/datepicker/vl-datepicker.component.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.component.ts
@@ -51,7 +51,7 @@ export class VlDatepickerComponent extends FormControl {
     private pattern = datepickerDefaults.pattern; // Wordt enkel gebruikt in de mask validator
     private position = datepickerDefaults.position;
     private isStatic = datepickerDefaults.isStatic;
-    private anchorPositioning = false;
+    private inlinePositioning = false;
     private polyfillReady = AnchorPositioningController.isNativelySupported();
     // Controllers
     private anchorController = new AnchorPositioningController(this);
@@ -99,7 +99,7 @@ export class VlDatepickerComponent extends FormControl {
             isOpen: { type: Boolean, state: true },
             position: { type: String },
             isStatic: { type: Boolean, attribute: 'static' },
-            anchorPositioning: { type: Boolean, attribute: 'anchor-positioning' },
+            inlinePositioning: { type: Boolean, attribute: 'inline-positioning' },
             polyfillReady: { type: Boolean, state: true },
         };
     }
@@ -108,9 +108,9 @@ export class VlDatepickerComponent extends FormControl {
         return this.shadowRoot?.querySelector('input');
     }
 
-    /** Anchor-modus enkel als het attribuut gezet is én de polyfills geladen zijn (anders default positionering). */
+    /** Anchor-modus is default; enkel uit als `inline-positioning` gezet is. Vereist geladen polyfills. */
     private get useAnchorPositioning(): boolean {
-        return this.anchorPositioning && this.polyfillReady;
+        return !this.inlinePositioning && this.polyfillReady;
     }
 
     connectedCallback() {
@@ -160,7 +160,7 @@ export class VlDatepickerComponent extends FormControl {
             this.cleaveInstance = new Cleave(this.validationTarget!, this.maskOptions);
         }
 
-        if (this.anchorPositioning && !this.polyfillReady && this.shadowRoot) {
+        if (!this.inlinePositioning && !this.polyfillReady && this.shadowRoot) {
             this.polyfillReady = await AnchorPositioningController.ensureSupport();
         }
 
@@ -171,13 +171,13 @@ export class VlDatepickerComponent extends FormControl {
     updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
 
-        if (changedProperties.has('anchorPositioning') && this.anchorPositioning && !this.polyfillReady && this.shadowRoot) {
+        if (changedProperties.has('inlinePositioning') && !this.inlinePositioning && !this.polyfillReady && this.shadowRoot) {
             AnchorPositioningController.ensureSupport().then((ok) => {
                 this.polyfillReady = ok;
             });
         }
         if (
-            (changedProperties.has('anchorPositioning') || changedProperties.has('polyfillReady')) &&
+            (changedProperties.has('inlinePositioning') || changedProperties.has('polyfillReady')) &&
             this.flatpickrInstance &&
             !this.isStatic
         ) {

--- a/libs/components/src/form/datepicker/vl-datepicker.positioning-css.ts
+++ b/libs/components/src/form/datepicker/vl-datepicker.positioning-css.ts
@@ -18,22 +18,22 @@ export const vlDatepickerPositioningStyles: CSSResult = css`
     /* Anchor-regels in @supports: browsers zonder CSS Anchor Positioning negeren ze en vallen terug
        op de default hierboven (de useAnchorPositioning getter in JS spiegelt deze detect). */
     @supports (anchor-name: --x) {
-    :host([anchor-positioning]) {
+    :host(:not([inline-positioning])) {
         anchor-scope: --datepicker-btn;
     }
 
-    :host([anchor-positioning]) button#toggle-calendar {
+    :host(:not([inline-positioning])) button#toggle-calendar {
         anchor-name: --datepicker-btn;
     }
 
-    :host([anchor-positioning]) #datepicker-calendar-placeholder {
+    :host(:not([inline-positioning])) #datepicker-calendar-placeholder {
         position: static;
         width: auto;
         z-index: auto;
     }
 
     /* Default: onder de button, links uitgelijnd, 2px gap. */
-    :host([anchor-positioning]) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])) .flatpickr-calendar:not(.static) {
         position: fixed;
         position-anchor: --datepicker-btn;
         top: calc(anchor(bottom) + 2px);
@@ -61,27 +61,27 @@ export const vlDatepickerPositioningStyles: CSSResult = css`
         right: 0;
     }
 
-    :host([anchor-positioning]) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])) .flatpickr-calendar:not(.static) {
         position-try-fallbacks: --align-right-below, --flip-above, --align-right-above;
     }
 
     /* Position mapping per position attribuut */
 
     /* auto varianten — met flip */
-    :host([anchor-positioning][position='auto']) .flatpickr-calendar:not(.static),
-    :host([anchor-positioning]:not([position])) .flatpickr-calendar:not(.static),
-    :host([anchor-positioning][position='auto left']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='auto']) .flatpickr-calendar:not(.static),
+    :host(:not([inline-positioning]):not([position])) .flatpickr-calendar:not(.static),
+    :host(:not([inline-positioning])[position='auto left']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         left: anchor(left);
         position-try-fallbacks: --align-right-below, --flip-above, --align-right-above;
     }
-    :host([anchor-positioning][position='auto center']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='auto center']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         left: anchor(center);
         translate: -50% 0;
         position-try-fallbacks: --flip-above;
     }
-    :host([anchor-positioning][position='auto right']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='auto right']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         right: anchor(right);
         left: auto;
@@ -89,21 +89,21 @@ export const vlDatepickerPositioningStyles: CSSResult = css`
     }
 
     /* above varianten — zonder flip */
-    :host([anchor-positioning][position='above']) .flatpickr-calendar:not(.static),
-    :host([anchor-positioning][position='above left']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='above']) .flatpickr-calendar:not(.static),
+    :host(:not([inline-positioning])[position='above left']) .flatpickr-calendar:not(.static) {
         top: auto;
         bottom: calc(anchor(top) + 2px);
         left: anchor(left);
         position-try-fallbacks: none;
     }
-    :host([anchor-positioning][position='above center']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='above center']) .flatpickr-calendar:not(.static) {
         top: auto;
         bottom: calc(anchor(top) + 2px);
         left: anchor(center);
         translate: -50% 0;
         position-try-fallbacks: none;
     }
-    :host([anchor-positioning][position='above right']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='above right']) .flatpickr-calendar:not(.static) {
         top: auto;
         bottom: calc(anchor(top) + 2px);
         right: anchor(right);
@@ -112,19 +112,19 @@ export const vlDatepickerPositioningStyles: CSSResult = css`
     }
 
     /* below varianten — zonder flip */
-    :host([anchor-positioning][position='below']) .flatpickr-calendar:not(.static),
-    :host([anchor-positioning][position='below left']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='below']) .flatpickr-calendar:not(.static),
+    :host(:not([inline-positioning])[position='below left']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         left: anchor(left);
         position-try-fallbacks: none;
     }
-    :host([anchor-positioning][position='below center']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='below center']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         left: anchor(center);
         translate: -50% 0;
         position-try-fallbacks: none;
     }
-    :host([anchor-positioning][position='below right']) .flatpickr-calendar:not(.static) {
+    :host(:not([inline-positioning])[position='below right']) .flatpickr-calendar:not(.static) {
         top: calc(anchor(bottom) + 2px);
         right: anchor(right);
         left: auto;

--- a/libs/components/src/form/form.web-types.json
+++ b/libs/components/src/form/form.web-types.json
@@ -249,8 +249,8 @@
                             "default": "false"
                         },
                         {
-                            "name": "anchor-positioning",
-                            "description": "Activeert CSS Anchor Positioning + Popover API voor de kalender positionering. Dit zorgt ervoor dat de kalender correct wordt gepositioneerd in scrollbare containers en niet wordt afgekapt door overflow of transform op ancestor-elementen (bijv. in een modal).",
+                            "name": "inline-positioning",
+                            "description": "Schakelt terug naar de klassieke flatpickr-positionering: de kalender rendert inline in de shadow DOM in plaats van de top-layer. Standaard (zonder dit attribuut) gebruikt de datepicker CSS Anchor Positioning + Popover API, zodat de kalender niet wordt afgekapt door overflow of transform op ancestor-elementen (bijv. in een modal).",
                             "default": "false"
                         }
                     ],


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-742