### PR TITLE
feat: FLUX-207 - vl-alert - instelbare ARIA-rol per context

### DIFF
--- a/libs/components/src/block/alert/index.ts
+++ b/libs/components/src/block/alert/index.ts
@@ -1,2 +1,9 @@
 export { VlAlert } from './vl-alert.component';
-export { ALERT_TYPE, ALERT_SIZE, ALERT_ICON, ALERT_ROLE, VlAlertClosedEvent } from './vl-alert.model';
+export {
+    ALERT_TYPE,
+    ALERT_SIZE,
+    ALERT_ICON,
+    ALERT_ROLE,
+    VlAlertClosedEvent,
+    type VlAlertAttributes,
+} from './vl-alert.model';

--- a/libs/components/src/block/alert/index.ts
+++ b/libs/components/src/block/alert/index.ts
@@ -1,2 +1,2 @@
 export { VlAlert } from './vl-alert.component';
-export { ALERT_TYPE, ALERT_SIZE, ALERT_ICON, VlAlertClosedEvent } from './vl-alert.model';
+export { ALERT_TYPE, ALERT_SIZE, ALERT_ICON, ALERT_ROLE, VlAlertClosedEvent } from './vl-alert.model';

--- a/libs/components/src/block/alert/stories/vl-alert.stories-arg.ts
+++ b/libs/components/src/block/alert/stories/vl-alert.stories-arg.ts
@@ -8,7 +8,7 @@ import {
     TYPES,
 } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
