### PR TITLE
fix: FLUX-780 + FLUX-784 - vl-progress-indicator - laatste stap en verbindingslijnen hersteld

### DIFF
--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -6,6 +6,8 @@ import {
     VlPopoverActionListComponent,
     VlPopoverComponent,
     VlPropertiesComponent,
+    VlWizard,
+    VlWizardPane,
 } from '@domg-wc/components/block';
 import { VlHeader } from '@domg-wc/components/compliance';
 import { VlFooter as VlFooterNext } from '@domg-wc/components/compliance/next';
@@ -28,7 +30,45 @@ export class AppComponent extends LitElement {
             VlPropertiesComponent,
             VlFooterNext,
             VlFormCrossValidationComponent,
+            VlWizard,
+            VlWizardPane,
         ]);
+    }
+
+    private showFlux780Wizard() {
+        const container = this.querySelector<HTMLDivElement>('#flux780-container');
+        if (container) {
+            container.style.display = 'block';
+        }
+    }
+
+    private setFlux780Step(wizardId: string, step: number) {
+        const wizard = this.querySelector<HTMLElement & { activeStep: number }>(`#${wizardId}`);
+        if (wizard) {
+            wizard.activeStep = step;
+        }
+    }
+
+    private renderFlux780Panes(wizardId: string) {
+        return html`
+            <vl-wizard-pane name="Type onderdeel">
+                <vl-title type="h3">Type onderdeel</vl-title>
+                <vl-button @click=${() => this.setFlux780Step(wizardId, 2)} type="button">Volgende stap</vl-button>
+            </vl-wizard-pane>
+            <vl-wizard-pane name="Gegevens">
+                <vl-title type="h3">Gegevens</vl-title>
+                <vl-button @click=${() => this.setFlux780Step(wizardId, 1)} secondary type="button"
+                    >Vorige stap</vl-button
+                >
+                <vl-button @click=${() => this.setFlux780Step(wizardId, 3)} type="button">Volgende stap</vl-button>
+            </vl-wizard-pane>
+            <vl-wizard-pane name="Verbindingen">
+                <vl-title type="h3">Verbindingen</vl-title>
+                <vl-button @click=${() => this.setFlux780Step(wizardId, 2)} secondary type="button"
+                    >Vorige stap</vl-button
+                >
+            </vl-wizard-pane>
+        `;
     }
 
     render() {
@@ -156,6 +196,41 @@ export class AppComponent extends LitElement {
                                         <vl-datepicker label="Vanaf"></vl-datepicker>
                                         <div style="height: 400px;"></div>
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="vl-section">
+                        <div class="vl-content-block vl-content-block--full-width">
+                            <vl-title type="h2">FLUX-780: vl-wizard rendert te groot vanuit verborgen container</vl-title>
+                            <p>
+                                Wizard B start in een <code>display:none</code> container (zoals een nog niet geopende
+                                modal). Bij het tonen is de progress-indicator te breed: label "Verbindingen" valt
+                                buiten de rand. Na "Volgende stap" corrigeert hij zichzelf. Wizard A (controle, altijd
+                                zichtbaar) rendert meteen correct.
+                            </p>
+                            <div style="margin-top: 16px;">
+                                <strong style="color: green;">A — controle, altijd zichtbaar</strong>
+                                <div style="max-width: 780px; border: 2px dashed green; padding: 12px;">
+                                    <vl-wizard id="flux780-wizard-control" active-step="1">
+                                        <vl-title slot="title" type="h2">Onderdeel toevoegen</vl-title>
+                                        ${this.renderFlux780Panes('flux780-wizard-control')}
+                                    </vl-wizard>
+                                </div>
+                            </div>
+                            <div style="margin-top: 16px;">
+                                <strong style="color: crimson;">B — start verborgen (modal-scenario, bug)</strong>
+                                <div>
+                                    <vl-button @click=${this.showFlux780Wizard} type="button">
+                                        Toon wizard B (simuleert modal open)
+                                    </vl-button>
+                                </div>
+                                <div id="flux780-container" style="display: none; max-width: 780px; border: 2px dashed crimson; padding: 12px; margin-top: 8px;">
+                                    <vl-wizard id="flux780-wizard-hidden" active-step="1">
+                                        <vl-title slot="title" type="h2">Rapporteringsplichtig onderdeel toevoegen</vl-title>
+                                        ${this.renderFlux780Panes('flux780-wizard-hidden')}
+                                    </vl-wizard>
                                 </div>
                             </div>
                         </div>

--- a/apps/playground-lit/src/app/app.component.ts
+++ b/apps/playground-lit/src/app/app.component.ts
@@ -5,6 +5,7 @@ import {
     VlPopoverActionComponent,
     VlPopoverActionListComponent,
     VlPopoverComponent,
+    VlModalComponent,
     VlPropertiesComponent,
     VlWizard,
     VlWizardPane,
@@ -32,39 +33,44 @@ export class AppComponent extends LitElement {
             VlFormCrossValidationComponent,
             VlWizard,
             VlWizardPane,
+            VlModalComponent,
         ]);
     }
 
-    private showFlux780Wizard() {
-        const container = this.querySelector<HTMLDivElement>('#flux780-container');
+    private openWizardModal() {
+        this.querySelector<VlModalComponent>('#wizard-modal')?.open();
+    }
+
+    private showHiddenWizard() {
+        const container = this.querySelector<HTMLDivElement>('#hidden-wizard-container');
         if (container) {
             container.style.display = 'block';
         }
     }
 
-    private setFlux780Step(wizardId: string, step: number) {
+    private setWizardStep(wizardId: string, step: number) {
         const wizard = this.querySelector<HTMLElement & { activeStep: number }>(`#${wizardId}`);
         if (wizard) {
             wizard.activeStep = step;
         }
     }
 
-    private renderFlux780Panes(wizardId: string) {
+    private renderWizardPanes(wizardId: string) {
         return html`
             <vl-wizard-pane name="Type onderdeel">
                 <vl-title type="h3">Type onderdeel</vl-title>
-                <vl-button @click=${() => this.setFlux780Step(wizardId, 2)} type="button">Volgende stap</vl-button>
+                <vl-button @click=${() => this.setWizardStep(wizardId, 2)} type="button">Volgende stap</vl-button>
             </vl-wizard-pane>
             <vl-wizard-pane name="Gegevens">
                 <vl-title type="h3">Gegevens</vl-title>
-                <vl-button @click=${() => this.setFlux780Step(wizardId, 1)} secondary type="button"
+                <vl-button @click=${() => this.setWizardStep(wizardId, 1)} secondary type="button"
                     >Vorige stap</vl-button
                 >
-                <vl-button @click=${() => this.setFlux780Step(wizardId, 3)} type="button">Volgende stap</vl-button>
+                <vl-button @click=${() => this.setWizardStep(wizardId, 3)} type="button">Volgende stap</vl-button>
             </vl-wizard-pane>
             <vl-wizard-pane name="Verbindingen">
                 <vl-title type="h3">Verbindingen</vl-title>
-                <vl-button @click=${() => this.setFlux780Step(wizardId, 2)} secondary type="button"
+                <vl-button @click=${() => this.setWizardStep(wizardId, 2)} secondary type="button"
                     >Vorige stap</vl-button
                 >
             </vl-wizard-pane>
@@ -213,24 +219,49 @@ export class AppComponent extends LitElement {
                             <div style="margin-top: 16px;">
                                 <strong style="color: green;">A — controle, altijd zichtbaar</strong>
                                 <div style="max-width: 780px; border: 2px dashed green; padding: 12px;">
-                                    <vl-wizard id="flux780-wizard-control" active-step="1">
+                                    <vl-wizard id="wizard-visible" active-step="1">
                                         <vl-title slot="title" type="h2">Onderdeel toevoegen</vl-title>
-                                        ${this.renderFlux780Panes('flux780-wizard-control')}
+                                        ${this.renderWizardPanes('wizard-visible')}
                                     </vl-wizard>
                                 </div>
                             </div>
                             <div style="margin-top: 16px;">
                                 <strong style="color: crimson;">B — start verborgen (modal-scenario, bug)</strong>
                                 <div>
-                                    <vl-button @click=${this.showFlux780Wizard} type="button">
+                                    <vl-button @click=${this.showHiddenWizard} type="button">
                                         Toon wizard B (simuleert modal open)
                                     </vl-button>
                                 </div>
-                                <div id="flux780-container" style="display: none; max-width: 780px; border: 2px dashed crimson; padding: 12px; margin-top: 8px;">
-                                    <vl-wizard id="flux780-wizard-hidden" active-step="1">
+                                <div id="hidden-wizard-container" style="display: none; max-width: 780px; border: 2px dashed crimson; padding: 12px; margin-top: 8px;">
+                                    <vl-wizard id="wizard-hidden" active-step="1">
                                         <vl-title slot="title" type="h2">Rapporteringsplichtig onderdeel toevoegen</vl-title>
-                                        ${this.renderFlux780Panes('flux780-wizard-hidden')}
+                                        ${this.renderWizardPanes('wizard-hidden')}
                                     </vl-wizard>
+                                </div>
+                            </div>
+                            <div style="margin-top: 32px;">
+                                <strong>C — wizard in een vl-modal (streepjes-issue)</strong>
+                                <div>
+                                    <vl-button @click=${this.openWizardModal} type="button">
+                                        Open modal met wizard
+                                    </vl-button>
+                                </div>
+                                <vl-modal id="wizard-modal" title="Rapporteringsplichtig onderdeel toevoegen">
+                                    <div slot="content">
+                                        <vl-wizard id="wizard-in-modal" active-step="1">
+                                            ${this.renderWizardPanes('wizard-in-modal')}
+                                        </vl-wizard>
+                                    </div>
+                                </vl-modal>
+                            </div>
+                            <div style="margin-top: 32px;">
+                                <strong>D — stacking context + ondoorzichtige achtergrond erboven</strong>
+                                <div id="stacking-context" style="isolation: isolate; max-width: 780px;">
+                                    <div style="background: #ffffff; padding: 12px; border: 2px dashed crimson;">
+                                        <vl-wizard id="wizard-in-stacking-context" active-step="1">
+                                            ${this.renderWizardPanes('wizard-in-stacking-context')}
+                                        </vl-wizard>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/libs/components/src/block/progress-indicator/vl-progress-indicator.component.cy.ts
+++ b/libs/components/src/block/progress-indicator/vl-progress-indicator.component.cy.ts
@@ -216,3 +216,28 @@ describe('cypress-component - block components - vl-progress-indicator - labels 
         shouldHaveLastLabelWithinContainer();
     });
 });
+
+describe('cypress-component - block components - vl-progress-indicator - track achter een ondoorzichtige voorouder', () => {
+    const steps = ['Type onderdeel', 'Gegevens', 'Verbindingen'];
+
+    it('should render the track inside its own stacking context', () => {
+        cy.mount(
+            html` <div style="isolation: isolate;">
+                <div style="background: #ffffff;">
+                    <vl-progress-indicator active-step="1" show-labels .steps=${steps}></vl-progress-indicator>
+                </div>
+            </div>`
+        );
+
+        cy.get('vl-progress-indicator')
+            .shadow()
+            .find('.vl-progress-indicator__segment')
+            .first()
+            .should(($segment) => {
+                const segment = $segment[0];
+
+                expect(getComputedStyle(segment, '::before').zIndex).to.equal('-1');
+                expect(getComputedStyle(segment).isolation).to.equal('isolate');
+            });
+    });
+});

--- a/libs/components/src/block/progress-indicator/vl-progress-indicator.component.cy.ts
+++ b/libs/components/src/block/progress-indicator/vl-progress-indicator.component.cy.ts
@@ -173,3 +173,46 @@ describe('cypress-component - block components - vl-progress-indicator - propert
         cy.get('@vl-click-step').should('have.been.calledWithMatch', { detail: { step: steps[0], number: 1 } });
     });
 });
+
+describe('cypress-component - block components - vl-progress-indicator - labels binnen de container', () => {
+    const steps = ['Type onderdeel', 'Gegevens', 'Verbindingen'];
+
+    const mountInContainer = (display: string) =>
+        cy.mount(
+            html` <div id="container" style="display: ${display}; width: 600px;">
+                <vl-progress-indicator active-step="1" show-labels .steps=${steps}></vl-progress-indicator>
+            </div>`
+        );
+
+    const waitForFirstRender = () =>
+        cy.get('vl-progress-indicator').then(($host) =>
+            cy.wrap(($host[0] as VlProgressIndicatorComponent).updateComplete)
+        );
+
+    const shouldHaveLastLabelWithinContainer = () => {
+        cy.get('vl-progress-indicator')
+            .shadow()
+            .find('.vl-progress-indicator__segment:last-child .vl-progress-indicator__label')
+            .should(($label) => {
+                const containerRight = Cypress.$('#container')[0].getBoundingClientRect().right;
+
+                expect($label[0].getBoundingClientRect().right).to.be.closeTo(containerRight, 1);
+            });
+    };
+
+    it('should keep the last label within the container when rendered in a visible container', () => {
+        mountInContainer('block');
+        waitForFirstRender();
+
+        shouldHaveLastLabelWithinContainer();
+    });
+
+    it('should keep the last label within the container when the container becomes visible after rendering', () => {
+        mountInContainer('none');
+        waitForFirstRender();
+
+        cy.get('#container').invoke('css', 'display', 'block');
+
+        shouldHaveLastLabelWithinContainer();
+    });
+});

--- a/libs/components/src/block/progress-indicator/vl-progress-indicator.component.ts
+++ b/libs/components/src/block/progress-indicator/vl-progress-indicator.component.ts
@@ -74,17 +74,38 @@ export class VlProgressIndicatorComponent extends BaseLitElement {
         };
     }
 
-    private updatePadding = async () => {
+    private updatePadding = () => {
         this.style.setProperty(
             '--vl-progress-indicator--padding-right',
             `${this.showLabels ? this.lastLabelWidth / 2 : 0}px`
         );
     };
 
+    private resizeObserver?: ResizeObserver;
+
+    private observePaddingSources() {
+        if (!this.resizeObserver) {
+            if (typeof ResizeObserver === 'undefined') return;
+
+            this.resizeObserver = new ResizeObserver(() => this.updatePadding());
+        }
+
+        this.resizeObserver.disconnect();
+        this.resizeObserver.observe(this);
+
+        const lastLabel = this.shadowRoot?.querySelector(
+            '.vl-progress-indicator__segment:last-child .vl-progress-indicator__label'
+        );
+        if (lastLabel) {
+            this.resizeObserver.observe(lastLabel);
+        }
+    }
+
     async updated(changedProps: Map<string, unknown>) {
         this.progressIndicator.updateStep(this.shadowRoot, this.activeStep, this.focusOnChange);
 
         if (changedProps.has('showLabels') || changedProps.has('steps')) {
+            this.observePaddingSources();
             this.updatePadding();
         }
     }
@@ -92,13 +113,13 @@ export class VlProgressIndicatorComponent extends BaseLitElement {
     connectedCallback(): void {
         super.connectedCallback();
 
-        window.addEventListener('resize', this.updatePadding);
+        this.observePaddingSources();
     }
 
     disconnectedCallback(): void {
         super.disconnectedCallback();
 
-        window.removeEventListener('resize', this.updatePadding);
+        this.resizeObserver?.disconnect();
     }
 
     render() {

--- a/libs/components/src/block/progress-indicator/vl-progress-indicator.flux-css.ts
+++ b/libs/components/src/block/progress-indicator/vl-progress-indicator.flux-css.ts
@@ -28,6 +28,7 @@ export const vlProgressIndicatorFluxStyles: CSSResult = css`
     .vl-progress-indicator__segment {
         position: relative;
         pointer-events: none;
+        isolation: isolate;
 
         /* track */
         &::before {


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-780
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-784

Twee losstaande bugs in vl-progress-indicator, elk in een eigen commit.

**FLUX-780** De rechterpadding wordt berekend uit de breedte van het laatste label. In een nog verborgen container, zoals een modal die nog niet openstond, was die breedte 0 en viel het laatste label buiten de rand. Er werd pas herrekend bij het wisselen van stap; een ResizeObserver reageert nu ook wanneer de container zichtbaar wordt.

**FLUX-784** De lijn tussen twee stappen is een `::before` met `z-index: -1`. Vormde een ancestor een stacking context, dan tekende de browser die lijn daarin in plaats van in het segment, waardoor ze achter een ondoorzichtige achtergrond verdween. `isolation: isolate` op het segment voorkomt dat.
