### PR TITLE
fix: FLUX-775 - vl-cookie-consent-opt-in - dubbele attribute-binding in test opgelost

### DIFF
--- a/libs/components/src/compliance/cookie-consent/vl-cookie-consent-opt-in.component.cy.ts
+++ b/libs/components/src/compliance/cookie-consent/vl-cookie-consent-opt-in.component.cy.ts
@@ -10,7 +10,6 @@ type MountDefaultProps = {
     checked?: boolean;
     mandatory?: boolean;
     disabled?: boolean;
-    error?: boolean;
 };
 
 const mountDefault = (props: MountDefaultProps) => {
@@ -21,7 +20,6 @@ const mountDefault = (props: MountDefaultProps) => {
             checked=${props.checked}
             mandatory=${props.mandatory}
             disabled=${props.disabled}
-            checked=${props.error}
         ></vl-cookie-consent-opt-in>`
     );
 };
@@ -32,7 +30,6 @@ const props = {
     checked: true,
     mandatory: true,
     disabled: true,
-    error: true,
 };
 
 describe('cypress-component - compliance components - vl-cookie-consent-opt-in', () => {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-775
http://bamboo.cumuli.be:8080/bamboo/browse/FLUX-CFWC424 ✅ 

## Wijziging

`mountDefault` had een tweede `checked=`-binding op hetzelfde element (copy-paste typo).
Die regel is geschrapt, samen met het bijhorende ongebruikte type-veld en prop.

## Waarom

lit's dev-build faalt op dubbele attribute-bindings ("Detected duplicate attribute
bindings"). Onder pnpm's strikte resolutie werd dat getriggerd, onder npm bleef het
verborgen: een latente bug.

## Verificatie

Enkel dit spec-bestand (3 schrappingen). Cypress-spec 6/6 groen, incl. a11y.