-import { ALERT_ICON, ALERT_SIZE, ALERT_TYPE, VlAlertClosedEvent } from '../vl-alert.model';
+import { ALERT_ICON, ALERT_ROLE, ALERT_SIZE, ALERT_TYPE, VlAlertClosedEvent } from '../vl-alert.model';
 
 export const alertArgs = {
     ...defaultArgs,
@@ -20,6 +20,7 @@ export const alertArgs = {
     size: '',
     type: '',
     message: '',
+    alertRole: ALERT_ROLE.ALERT as ALERT_ROLE,
     defaultSlot: '',
     titleSlot: '',
     actionsSlot: '',
@@ -110,6 +111,20 @@ export const alertArgTypes: ArgTypes<typeof alertArgs> = {
             },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: alertArgs.type },
+        },
+    },
+    alertRole: {
+        name: 'alert-role',
+        description:
+            'ARIA rol van de waarschuwing.<br>`alert` voor dynamisch verschijnende beknopte meldingen, ' +
+            '`alertdialog` voor meldingen die een actie vereisen, `no-role` voor meldingen die al bij het ' +
+            'laden van de pagina zichtbaar zijn.<br>Onbekende waarden vallen terug op `alert`.',
+        control: { type: CONTROLS.SELECT },
+        options: Object.values(ALERT_ROLE),
+        table: {
+            type: { summary: getSelectControlOptions(Object.values(ALERT_ROLE)) },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: alertArgs.alertRole },
         },
     },
     titleSlot: {

--- a/libs/components/src/block/alert/stories/vl-alert.stories-doc.mdx
+++ b/libs/components/src/block/alert/stories/vl-alert.stories-doc.mdx
@@ -99,6 +99,89 @@ Een newline na de opening-tag wordt door \`pre-line\` als witruimte weergegeven.
 <Canvas of={VlAlertStories.AlertMultiline}/>
 
 
+## Toegankelijkheid
+
+### Draag de betekenis niet enkel via kleur en icoon over
+
+Het `type` van de melding wordt visueel vertaald naar een kleur en - via het `icon` attribuut - naar een icoon. Die
+signalen bereiken gebruikers van een schermlezer niet en vallen weg in hoog contrast. Zet de aard van de melding
+daarom ook in de tekst, bijvoorbeeld met een titel als "Opgelet!" of "Gelukt!", zodat de boodschap zonder kleur en
+icoon volledig blijft.
+
+### Kies de rol die bij de context past
+
+Een melding krijgt niet in elke context dezelfde ARIA rol. Stem die af met het `alert-role` attribuut, volgens de
+richtlijnen voor [`alert`](https://www.w3.org/TR/wai-aria-1.2/#alert) en
+[`alertdialog`](https://www.w3.org/TR/wai-aria-1.2/#alertdialog).
+
+<table>
+    <tr>
+        <td>Waarde</td>
+        <td>Wanneer</td>
+        <td>Gedrag bij een schermlezer</td>
+    </tr>
+    <tr>
+        <td>`alert` (default)</td>
+        <td>De melding verschijnt dynamisch na een actie van de gebruiker, is beknopt en vraagt zelf geen actie.</td>
+        <td>De melding wordt voorgelezen zodra ze verschijnt, zonder dat de focus verspringt.</td>
+    </tr>
+    <tr>
+        <td>`alertdialog`</td>
+        <td>De melding verschijnt dynamisch en vereist een actie van de gebruiker, typisch via een knop in het `actions` slot.</td>
+        <td>De melding wordt aangekondigd als een dialoog met een naam en een beschrijving. De afnemer verplaatst zelf de focus naar de melding, zie hieronder.</td>
+    </tr>
+    <tr>
+        <td>`no-role`</td>
+        <td>De melding staat al op de pagina bij het laden, bijvoorbeeld een permanente info- of storingsmelding.</td>
+        <td>Geen live region: de melding wordt gewoon voorgelezen op haar plaats in de leesvolgorde.</td>
+    </tr>
+</table>
+
+Hou meldingen met `alert-role="alert"` beknopt: een schermlezer leest de volledige inhoud in één keer voor en
+onderbreekt daarmee waar de gebruiker mee bezig was.
+
+```html
+<!-- melding die al bij het laden van de pagina zichtbaar is -->
+<vl-alert alert-role="no-role" type="info" icon="info-circle" title="Onderhoud">
+    <span>Op zaterdag is dit loket beperkt beschikbaar.</span>
+</vl-alert>
+```
+
+### Focus bij `alertdialog`
+
+Een `alertdialog` hoort de focus te krijgen zodra hij verschijnt, anders mist een toetsenbord- of schermlezergebruiker
+de melding en de bijhorende actie. De component doet dat bewust niet automatisch: enkel de afnemer weet op welk moment
+de melding verschijnt en welk element de focus moet krijgen.
+
+<FluxAlert type="warning">
+{`
+Bij alert-role="alertdialog" moet de afnemer zelf de focus naar de melding of naar de actieknop erin verplaatsen.
+`}
+</FluxAlert>
+
+```js
+const alert = document.querySelector('vl-alert');
+alert.focus(); // verplaatst de focus naar de melding zelf
+```
+
+`focus()` op de melding legt de focus op de dialoog, waardoor een schermlezer de rol, de naam en de beschrijving
+aankondigt. Wil je de gebruiker meteen bij de actie zetten, focus dan de knop in het `actions` slot; de melding wordt
+dan aangekondigd als context van die knop.
+
+```js
+const alert = document.querySelector('vl-alert');
+alert.querySelector('vl-button')?.focus();
+```
+
+Bij deze rol koppelt de component de titel als naam (`aria-labelledby`) en de boodschap als beschrijving
+(`aria-describedby`) aan de melding, maar enkel wanneer die effectief inhoud hebben: een verwijzing naar een leeg
+element levert immers geen naam of beschrijving op. Voorzie daarom altijd een titel via het `title` attribuut of het
+`title` slot, want zonder titel heeft de `alertdialog` geen toegankelijke naam. Een controle met axe meldt dat als
+`aria-dialog-name`.
+
+<Canvas of={VlAlertStories.AlertAlertDialog}/>
+
+
 ## Referenties
 
 ### Digitaal Vlaanderen

--- a/libs/components/src/block/alert/stories/vl-alert.stories.ts
+++ b/libs/components/src/block/alert/stories/vl-alert.stories.ts
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '../vl-alert.component';
-import { ALERT_ICON, ALERT_TYPE } from '../vl-alert.model';
+import { ALERT_ICON, ALERT_ROLE, ALERT_TYPE } from '../vl-alert.model';
 import { alertArgs, alertArgTypes } from './vl-alert.stories-arg';
 import alertDoc from './vl-alert.stories-doc.mdx';
 import { registerWebComponents } from '@domg-wc/common';
@@ -35,6 +35,7 @@ const AlertTemplate = story(
         naked,
         multiline,
         message,
+        alertRole,
         defaultSlot,
         actionsSlot,
         titleSlot,
@@ -49,6 +50,7 @@ const AlertTemplate = story(
             size=${size}
             type=${type}
             message=${message}
+            alert-role=${alertRole}
             @vl-alert-closed="${alertClosed}"
             data-cy="alert"
         >
@@ -163,4 +165,15 @@ AlertMultiline.args = {
     type: ALERT_TYPE.INFO,
     icon: ALERT_ICON.INFO_CIRCLE,
     multiline: true,
+};
+
+export const AlertAlertDialog = AlertTemplate.bind({});
+AlertAlertDialog.storyName = 'vl-alert - alertdialog';
+AlertAlertDialog.args = {
+    title: 'Uw sessie verloopt',
+    type: ALERT_TYPE.WARNING,
+    icon: ALERT_ICON.WARNING,
+    alertRole: ALERT_ROLE.ALERT_DIALOG,
+    defaultSlot: '<span>Over 2 minuten wordt u automatisch afgemeld. Wilt u aangemeld blijven?</span>',
+    actionsSlot: '<vl-button slot="actions">Aangemeld blijven</vl-button>',
 };

--- a/libs/components/src/block/alert/vl-alert.component.cy.ts
+++ b/libs/components/src/block/alert/vl-alert.component.cy.ts
@@ -183,3 +183,151 @@ describe('cypress-component - block components - vl-alert - naked', () => {
         cy.get('vl-alert').shadow().find('.vl-alert__icon > span.vl-icon--warning');
     });
 });
+
+describe('cypress-component - block components - vl-alert - alert-role', () => {
+    it('should have role alert by default', () => {
+        cy.mount(html`<vl-alert title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'role', 'alert');
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'aria-labelledby');
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'aria-describedby');
+    });
+
+    it('should not have a role when alert-role is no-role', () => {
+        cy.mount(html`<vl-alert alert-role="no-role" title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'role');
+    });
+
+    it('should have role alertdialog with a name and a description when alert-role is alertdialog', () => {
+        cy.mount(html`
+            <vl-alert alert-role="alertdialog" title="Lorem ipsum">
+                <p>Ipsum dolor sit amet.</p>
+                <button slot="actions">Bevestigen</button>
+            </vl-alert>
+        `);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'role', 'alertdialog');
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-labelledby', 'title');
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-describedby', 'message');
+    });
+
+    it('should not reference the title when there is no title', () => {
+        cy.mount(html`
+            <vl-alert alert-role="alertdialog">
+                <p>Ipsum dolor sit amet.</p>
+                <button slot="actions">Bevestigen</button>
+            </vl-alert>
+        `);
+
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'aria-labelledby');
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-describedby', 'message');
+    });
+
+    it('should not reference the message when there is no message', () => {
+        cy.mount(html`<vl-alert alert-role="alertdialog" title="Lorem ipsum"></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-labelledby', 'title');
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'aria-describedby');
+    });
+
+    it('should reference a slotted title and the message property', () => {
+        cy.mount(html`
+            <vl-alert alert-role="alertdialog" message="Ipsum dolor sit amet.">
+                <span slot="title">Lorem ipsum</span>
+            </vl-alert>
+        `);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-labelledby', 'title');
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-describedby', 'message');
+    });
+
+    it('should reference a title that is slotted after the first render', () => {
+        cy.mount(html`<vl-alert alert-role="alertdialog"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'aria-labelledby');
+
+        cy.get('vl-alert').then(($alert) => {
+            const title = document.createElement('span');
+            title.setAttribute('slot', 'title');
+            title.textContent = 'Lorem ipsum';
+            $alert[0].appendChild(title);
+        });
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'aria-labelledby', 'title');
+    });
+
+    it('should fall back to role alert for an unknown alert-role', () => {
+        cy.mount(html`<vl-alert alert-role="banner" title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'role', 'alert');
+    });
+
+    it('should change the role', () => {
+        cy.mount(html`<vl-alert title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').invoke('attr', 'alert-role', 'alertdialog');
+        cy.waitForLitUpdate('vl-alert');
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'role', 'alertdialog');
+    });
+
+    it('should be focusable when alert-role is alertdialog', () => {
+        cy.mount(html`
+            <vl-alert alert-role="alertdialog" title="Lorem ipsum">
+                <p>Ipsum dolor sit amet.</p>
+                <button slot="actions">Bevestigen</button>
+            </vl-alert>
+        `);
+
+        cy.get('vl-alert').shadow().find('#alert').should('have.attr', 'tabindex', '-1');
+
+        cy.get('vl-alert').then(($alert) => {
+            $alert[0].focus();
+
+            expect($alert[0].shadowRoot?.activeElement?.id).to.equal('alert');
+        });
+    });
+
+    it('should not be focusable for the other roles', () => {
+        cy.mount(html`<vl-alert title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#alert').should('not.have.attr', 'tabindex');
+
+        cy.get('vl-alert').then(($alert) => {
+            $alert[0].focus();
+
+            expect($alert[0].shadowRoot?.activeElement).to.equal(null);
+        });
+    });
+
+    it('should be accessible as alertdialog', () => {
+        cy.mount(html`
+            <vl-alert alert-role="alertdialog" title="Lorem ipsum">
+                <p>Ipsum dolor sit amet.</p>
+                <button slot="actions">Bevestigen</button>
+            </vl-alert>
+        `);
+
+        cy.injectAxe();
+
+        cy.checkA11y('vl-alert');
+    });
+});
+
+describe('cypress-component - block components - vl-alert - slots na de eerste render', () => {
+    it('should show the actions slot when a button is slotted after the first render', () => {
+        cy.mount(html`<vl-alert title="Lorem ipsum"><p>Ipsum dolor sit amet.</p></vl-alert>`);
+
+        cy.get('vl-alert').shadow().find('#actions').should('have.class', 'vl-u-visually-hidden');
+
+        cy.get('vl-alert').then(($alert) => {
+            const button = document.createElement('button');
+            button.setAttribute('slot', 'actions');
+            button.textContent = 'Bevestigen';
+            $alert[0].appendChild(button);
+        });
+
+        cy.get('vl-alert').shadow().find('#actions').should('not.have.class', 'vl-u-visually-hidden');
+    });
+});

