### PR TITLE
feat: FLUX-774 - vl-video-player - type attribuut voor expliciet mimetype

### DIFF
--- a/libs/components/src/block/video-player/stories/vl-video-player.stories-arg.ts
+++ b/libs/components/src/block/video-player/stories/vl-video-player.stories-arg.ts
@@ -47,4 +47,15 @@ export const videoPlayerArgTypes: ArgTypes<VideoPlayerArgs> = {
             defaultValue: { summary: videoPlayerArgs.poster },
         },
     },
+    type: {
+        name: 'type',
+        description:
+            'Stelt het mediatype (mimetype) van de bron in, bv. "video/mp4". Nodig wanneer de source-URL geen' +
+            ' bestandsextensie bevat; anders wordt het type uit de extensie afgeleid.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: videoPlayerArgs.type },
+        },
+    },
 };

--- a/libs/components/src/block/video-player/stories/vl-video-player.stories-doc.mdx
+++ b/libs/components/src/block/video-player/stories/vl-video-player.stories-doc.mdx
@@ -27,6 +27,20 @@ import { VlVideoPlayerComponent } from '@domg-wc/components/block';
 <Canvas of={VlVideoPlayerStories.VideoPlayerDefault} />
 
 
+## Mediatype instellen
+
+Standaard leidt de speler het mediatype af uit de bestandsextensie in de `source`-URL (bv. `.mp4`).
+Wanneer de bron-URL geen extensie bevat - bijvoorbeeld een download- of API-link zoals
+`https://.../stukken/123/download` - kan het type niet afgeleid worden. Zet het `type`-attribuut in dat geval
+expliciet:
+
+```html
+<vl-video-player source="https://.../stukken/123/download" type="video/mp4"></vl-video-player>
+```
+
+Ondersteunde waarden zijn de video-mimetypes van de speler, o.a. `video/mp4`, `video/webm`, `video/ogg`.
+
+
 ## Configuratie
 
 <ArgTypes of={VlVideoPlayerStories.VideoPlayerDefault} />

--- a/libs/components/src/block/video-player/stories/vl-video-player.stories.ts
+++ b/libs/components/src/block/video-player/stories/vl-video-player.stories.ts
@@ -20,8 +20,9 @@ export default {
 
 export const VideoPlayerDefault = story<VideoPlayerArgs>(
     videoPlayerArgs,
-    ({ source, subtitles, poster, title }) => html`
-        <vl-video-player title=${title} source=${source} subtitles=${subtitles} poster=${poster}> </vl-video-player>
+    ({ source, subtitles, poster, title, type }) => html`
+        <vl-video-player title=${title} source=${source} subtitles=${subtitles} poster=${poster} type=${type}>
+        </vl-video-player>
     `
 );
 VideoPlayerDefault.storyName = 'vl-video-player - default';

--- a/libs/components/src/block/video-player/vl-video-player.component.cy.ts
+++ b/libs/components/src/block/video-player/vl-video-player.component.cy.ts
@@ -54,6 +54,18 @@ describe('cypress-component - block components - vl-video-player', () => {
             .should('have.attr', 'aria-label', `Afspelen, ${title}`);
     });
 
+    it('should set source with an explicit type via a source element', () => {
+        cy.mount(html`<vl-video-player source=${source} type="video/mp4"></vl-video-player>`);
+
+        cy.get('vl-video-player')
+            .shadow()
+            .find('media-provider')
+            .find('video')
+            .find('source')
+            .should('have.attr', 'src', source)
+            .and('have.attr', 'type', 'video/mp4');
+    });
+
     it('should set poster', () => {
         cy.mount(html`<vl-video-player source=${source} poster=${poster}></vl-video-player>`);
 

--- a/libs/components/src/block/video-player/vl-video-player.component.ts
+++ b/libs/components/src/block/video-player/vl-video-player.component.ts
@@ -1,6 +1,6 @@
 import { BaseLitElement, webComponent } from '@domg-wc/common';
 import { CSSResult, html, PropertyDeclarations, PropertyValues } from 'lit';
-import { TextTrackInit } from 'vidstack';
+import { TextTrackInit, VideoMimeType } from 'vidstack';
 import { MediaPlayerElement } from 'vidstack/elements';
 import { PlyrLayout, VidstackPlayer } from 'vidstack/global/player';
 import videoPlayerStyles from './vl-video-player.css';
@@ -12,6 +12,7 @@ export class VlVideoPlayerComponent extends BaseLitElement {
     private poster: string | undefined;
     private source: string | undefined;
     private subtitles: string | undefined;
+    private type: string | undefined;
 
     static get styles(): (CSSResult | CSSResult[])[] {
         return [...videoPlayerStyles];
@@ -23,6 +24,7 @@ export class VlVideoPlayerComponent extends BaseLitElement {
             poster: { type: String },
             source: { type: String },
             subtitles: { type: String },
+            type: { type: String },
         };
     }
 
@@ -43,7 +45,10 @@ export class VlVideoPlayerComponent extends BaseLitElement {
         this.playerInstance = await VidstackPlayer.create({
             target: video,
             title: this.title,
-            src: this.source,
+            src:
+                this.type && this.source
+                    ? [{ src: this.source, type: this.type as VideoMimeType }]
+                    : this.source,
             poster: this.poster,
             layout: new PlyrLayout({ translations: plyrTranslations, clickToPlay: true }),
         });

--- a/libs/components/src/block/video-player/vl-video-player.defaults.ts
+++ b/libs/components/src/block/video-player/vl-video-player.defaults.ts
@@ -3,4 +3,5 @@ export const videoPlayerDefaults = {
     source: '' as string,
     subtitles: '' as string,
     poster: '' as string,
+    type: '' as string,
 } as const;


### PR DESCRIPTION
Voegt een optioneel 'type'-attribuut toe zodat een bron-URL zonder bestandsextensie (bv. een download-/API-link) toch afgespeeld kan worden. Bij gezet type geeft de component src als { src, type } aan vidstack, dat een <source>-element rendert i.p.v. het src-attribuut. Zonder type blijft het bestaande gedrag (extensie-inferentie) ongewijzigd.

https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-774
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC423