### PR TITLE
fix: FLUX-219 - vl-description-data - label/waarde als description list

### DIFF
--- a/apps/storybook/.storybook/flux-meta-data/json/components-block.meta-data.json
+++ b/apps/storybook/.storybook/flux-meta-data/json/components-block.meta-data.json
@@ -124,7 +124,7 @@
             "generation": "legacy",
             "css": "govflanders",
             "tests": ["Component", "Storybook"],
-            "documentation": "template",
+            "documentation": "basis",
             "wcagLevel": "TODO",
             "jiraMeta": "FLUX-220"
         }

--- a/libs/components/src/block/description-data/stories/vl-description-data.stories-doc.mdx
+++ b/libs/components/src/block/description-data/stories/vl-description-data.stories-doc.mdx
@@ -1,0 +1,98 @@
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
+import * as VlDescriptionDataStories from './vl-description-data.stories';
+
+# Description Data
+
+<FluxComponentMetaData id="components-block-description-data-description-data" />
+
+
+## Doel
+
+Gebruik de `description-data` component om label / waarde-paren als een samenhangende lijst weer te geven, bijvoorbeeld
+de metadata van een publicatie. De paren worden als een `<dl>` met `<dt>` en `<dd>` gerenderd, zodat een schermlezer
+elk paar als term en definitie aankondigt.
+
+
+## Voorbeeld
+
+```js
+import { VlDescriptionData, VlDescriptionDataItem } from '@domg-wc/components/block';
+```
+
+```html
+<vl-description-data>
+    <vl-description-data-item label="Uitgever" value="Kind en Gezin"></vl-description-data-item>
+</vl-description-data>
+```
+
+<Canvas of={VlDescriptionDataStories.descriptionDataDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlDescriptionDataStories.descriptionDataDefault} />
+
+
+## Enkel description-data-item als kind
+
+De `vl-description-data` mag als directe kinderen **uitsluitend** `vl-description-data-item` componenten bevatten.
+
+<FluxAlert type="warning">
+{`
+    Elk ander element tussen de items wordt genegeerd: het wordt niet in de beschrijvingslijst opgenomen en is ook
+    niet zichtbaar op de pagina. Tijdens ontwikkeling verschijnt hiervoor een waarschuwing in de console.
+`}
+</FluxAlert>
+
+<br/>
+
+### Correct gebruik
+
+```html
+<vl-description-data>
+    <vl-description-data-item label="Uitgever" value="Kind en Gezin"></vl-description-data-item>
+    <vl-description-data-item label="Publicatiedatum" value="Augustus 2018"></vl-description-data-item>
+</vl-description-data>
+```
+
+### Foutief gebruik
+
+```html
+<vl-description-data>
+    <vl-description-data-item label="Uitgever" value="Kind en Gezin"></vl-description-data-item>
+    <!-- wordt genegeerd: niet gerenderd en niet zichtbaar -->
+    <div>Extra informatie</div>
+    <!-- wordt genegeerd: enkel directe kinderen tellen mee -->
+    <div>
+        <vl-description-data-item label="Publicatiedatum" value="Augustus 2018"></vl-description-data-item>
+    </div>
+</vl-description-data>
+```
+
+## Waarom deze beperking
+
+Een `<dl>` is enkel een geldige beschrijvingslijst als de `<dt>` en `<dd>` er rechtstreeks (of via een wrapper-`div`)
+onder hangen. Als elk item zijn eigen `<dt>`/`<dd>` rendert, dan staat de item-host er in de flattened-tree tussen en
+valt de term / definitie-relatie voor schermlezers weg. Daarom leest de `vl-description-data` het `label` en `value` van
+elk item en rendert ze zelf in 1 `<dl>`. Alles wat geen `vl-description-data-item` is, past niet in dat model en
+wordt overgeslagen.
+
+Gevolgen om rekening mee te houden:
+
+- De inhoud van de `label`- en `value`-slots wordt **gekloond** naar de shadow DOM van de `vl-description-data`.
+  Statische opmaak (bv. een `<a href="...">`) werkt daardoor gewoon, maar event-listeners op die inhoud niet: ze
+  overleven het klonen niet.
+- Een `vl-description-data-item` dat je los gebruikt (buiten een `vl-description-data`) rendert wel zijn eigen
+  label en waarde, maar dan zonder de `<dl>`-structuur.
+- Wijzigingen in de light DOM (items toevoegen, verwijderen, of een `label`/`value` aanpassen) worden
+  automatisch doorgevoerd.
+
+
+## Varianten
+
+### Item over de volledige breedte
+
+Met het `items-size` attribuut op een individueel item overschrijf je de kolombreedte die de `vl-description-data`
+oplegt. Zo laat je bijvoorbeeld 1 item de volledige breedte innemen.
+
+<Canvas of={VlDescriptionDataStories.descriptionDataWithSpanner} />