--- a/libs/components/src/block/alert/vl-alert.component.ts
+++ b/libs/components/src/block/alert/vl-alert.component.ts
@@ -4,8 +4,9 @@ import { alertStyle } from '@domg/govflanders-style/component';
 import { CSSResult, html, PropertyDeclarations, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
-import { VlAlertClosedEvent, VlAlertModel } from './vl-alert.model';
+import { ALERT_ROLE, VlAlertClosedEvent, VlAlertModel } from './vl-alert.model';
 import { vlAlertFluxStyles } from './vl-alert.flux-css';
 
 @customElement('vl-alert')
@@ -18,6 +19,7 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
     naked = false;
     closable = false;
     multiline = false;
+    alertRole: ALERT_ROLE = ALERT_ROLE.ALERT;
 
     static get styles(): CSSResult[] {
         return [resetStyle, alertStyle, accessibilityStyle, markStyle, vlAlertFluxStyles, vlIconStyles];
@@ -33,6 +35,7 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
             naked: { type: Boolean, attribute: 'naked' },
             message: { type: String, attribute: 'message' },
             multiline: { type: Boolean, attribute: 'multiline', reflect: true },
+            alertRole: { type: String, attribute: 'alert-role' },
         };
     }
 
@@ -46,23 +49,37 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
 
         const markClass = this.naked ? `vl-u-mark--${this.type}` : '';
         const hideEmptyActionsSlot = findNodesForSlot(this, 'actions')?.length ? '' : 'vl-u-visually-hidden';
