### PR TITLE
fix: FLUX-781 - build - dependency-injectie via node in plaats van jq

### DIFF
--- a/resources/bash-scripts/libs-add-dependencies.sh
+++ b/resources/bash-scripts/libs-add-dependencies.sh
@@ -19,14 +19,8 @@ npm list $(npx depcheck ./build/dist/libs/components --oneline | tail -n +2) --j
 npm list $(npx depcheck ./build/dist/libs/map --oneline | tail -n +2) --json --depth 0 > ./build/dep-to-add/map-dta.json
 
 # breidt de package.json's van de libraries uit met de ontbrekende dependencies
-cd ./build/dist/libs/common
-jq -r '.dependencies | to_entries[] | "jq '\''.dependencies[\"\(.key)\"]=\"\(.value.version)\"'\'' package.json > tmp.json && mv tmp.json package.json"' ../../../dep-to-add/common-dta.json | bash
-cd ../styles
-jq -r '.dependencies | to_entries[] | "jq '\''.dependencies[\"\(.key)\"]=\"\(.value.version)\"'\'' package.json > tmp.json && mv tmp.json package.json"' ../../../dep-to-add/styles-dta.json | bash
-cd ../components
-jq -r '.dependencies | to_entries[] | "jq '\''.dependencies[\"\(.key)\"]=\"\(.value.version)\"'\'' package.json > tmp.json && mv tmp.json package.json"' ../../../dep-to-add/components-dta.json | bash
-cd ../map
-jq -r '.dependencies | to_entries[] | "jq '\''.dependencies[\"\(.key)\"]=\"\(.value.version)\"'\'' package.json > tmp.json && mv tmp.json package.json"' ../../../dep-to-add/map-dta.json | bash
-
-# back to the root folder
-cd ../../../..
+for LIB in common styles components map; do
+    node ./resources/utils-build/add-dependencies.mjs \
+        ./build/dep-to-add/${LIB}-dta.json \
+        ./build/dist/libs/${LIB}/package.json
+done

--- a/resources/utils-build/add-dependencies.mjs
+++ b/resources/utils-build/add-dependencies.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const [dependenciesFile, packageFile] = process.argv.slice(2);
+
+if (!dependenciesFile || !packageFile) {
+    console.error('gebruik: node add-dependencies.mjs <dta-bestand> <package.json>');
+    process.exit(1);
+}
+
+const readJson = (file) => {
+    try {
+        return JSON.parse(readFileSync(file, 'utf8'));
+    } catch (error) {
+        console.error(`add-dependencies faalde: kan '${file}' niet lezen - ${error.message}`);
+        process.exit(1);
+    }
+};
+
+const toAdd = readJson(dependenciesFile).dependencies ?? {};
+const packageJson = readJson(packageFile);
+
+packageJson.dependencies ??= {};
+
+for (const [name, entry] of Object.entries(toAdd)) {
+    if (!entry?.version) {
+        console.error(`add-dependencies faalde: geen versie voor '${name}' in '${dependenciesFile}'`);
+        process.exit(1);
+    }
+
+    packageJson.dependencies[name] = entry.version;
+}
+
+writeFileSync(packageFile, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+console.log(`[done] - add-dependencies - ${packageFile} (${Object.keys(toAdd).length} dependencies)`);


### PR DESCRIPTION
jq zit niet in de cypress CI-image en apt-get kan het op de Jenkins-pod niet installeren, want die heeft geen egress naar deb.debian.org. De injectie werd daardoor stil overgeslagen: in de pipeline 'jq ... | bash' telt enkel de exitcode van bash, dus die was 0 en set -e brak niet af. Vanaf 2.17.1 verloren alle vier de gepubliceerde packages hierdoor hun externe dependencies.

De jq-stap is vervangen door resources/utils-build/add-dependencies.mjs. Node zit gegarandeerd in de image, net zoals bij upload-to-artifactory.mjs dat om dezelfde reden curl verving. Een falend node-script geeft een niet-nul exitcode, waardoor set -e de build nu wel afbreekt.

npm pkg set was geen optie: dependencynamen met een punt erin, zoals choices.js en cleave.js, worden dan als een genest pad geinterpreteerd.

De output is byte-identiek aan die van de jq-implementatie, geverifieerd op de dependency-set van het gepubliceerde 2.17.0.