--- a/libs/components/src/block/description-data/stories/vl-description-data.stories.ts
+++ b/libs/components/src/block/description-data/stories/vl-description-data.stories.ts
@@ -2,6 +2,7 @@ import { html } from 'lit';
 import '../vl-description-data-item.component';
 import '../vl-description-data.component';
 import { descriptionDataArgs, descriptionDataArgTypes } from './vl-description-data.stories-arg';
+import descriptionDataDoc from './vl-description-data.stories-doc.mdx';
 import { Meta } from '@storybook/web-components-vite';
 
 export default {
@@ -10,6 +11,11 @@ export default {
     tags: ['autodocs'],
     args: descriptionDataArgs,
     argTypes: descriptionDataArgTypes,
+    parameters: {
+        docs: {
+            page: descriptionDataDoc,
+        },
+    },
 } as Meta<typeof descriptionDataArgs>;
 
 export const descriptionDataDefault = ({

--- a/libs/components/src/block/description-data/vl-description-data-item.component.ts
+++ b/libs/components/src/block/description-data/vl-description-data-item.component.ts
@@ -37,11 +37,10 @@ export class VlDescriptionDataItem extends BaseLitElement {
         const valueClass = 'vl-description-data__value';
         return html`
             ${this.hasSlot('label')
-                ? html` <slot name="label" class=${labelClass}></slot>`
+                ? html`<slot name="label" class=${labelClass}></slot>`
                 : html`<span class=${labelClass}>${this.label}</span>`}
             ${this.hasSlot('value')
-                ? html`
-                    <slot name="value" class=${valueClass}></span>`
+                ? html`<slot name="value" class=${valueClass}></slot>`
                 : html`<span class=${valueClass}>${this.value}</span>`}
         `;
     }

--- a/libs/components/src/block/description-data/vl-description-data.component.cy.ts
+++ b/libs/components/src/block/description-data/vl-description-data.component.cy.ts
@@ -34,6 +34,24 @@ const mountDefault = ({ bordered = false }: { bordered?: boolean }) => {
     );
 };
 
+const mountWithSlots = () => {
+    cy.mount(
+        html`
+            <vl-description-data>
+                <vl-description-data-item data-cy="description-data-item-1">
+                    <span slot="label">Uitgever</span>
+                    <span slot="value"><a href="#">Kind en Gezin</a></span>
+                </vl-description-data-item>
+                <vl-description-data-item
+                    label="Publicatiedatum"
+                    value="Augustus 2018"
+                    data-cy="description-data-item-2"
+                ></vl-description-data-item>
+            </vl-description-data>
+        `
+    );
+};
+
 const mountWithItemSizeOverride = () => {
     cy.mount(
         html`
@@ -69,11 +87,22 @@ const mountWithItemSizeOverride = () => {
     );
 };
 
+const getColumn = (index: number) => cy.get('vl-description-data').shadow().find('dl.vl-grid > .vl-column').eq(index);
+
+const IGNORED_CHILDREN_WARNING =
+    'vl-description-data rendert enkel vl-description-data-item kinderen, andere elementen worden genegeerd';
+
+const spyOnConsoleWarn = () => {
+    cy.window().then((win) => {
+        cy.spy(win.console, 'warn').as('consoleWarn');
+    });
+};
+
 describe('cypress-component - block components - vl-description-data - default', () => {
     it('should mount', () => {
         mountDefault({});
 
-        cy.get('vl-description-data').shadow();
+        cy.get('vl-description-data').shadow().find('dl');
     });
 
     it('should be accessible', () => {
@@ -89,17 +118,173 @@ describe('cypress-component - block components - vl-description-data - default',
         cy.get('vl-description-data').shadow().find('div.vl-description-data.vl-description-data--bordered');
     });
 
-    it('should contain a valid label and value for each item', () => {
+    it('should render a description list with a term and a definition per item', () => {
         mountDefault({});
 
-        cy.getDataCy('description-data-item-1').shadow().find('.vl-description-data__label').contains('Uitgever');
-        cy.getDataCy('description-data-item-1').shadow().find('.vl-description-data__value').contains('Kind en Gezin');
-        cy.getDataCy('description-data-item-2').shadow().find('.vl-description-data__label').contains('Publicatiedatum');
-        cy.getDataCy('description-data-item-2').shadow().find('.vl-description-data__value').contains('Augustus 2018');
-        cy.getDataCy('description-data-item-3').shadow().find('.vl-description-data__label').contains('Publicatietype');
-        cy.getDataCy('description-data-item-3').shadow().find('.vl-description-data__value').contains('Brochure');
-        cy.getDataCy('description-data-item-4').shadow().find('.vl-description-data__label').contains('Categorie');
-        cy.getDataCy('description-data-item-4').shadow().find('.vl-description-data__value').contains('Kinderen en jongeren');
+        const items = [
+            { label: 'Uitgever', value: 'Kind en Gezin' },
+            { label: 'Publicatiedatum', value: 'Augustus 2018' },
+            { label: 'Publicatietype', value: 'Brochure' },
+            { label: 'Categorie', value: 'Kinderen en jongeren' },
+        ];
+        items.forEach((item, index) => {
+            getColumn(index).find('dt.vl-description-data__label').should('contain.text', item.label);
+            getColumn(index).find('dd.vl-description-data__value').should('contain.text', item.value);
+        });
+    });
+
+    it('should group each dt and dd in a column that is a direct child of the dl', () => {
+        mountDefault({});
+
+        cy.get('vl-description-data').shadow().find('dl').children().should('have.length', 4);
+        cy.get('vl-description-data')
+            .shadow()
+            .find('dl > div.vl-column')
+            .each((column) => {
+                cy.wrap(column).find('> dt').should('have.length', 1);
+                cy.wrap(column).find('> dd').should('have.length', 1);
+            });
+    });
+
+    it('should lay the columns out in a single grid row', () => {
+        cy.viewport(1024, 768);
+        mountDefault({});
+
+        cy.get('vl-description-data')
+            .shadow()
+            .find('dl > div.vl-column')
+            .then((columns) => {
+                const [first, second] = [columns[0].getBoundingClientRect(), columns[1].getBoundingClientRect()];
+
+                expect(second.top).to.be.closeTo(first.top, 1);
+                expect(second.left).to.be.greaterThan(first.right - 1);
+            });
+    });
+
+    it('should not render the items in the light DOM', () => {
+        mountDefault({});
+
+        cy.getDataCy('description-data-item-1').should('not.be.visible');
+    });
+
+    it('should render an empty dl without items', () => {
+        cy.mount(html`<vl-description-data></vl-description-data>`);
+
+        cy.get('vl-description-data').shadow().find('dl').children().should('have.length', 0);
+    });
+
+    it('should not render children that are not a vl-description-data-item', () => {
+        spyOnConsoleWarn();
+        cy.mount(
+            html`
+                <vl-description-data>
+                    <vl-description-data-item label="Uitgever" value="Kind en Gezin"></vl-description-data-item>
+                    <div data-cy="other-child">Geen item</div>
+                </vl-description-data>
+            `
+        );
+
+        cy.get('vl-description-data').shadow().find('dl').children().should('have.length', 1);
+        cy.getDataCy('other-child').should('not.be.visible');
+        cy.get('@consoleWarn').should('be.calledWith', IGNORED_CHILDREN_WARNING);
+    });
+
+    it('should warn only once about ignored children', () => {
+        spyOnConsoleWarn();
+        cy.mount(
+            html`
+                <vl-description-data>
+                    <vl-description-data-item label="Uitgever" value="Kind en Gezin"></vl-description-data-item>
+                    <div data-cy="other-child">Geen item</div>
+                </vl-description-data>
+            `
+        );
+
+        cy.get('@consoleWarn').should('be.calledOnceWith', IGNORED_CHILDREN_WARNING);
+
+        cy.runTestFor<VlDescriptionData>('vl-description-data', (component) => {
+            const item = document.createElement('vl-description-data-item');
+            item.setAttribute('label', 'Auteur');
+            item.setAttribute('value', 'Vlaamse overheid');
+            component.append(item);
+            component.append(document.createElement('span'));
+        });
+
+        // het extra dt bewijst dat de MutationObserver buildEntries opnieuw uitgevoerd heeft, met nog steeds een
+        // genegeerd kind in de light DOM
+        cy.get('vl-description-data').shadow().find('dt').should('have.length', 2);
+        cy.get('@consoleWarn').should('be.calledOnceWith', IGNORED_CHILDREN_WARNING);
+    });
+});
+
+describe('cypress-component - block components - vl-description-data - slots', () => {
+    it('should use the label and value slot content', () => {
+        mountWithSlots();
+
+        getColumn(0).find('dt').should('contain.text', 'Uitgever');
+        getColumn(0).find('dd a').should('contain.text', 'Kind en Gezin');
+    });
+
+    it('should not keep the slot attribute on the cloned content', () => {
+        mountWithSlots();
+
+        getColumn(0).find('dt > span').should('not.have.attr', 'slot');
+    });
+
+    it('should be accessible', () => {
+        mountWithSlots();
+
+        cy.injectAxe();
+        cy.checkA11y('vl-description-data');
+    });
+});
+
+describe('cypress-component - block components - vl-description-data - light DOM changes', () => {
+    it('should update the shadow DOM after an item is added', () => {
+        mountDefault({});
+
+        cy.runTestFor<VlDescriptionData>('vl-description-data', (component) => {
+            const item = document.createElement('vl-description-data-item');
+            item.setAttribute('label', 'Auteur');
+            item.setAttribute('value', 'Vlaamse overheid');
+            component.append(item);
+        });
+
+        cy.get('vl-description-data').shadow().find('dt').should('have.length', 5);
+        getColumn(4).find('dt').should('contain.text', 'Auteur');
+        getColumn(4).find('dd').should('contain.text', 'Vlaamse overheid');
+    });
+
+    it('should update the shadow DOM after an item is removed', () => {
+        mountDefault({});
+
+        cy.runTestFor<VlDescriptionData>('vl-description-data', (component) => {
+            component.children[0].remove();
+        });
+
+        cy.get('vl-description-data').shadow().find('dt').should('have.length', 3);
+        getColumn(0).find('dt').should('contain.text', 'Publicatiedatum');
+    });
+
+    it('should update the shadow DOM when a label attribute is mutated in-place', () => {
+        mountDefault({});
+
+        cy.runTestFor<VlDescriptionData>('vl-description-data', (component) => {
+            component.children[0].setAttribute('label', 'Verantwoordelijke uitgever');
+        });
+
+        getColumn(0).find('dt').should('contain.text', 'Verantwoordelijke uitgever');
+    });
+
+    it('should update the shadow DOM when slotted text is mutated in-place', () => {
+        mountWithSlots();
+
+        cy.runTestFor<VlDescriptionData>('vl-description-data', (component) => {
+            const textNode = component.querySelector('[slot="label"]')?.firstChild;
+            textNode!.textContent = 'Verantwoordelijke uitgever';
+        });
+
+        getColumn(0).find('dt').should('contain.text', 'Verantwoordelijke uitgever');
     });
 });
 
@@ -122,5 +307,34 @@ describe('cypress-component - block components - vl-description-data - per-item 
             .find('.vl-grid > .vl-column')
             .eq(4)
             .should('have.class', 'vl-column--12');
+    });
+});
+
+describe('cypress-component - block components - vl-description-data-item - standalone', () => {
+    it('should render the label and the value', () => {
+        cy.mount(
+            html`<vl-description-data-item
+                label="Uitgever"
+                value="Kind en Gezin"
+                data-cy="description-data-item"
+            ></vl-description-data-item>`
+        );
+
+        cy.getDataCy('description-data-item').shadow().find('.vl-description-data__label').contains('Uitgever');
+        cy.getDataCy('description-data-item').shadow().find('.vl-description-data__value').contains('Kind en Gezin');
+    });
+
+    it('should render the label and value slots', () => {
+        cy.mount(
+            html`<vl-description-data-item data-cy="description-data-item">
+                <span slot="label">Uitgever</span>
+                <span slot="value">Kind en Gezin</span>
+            </vl-description-data-item>`
+        );
+
+        cy.getDataCy('description-data-item').shadow().find('slot[name="label"]');
+        cy.getDataCy('description-data-item').shadow().find('slot[name="value"]');
+        cy.getDataCy('description-data-item').should('contain.text', 'Uitgever');
+        cy.getDataCy('description-data-item').should('contain.text', 'Kind en Gezin');
     });
 });

--- a/libs/components/src/block/description-data/vl-description-data.component.ts
+++ b/libs/components/src/block/description-data/vl-description-data.component.ts
@@ -1,10 +1,16 @@
-import { BaseLitElement } from '@domg-wc/common';
+import { BaseLitElement, onChildListChange } from '@domg-wc/common';
 import { vlGridStyles, vlResetStyles } from '@domg-wc/styles';
 import { descriptionDataStyle } from '@domg/govflanders-style/component';
-import { html } from 'lit';
+import { html, PropertyDeclarations, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { VlDescriptionDataItem } from './vl-description-data-item.component';
+
+type DescriptionDataEntry = {
+    item: VlDescriptionDataItem;
+    label: string | Node[];
+    value: string | Node[];
+};
 
 @customElement('vl-description-data')
 export class VlDescriptionData extends BaseLitElement {
@@ -13,35 +19,67 @@ export class VlDescriptionData extends BaseLitElement {
     private smallSize = 0;
     private extraSmallSize = 0;
     private bordered = false;
+    private entries: DescriptionDataEntry[] = [];
+    private mutationObserver: MutationObserver | null = null;
+    private ignoredChildrenWarningShown = false;
 
     static get styles() {
         return [vlResetStyles, descriptionDataStyle, vlGridStyles];
     }
 
-    static get properties() {
+    static get properties(): PropertyDeclarations {
         return {
             size: { type: Number, attribute: 'items-size' },
             mediumSize: { type: Number, attribute: 'items-medium-size' },
             smallSize: { type: Number, attribute: 'items-small-size' },
             extraSmallSize: { type: Number, attribute: 'items-extra-small-size' },
             bordered: { type: Boolean, attribute: 'bordered' },
+            entries: { state: true },
         };
     }
 
-    firstUpdated() {
-        const observer = new MutationObserver(() => {
-            this.requestUpdate();
-        });
+    connectedCallback() {
+        super.connectedCallback();
 
-        observer.observe(this, { subtree: true, childList: true });
+        this.buildEntries();
+        this.observeLightDomChange();
     }
 
-    private buildColumnClasses(child: Element) {
-        const item = child instanceof VlDescriptionDataItem ? child : null;
-        const size = item?.itemsSize ?? this.size;
-        const mediumSize = item?.itemsMediumSize ?? this.mediumSize;
-        const smallSize = item?.itemsSmallSize ?? this.smallSize;
-        const extraSmallSize = item?.itemsExtraSmallSize ?? this.extraSmallSize;
+    disconnectedCallback() {
+        super.disconnectedCallback();
+
+        this.disconnectMutationObserver();
+    }
+
+    render(): TemplateResult {
+        const classes = {
+            'vl-description-data--bordered': this.bordered,
+        };
+        return html`
+            <div class="vl-description-data ${classMap(classes)}">
+                <dl class="vl-grid">${this.entries.map((entry) => this.renderEntry(entry))}</dl>
+            </div>
+        `;
+    }
+
+    private renderEntry(entry: DescriptionDataEntry): TemplateResult {
+        return html`
+            <div class="vl-column ${classMap(this.buildColumnClasses(entry.item))}">
+                <dt class="vl-description-data__label">${entry.label}</dt>
+                <dd class="vl-description-data__value">${entry.value}</dd>
+            </div>
+        `;
+    }
+
+    private get columnSize(): number {
+        return this.size || 12 / this.entries.length;
+    }
+
+    private buildColumnClasses(item: VlDescriptionDataItem) {
+        const size = item.itemsSize ?? this.columnSize;
+        const mediumSize = item.itemsMediumSize ?? this.mediumSize;
+        const smallSize = item.itemsSmallSize ?? this.smallSize;
+        const extraSmallSize = item.itemsExtraSmallSize ?? this.extraSmallSize;
         return {
             [`vl-column--${size}`]: !!size,
             [`vl-column--m-${mediumSize}`]: !!mediumSize,
@@ -50,26 +88,62 @@ export class VlDescriptionData extends BaseLitElement {
         };
     }
 
-    render() {
-        this.size = this.size || 12 / this.children.length;
-        const classes = {
-            'vl-description-data--bordered': this.bordered,
-        };
-        return html`
-            <div class="vl-description-data ${classMap(classes)}">
-                <div class="vl-grid">
-                    ${[...Array.from(this.children)].map((child, index) => {
-                        const name = `item-${index}`;
-                        child.setAttribute('slot', name);
-                        return html`
-                            <div class="vl-column ${classMap(this.buildColumnClasses(child))}">
-                                <slot name=${name}></slot>
-                            </div>
-                        `;
-                    })}
-                </div>
-            </div>
-        `;
+    // De dt/dd moeten in dezelfde shadow root staan als de dl: ge-slot vanuit het item zouden ze anders in de
+    // flattened tree gescheiden zijn van de dl door de item-host, waardoor de term/definitie-relatie wegvalt.
+    private buildEntries() {
+        const children = Array.from(this.children);
+
+        this.entries = children
+            .filter((child): child is VlDescriptionDataItem => child instanceof VlDescriptionDataItem)
+            .map((item) => ({
+                item,
+                label: this.buildContent(item, 'label'),
+                value: this.buildContent(item, 'value'),
+            }));
+
+        this.warnAboutIgnoredChildren(children);
+    }
+
+    private buildContent(item: Element, name: 'label' | 'value'): string | Node[] {
+        const slotted = Array.from(item.children).filter((child) => child.getAttribute('slot') === name);
+
+        if (!slotted.length) {
+            return item.getAttribute(name) ?? '';
+        }
+        // het ge-slotte element zelf wordt mee gekloond: een consumer kan er rechtstreeks bv. een <a> in plaatsen,
+        // dus door enkel zijn kinderen te clonen zou er inhoud verloren gaan.
+        return slotted.map((child) => {
+            const clone = child.cloneNode(true) as Element;
+            clone.removeAttribute('slot');
+            return clone;
+        });
+    }
+
+    private warnAboutIgnoredChildren(children: Element[]) {
+        if (this.ignoredChildrenWarningShown || children.length === this.entries.length) {
+            return;
+        }
+
+        console.warn(
+            `${this.localName} rendert enkel vl-description-data-item kinderen, andere elementen worden genegeerd`,
+        );
+        this.ignoredChildrenWarningShown = true;
+    }
+
+    private observeLightDomChange() {
+        this.disconnectMutationObserver();
+        // ook attributen en tekst worden geobserveerd, zodat de gekloonde inhoud synchroon blijft met de light DOM
+        this.mutationObserver = onChildListChange(this, () => this.buildEntries(), {
+            childList: true,
+            subtree: true,
+            characterData: true,
+            attributes: true,
+        });
+    }
+
+    private disconnectMutationObserver() {
+        this.mutationObserver?.disconnect();
+        this.mutationObserver = null;
     }
 }
 

--- a/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components-block.wt-config.ts
@@ -92,7 +92,7 @@ export const buildWTConfigComponentsBlock: WTConfigArray = [
     buildWTConfig(
         'vl-description-data',
         descriptionDataArgTypes,
-        null,
+        '../../libs/components/src/block/description-data/stories/vl-description-data.stories-doc.mdx',
         '/docs/components-block-description-data-description-data--documentatie'
     ),
     buildWTConfig(


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-219

## Samenvatting
`vl-description-data` toont zijn label/waarde-paren nu als een echte description list. Screenreaders kondigen elk paar aan als term en definitie in plaats van als losse tekst. Visueel en qua API verandert er niets voor de consumer.

## Wijzigingen
- De component rendert één `<dl>` met per item een `<dt>` (label) en een `<dd>` (waarde) in plaats van `div`'s en `span`'s.
- De kolomlayout blijft behouden: elk paar zit in een `div.vl-column` binnen de `dl`, wat HTML5 toelaat zonder de term/definitie-relatie te breken.
- De inhoud van de `label`- en `value`-slots wordt naar de shadow DOM gekloond en blijft automatisch synchroon met wijzigingen in de light DOM (toegevoegde of verwijderde items, gewijzigde attributen en gewijzigde tekst).
- Kinderen die geen `vl-description-data-item` zijn, worden niet meer gerenderd — ze zouden de description list ongeldig maken. De component logt daarvoor één waarschuwing in de console.
- Renderfout in `vl-description-data-item` gefixt: de `value`-slot werd afgesloten met een verkeerde tag.
- De kolombreedte-fallback (`12 / aantal items`) volgt nu een wijzigend aantal items in plaats van te bevriezen op de eerste render.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes. Twee gedragswijzigingen binnen de bestaande API: slot-inhoud wordt gekloond naar de shadow DOM (event listeners die rechtstreeks op een geslot element gezet worden, werken niet meer op de zichtbare inhoud — zelfde gedrag als `vl-properties`), en niet-`vl-description-data-item`-kinderen worden niet meer getoond.

## Succescriteria
- [x] De gerenderde markup gebruikt een `<dl>` als container met `<dt>` voor het label en `<dd>` voor de waarde — de component rendert de volledige `dl`/`dt`/`dd` zelf in zijn shadow root.
- [x] Een screenreader kondigt elk paar aan als term/definitie; de `dt`/`dd`-relatie is intact in de flattened accessibility tree — alles staat in één shadow root, de items worden niet meer geslot en er zit geen custom-element-grens meer tussen de `dl` en de `dt`/`dd`.
- [x] De bestaande publieke API blijft werken — alle attributen en de `label`/`value`-slots zijn ongewijzigd en afgedekt door tests.
- [x] De bestaande grid-/kolomlayout en `--bordered` styling blijven visueel ongewijzigd — dezelfde klassen op dezelfde geneste structuur, en een grid-test bewaakt de kolomlayout.
- [x] Geverifieerd met een axe/WCAG-audit (geen "list structure"-violations meer) — `cy.checkA11y` draait groen op zowel de attribuut- als de slot-variant; een handmatige screenreader-check blijft aangeraden bij QA.