+        const role = this.getEffectiveRole();
+        const isAlertDialog = role === ALERT_ROLE.ALERT_DIALOG;
+        // we verwijzen enkel naar een element dat effectief inhoud heeft: de titel benoemt, de boodschap beschrijft
+        const hasTitle = Boolean(this.title) || Boolean(findNodesForSlot(this, 'title')?.length);
+        const hasMessage = Boolean(this.message) || this.hasDefaultSlotContent();
+        const labelledBy = isAlertDialog && hasTitle ? 'title' : undefined;
+        const describedBy = isAlertDialog && hasMessage ? 'message' : undefined;
 
         return html`
-            <div id="alert" class=${classMap(classes)} role="alert">
+            <div
+                id="alert"
+                class=${classMap(classes)}
+                role=${ifDefined(role)}
+                tabindex=${ifDefined(isAlertDialog ? '-1' : undefined)}
+                aria-labelledby=${ifDefined(labelledBy)}
+                aria-describedby=${ifDefined(describedBy)}
+            >
                 ${this.icon &&
                 html` <div class="vl-alert__icon">
                     <span class="vl-icon vl-icon--${this.icon}"></span>
                 </div>`}
                 <div id="content" class="vl-alert__content">
                     <p id="title" class="vl-alert__title">
-                        <slot class=${markClass} name="title">${this.title}</slot>
+                        <slot class=${markClass} @slotchange=${this.handleSlotChange} name="title">${this.title}</slot>
                     </p>
                     <div id="message" class="vl-alert__message">
                         <p class=${markClass}>${this.message}</p>
-                        <slot id="message-slot"></slot>
+                        <slot id="message-slot" @slotchange=${this.handleSlotChange}></slot>
                     </div>
                     <div id="actions" class="vl-alert__actions ${hideEmptyActionsSlot}">
-                        <slot id="actions-slot" @slotchange=${this.requestUpdate} name="actions"></slot>
+                        <slot id="actions-slot" @slotchange=${this.handleSlotChange} name="actions"></slot>
                     </div>
                 </div>
                 ${this.closable
@@ -82,6 +99,46 @@ export class VlAlert extends BaseLitElement implements VlAlertModel {
                     : ''}
             </div>
         `;
+    }
+
+    /**
+     * Verplaatst de focus naar de melding zelf, zodat een schermlezer haar rol, naam en beschrijving aankondigt.
+     * Enkel bij alert-role="alertdialog" is de melding focusbaar; bij de andere rollen gebeurt er niets.
+     */
+    override focus(options?: FocusOptions): void {
+        const alert = this.shadowRoot?.querySelector<HTMLElement>('#alert');
+
+        if (alert) {
+            alert.focus(options);
+            return;
+        }
+
+        super.focus(options);
+    }
+
+    // lit 3 breekt requestUpdate af wanneer het rechtstreeks als listener gebonden wordt: het event komt dan binnen
+    // als property-naam en de update wordt genegeerd
+    private handleSlotChange = () => this.requestUpdate();
+
+    private hasDefaultSlotContent(): boolean {
+        return Array.from(this.childNodes).some((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return Boolean(node.textContent?.trim());
+            }
+
+            return node.nodeType === Node.ELEMENT_NODE && !(node as Element).hasAttribute('slot');
+        });
+    }
+
+    private getEffectiveRole(): ALERT_ROLE | undefined {
+        switch (this.alertRole) {
+            case ALERT_ROLE.NO_ROLE:
+                return undefined;
+            case ALERT_ROLE.ALERT_DIALOG:
+                return ALERT_ROLE.ALERT_DIALOG;
+            default:
+                return ALERT_ROLE.ALERT;
+        }
     }
 
     private removeAlert() {

--- a/libs/components/src/block/alert/vl-alert.model.ts
+++ b/libs/components/src/block/alert/vl-alert.model.ts
@@ -48,3 +48,10 @@ export interface VlAlertModel {
     multiline?: boolean;
     alertRole?: ALERT_ROLE;
 }
+
+/**
+ * De instellingen van een alert met de attribuutnaam als key, zoals de documentatie ze noemt.
+ */
+export interface VlAlertAttributes extends Omit<VlAlertModel, 'alertRole'> {
+    'alert-role'?: ALERT_ROLE;
+}

--- a/libs/components/src/block/alert/vl-alert.model.ts
+++ b/libs/components/src/block/alert/vl-alert.model.ts
@@ -21,6 +21,14 @@ export const ALERT_SIZE = {
 
 export type ALERT_SIZE = (typeof ALERT_SIZE)[keyof typeof ALERT_SIZE];
 
+export const ALERT_ROLE = {
+    ALERT: 'alert',
+    ALERT_DIALOG: 'alertdialog',
+    NO_ROLE: 'no-role',
+} as const;
+
+export type ALERT_ROLE = (typeof ALERT_ROLE)[keyof typeof ALERT_ROLE];
+
 export class VlAlertClosedEvent extends Event {
     static eventType = 'vl-alert-closed';
 
@@ -38,4 +46,5 @@ export interface VlAlertModel {
     naked?: boolean;
     closable?: boolean;
     multiline?: boolean;
+    alertRole?: ALERT_ROLE;
 }

--- a/libs/components/src/block/index.ts
+++ b/libs/components/src/block/index.ts
@@ -1,5 +1,13 @@
 export { VlAccordionComponent } from './accordion';
-export { ALERT_ICON, ALERT_SIZE, ALERT_TYPE, VlAlert, VlAlertClosedEvent } from './alert';
+export {
+    ALERT_ICON,
+    ALERT_ROLE,
+    ALERT_SIZE,
+    ALERT_TYPE,
+    VlAlert,
+    VlAlertClosedEvent,
+    type VlAlertAttributes,
+} from './alert';
 export { VlAutocomplete, type AutocompleteItem, type AutocompleteItemTemplateFn } from './autocomplete';
 export { VlBreadcrumbComponent, VlBreadcrumbItemComponent } from './breadcrumb';
 export {

--- a/libs/components/src/block/toaster/stories/vl-toaster.stories-doc.mdx
+++ b/libs/components/src/block/toaster/stories/vl-toaster.stories-doc.mdx
@@ -57,7 +57,8 @@ toaster.showAlert({
 ```
 
 Het meegegeven object ondersteunt alle attributen van de [vl-alert](/docs/components-block-alert--documentatie)
-component, zoals `multiline` om regeleinden (`\n`) in de `message` te bewaren.
+component, met de attribuutnaam als key, zoals `multiline` om regeleinden (`\n`) in de `message` te bewaren of
+`alert-role` om de rol van de melding te kiezen.
 
 <Canvas of={VlToasterStories.ToasterShowAlert} />
 

--- a/libs/components/src/block/toaster/vl-toaster.component.cy.ts
+++ b/libs/components/src/block/toaster/vl-toaster.component.cy.ts
@@ -1,7 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { VlButtonComponent } from '@domg-wc/components/atom';
 import { html } from 'lit';
-import { VlAlert } from '../alert';
+import { ALERT_ROLE, VlAlert } from '../alert';
 import { VlToasterComponent } from './vl-toaster.component';
 
 registerWebComponents([VlToasterComponent, VlButtonComponent, VlAlert]);
@@ -213,6 +213,24 @@ describe('cypress-component - block components - vl-toaster', () => {
                 .then(($message) => {
                     expect(getComputedStyle($message[0]).whiteSpace).to.not.equal('pre-line');
                 });
+        });
+    });
+
+    it('should show a dynamically created alert with a multi-word attribute', () => {
+        cy.mount(html` <vl-toaster></vl-toaster> `);
+        cy.get('vl-toaster').then(($toaster) => {
+            $toaster[0].showAlert({
+                title: 'Gelukt',
+                message: 'Wij hebben uw melding goed ontvangen en nemen deze spoedig in behandeling.',
+                type: 'success',
+                'alert-role': ALERT_ROLE.ALERT_DIALOG,
+            });
+            cy.get('vl-toaster')
+                .shadow()
+                .find('vl-alert')
+                .shadow()
+                .find('#alert')
+                .should('have.attr', 'role', 'alertdialog');
         });
     });
 

--- a/libs/components/src/block/toaster/vl-toaster.component.ts
+++ b/libs/components/src/block/toaster/vl-toaster.component.ts
@@ -1,7 +1,7 @@
 import { BaseLitElement, registerWebComponents, webComponent } from '@domg-wc/common';
 import { CSSResult, html, HTMLTemplateResult, PropertyDeclarations } from 'lit';
 import { VlAlert } from '../alert';
-import { VlAlertModel } from '../alert/vl-alert.model';
+import { VlAlertAttributes } from '../alert/vl-alert.model';
 import { toasterStyles } from './vl-toaster.css';
 import { toasterDefaults } from './vl-toaster.defaults';
 import { Placement } from './vl-toaster.model';
@@ -75,10 +75,10 @@ export class VlToasterComponent extends BaseLitElement {
     }
 
     /**
-     * Toont een vl-alert in de toaster met de opgegeven attributen/properties.
+     * Toont een vl-alert in de toaster met de opgegeven attributen.
      * @param alert
      */
-    showAlert(alert: VlAlertModel) {
+    showAlert(alert: VlAlertAttributes) {
         const vlAlert = document.createElement('vl-alert');
         Object.entries(alert).forEach(([key, value]) => {
             if (value) {


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-207

## Samenvatting
De `vl-alert` dwong tot nu toe onvoorwaardelijk `role="alert"` af, ook in contexten waar die rol volgens WCAG/ARIA niet past. Afnemers stemmen de rol nu af op de gebruikscontext via het nieuwe optionele `alert-role` attribuut, en de Storybook-documentatie legt uit welke rol wanneer hoort.

## Wijzigingen
- Nieuw `alert-role` attribuut met de waarden `alert` (default, bestaand gedrag), `alertdialog` en `none`; bij `none` wordt geen rol gerenderd en onbekende waarden vallen terug op `alert`.
- Bij `alert-role="alertdialog"` krijgt de melding automatisch de titel als toegankelijke naam en de boodschap als beschrijving, zoals ARIA voor die rol vereist.
- Nieuwe sectie "Toegankelijkheid" in de Storybook-docs: betekenis niet enkel via kleur en icoon, een keuzetabel die de gebruikscontext aan de juiste rol koppelt, en de focus-verantwoordelijkheid van de afnemer bij `alertdialog`.
- Nieuwe story "vl-alert - alertdialog" die het actie-vereisende scenario toont, en een `alert-role` control op de bestaande stories.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] Afnemers begrijpen uit de Storybook-docs welke `role` past bij welke context (statisch / dynamisch beknopt / dynamisch met actie) — keuzetabel in de sectie Toegankelijkheid koppelt elke context aan `none`, `alert` of `alertdialog`, met het schermlezergedrag erbij.
- [x] Een Accessibility-sectie in `vl-alert.stories-doc.mdx` analoog aan Webuniversum — drie subsecties: betekenis niet enkel via kleur/icoon, `alert` vs `alertdialog` vs `none` (met WAI-ARIA-links), en focus naar het interactieve element.
- [x] De component biedt een manier om de juiste rol te zetten i.p.v. een hardgecodeerde `role="alert"`, minstens additief — het `alert-role` attribuut is additief met default `alert`; bestaande afnemers zien geen gedragswijziging.
- [x] Voor actie-vereisende meldingen (`AlertWithButton`, actions-slot) is gedocumenteerd/voorzien dat de focus naar de alert springt — gedocumenteerd met waarschuwing en codevoorbeeld dat de afnemer de focus verplaatst; automatisch focus-management blijft gereserveerd tot de PO bevestigt dat `alertdialog` een ondersteund scenario wordt (Voorstel 3).
