### PR TITLE
fix: FLUX-236 - vl-http-error-message - debug-info als definitielijst en verwijzing naar adresbalk

### DIFF
--- a/libs/components/src/block/http-error-message/error-codes.ts
+++ b/libs/components/src/block/http-error-message/error-codes.ts
@@ -17,7 +17,7 @@ const errorCodes: ErrorCode = {
         imageAlt: 'Verkeerd verzoek',
         errorText: html` <p>
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 400">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 400.
+            URL in de adresbalk en de foutcode 400.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -30,7 +30,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Om toegang te krijgen tot deze pagina, moet u eerst aangemeld zijn.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 401">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 401.
+            URL in de adresbalk en de foutcode 401.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -43,7 +43,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             U heeft daarvoor onvoldoende rechten.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 403">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 403.
+            URL in de adresbalk en de foutcode 403.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -57,7 +57,7 @@ const errorCodes: ErrorCode = {
             We vonden de pagina niet terug. Controleer even of u een tikfout heeft gemaakt. Bent u via een link of
             website op deze pagina gekomen.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 404">Mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 404.
+            daarbij de URL in de adresbalk en de foutcode 404.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -70,7 +70,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 405">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 405.
+            URL in de adresbalk en de foutcode 405.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -83,7 +83,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Het laden van de pagina duurde te lang. Probeer het opnieuw en als het nog niet lukt:
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 408">mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 408.
+            daarbij de URL in de adresbalk en de foutcode 408.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -96,7 +96,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Deze pagina bestaat niet meer.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 410">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 410.
+            URL in de adresbalk en de foutcode 410.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -109,7 +109,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ontbreekt blijkbaar iets.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 411">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 411.
+            URL in de adresbalk en de foutcode 411.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -122,7 +122,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 412">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 412.
+            URL in de adresbalk en de foutcode 412.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -135,7 +135,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 413">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 413.
+            URL in de adresbalk en de foutcode 413.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -148,7 +148,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 414">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 414.
+            URL in de adresbalk en de foutcode 414.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -161,7 +161,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Het mediatype van de gevraagde gegevens wordt niet ondersteund door de server.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 415">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 415.
+            URL in de adresbalk en de foutcode 415.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -174,7 +174,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout. Probeer het nog eens. Lukt het nog niet,
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 500">mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 500.
+            daarbij de URL in de adresbalk en de foutcode 500.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -187,7 +187,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 501">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 501.
+            URL in de adresbalk en de foutcode 501.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -200,7 +200,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             De website is tijdelijk niet bereikbaar. Probeer later opnieuw. Heb je vragen:
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 502">mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 502.
+            daarbij de URL in de adresbalk en de foutcode 502.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -213,7 +213,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Probeer later opnieuw. Heb je vragen:
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 503">mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 503.
+            daarbij de URL in de adresbalk en de foutcode 503.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -226,7 +226,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             De website is tijdelijk niet bereikbaar. Probeer later opnieuw. Heb je vragen:
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 504">mail dan de helpdesk</a> en vermeld
-            daarbij de URL hierboven en de foutcode 504.
+            daarbij de URL in de adresbalk en de foutcode 504.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -239,7 +239,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             De HTTP-versie van uw verzoek wordt niet ondersteund door onze server.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 505">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 505.
+            URL in de adresbalk en de foutcode 505.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>
@@ -252,7 +252,7 @@ const errorCodes: ErrorCode = {
         errorText: html` <p>
             Er ging iets fout.
             <a href="mailto:help@omgevingvlaanderen.be?subject=HTTP-code 506">Mail de helpdesk</a> en vermeld daarbij de
-            URL hierboven en de foutcode 506.
+            URL in de adresbalk en de foutcode 506.
         </p>`,
         errorActions: html` <div>
             <vl-link href="/">Terug naar de startpagina</vl-link>

--- a/libs/components/src/block/http-error-message/vl-http-error-message.component.cy.ts
+++ b/libs/components/src/block/http-error-message/vl-http-error-message.component.cy.ts
@@ -87,7 +87,7 @@ describe('cypress-component - block components - vl-http-error-message - default
             .find('div[id="info"]')
             .then(($info) => {
                 cy.wrap($info)
-                    .find('tr > td#url')
+                    .find('dl > dd#url')
                     .invoke('text')
                     .then((url) => {
                         const urlPattern = /(http[s]?:\/\/)?([^\s(["<,>]*\.[^\s[",><]*)?(:\d+)?(\/\S*)?/;
@@ -95,7 +95,7 @@ describe('cypress-component - block components - vl-http-error-message - default
                         expect(urlPattern.test(url)).to.be.true;
                     });
                 cy.wrap($info)
-                    .find('tr > td#time')
+                    .find('dl > dd#time')
                     .invoke('text')
                     .then((time) => {
                         const timePattern =
@@ -104,11 +104,29 @@ describe('cypress-component - block components - vl-http-error-message - default
                         expect(timePattern.test(time)).to.be.true;
                     });
                 cy.wrap($info)
-                    .find('tr > td#user-agent')
+                    .find('dl > dd#user-agent')
                     .invoke('text')
                     .then((text) => {
                         assert.isNotEmpty(text, 'User-agent info element should contain text');
                     });
+            });
+    });
+
+    it('should render the debugging info as a description list', () => {
+        cy.get('vl-http-error-message').shadow().find('div[id="info"] table').should('not.exist');
+
+        cy.get('vl-http-error-message')
+            .shadow()
+            .find('div[id="info"] dl')
+            .then(($list) => {
+                const children = $list.children().toArray();
+                const tagNames = children.map((child) => child.tagName.toLowerCase());
+                const labels = children
+                    .filter((child) => child.tagName === 'DT')
+                    .map((term) => term.textContent?.trim());
+
+                expect(tagNames).to.deep.equal(['dt', 'dd', 'dt', 'dd', 'dt', 'dd']);
+                expect(labels).to.deep.equal(['URL:', 'Tijd:', 'User-agent:']);
             });
     });
 });
@@ -182,7 +200,7 @@ describe('cypress-component - block components - vl-http-error-message - error-c
                 'contain',
                 'We vonden de pagina niet terug. Controleer even of u een tikfout heeft gemaakt. Bent u via een link of\n            website op deze pagina gekomen.'
             )
-            .and('contain', 'en vermeld\n            daarbij de URL hierboven en de foutcode 404.');
+            .and('contain', 'en vermeld\n            daarbij de URL in de adresbalk en de foutcode 404.');
     });
 
     it('should contain an action button', () => {
@@ -198,7 +216,7 @@ describe('cypress-component - block components - vl-http-error-message - error-c
             .find('div[id="info"]')
             .then(($info) => {
                 cy.wrap($info)
-                    .find('tr > td#url')
+                    .find('dl > dd#url')
                     .invoke('text')
                     .then((url) => {
                         const urlPattern = /(http[s]?:\/\/)?([^\s(["<,>]*\.[^\s[",><]*)?(:\d+)?(\/\S*)?/;
@@ -206,7 +224,7 @@ describe('cypress-component - block components - vl-http-error-message - error-c
                         expect(urlPattern.test(url)).to.be.true;
                     });
                 cy.wrap($info)
-                    .find('tr > td#time')
+                    .find('dl > dd#time')
                     .invoke('text')
                     .then((time) => {
                         const timePattern =
@@ -215,7 +233,7 @@ describe('cypress-component - block components - vl-http-error-message - error-c
                         expect(timePattern.test(time)).to.be.true;
                     });
                 cy.wrap($info)
-                    .find('tr > td#user-agent')
+                    .find('dl > dd#user-agent')
                     .invoke('text')
                     .then((text) => {
                         assert.isNotEmpty(text, 'User-agent info element should contain text');

--- a/libs/components/src/block/http-error-message/vl-http-error-message.component.ts
+++ b/libs/components/src/block/http-error-message/vl-http-error-message.component.ts
@@ -16,7 +16,7 @@ export class VlHttpErrorMessage extends BaseHTMLElement {
     constructor() {
         const html = `
           <div class="vl-form-message-container vl-grid vl-stacked-small">
-            <div class="vl-column vl-column--justify-self-center vl-column--6  vl-column--m-6  vl-column--s-8 vl-column--xs-12">
+            <div class="vl-column vl-column--6 vl-column--m-6 vl-column--s-8 vl-column--xs-12">
               <div class="vl-grid vl-stacked-small">
                 <div class="vl-column vl-column--12">
                   <h2 id="title"></h2>
@@ -24,20 +24,14 @@ export class VlHttpErrorMessage extends BaseHTMLElement {
                   <vl-typography id="error-text"></vl-typography>
                 </div>
                 <div id="info" class="vl-column vl-column--12">
-                  <table>
-                    <tr>
-                      <td>URL:</td>
-                      <td id="url"></td>
-                    </tr>
-                    <tr>
-                      <td>Tijd:</td>
-                      <td id="time"></td>
-                    </tr>
-                    <tr>
-                      <td>User-agent:</td>
-                      <td id="user-agent"></td>
-                    </tr>
-                  </table>
+                  <dl>
+                    <dt>URL:</dt>
+                    <dd id="url"></dd>
+                    <dt>Tijd:</dt>
+                    <dd id="time"></dd>
+                    <dt>User-agent:</dt>
+                    <dd id="user-agent"></dd>
+                  </dl>
                 </div>
                 <div id="actions" class="vl-column vl-column--12"><div id="error-actions"><slot name="actions"></slot></div></div>
               </div>

--- a/libs/components/src/block/http-error-message/vl-http-error-message.flux-css.ts
+++ b/libs/components/src/block/http-error-message/vl-http-error-message.flux-css.ts
@@ -5,11 +5,16 @@ export const vlHttpErrorMessageFluxStyles: CSSResult = css`
     #info {
         font-size: small;
     }
-    td {
-        padding-right: 15px;
-    }
-    table {
+
+    dl {
+        display: grid;
+        grid-template-columns: max-content auto;
         color: dimgray;
+    }
+
+    dt,
+    dd {
+        padding-right: 15px;
     }
 
     @media screen and (max-width: ${vlMediaScreenSmall}px) {


### PR DESCRIPTION
## Jira
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-236

## Samenvatting
De debug-info (URL, tijd, user-agent) van `vl-http-error-message` wordt voortaan als definitielijst getoond in plaats van als tabel, zodat screenreaders die aankondigen als beschrijvende sleutel-waardeparen (WCAG 1.3.1). De foutcode-teksten verwijzen nu naar "de URL in de adresbalk". Visueel verandert er niets.

## Wijzigingen
- Debug-info-blok gerenderd als `<dl>` met `<dt>`/`<dd>`-paren in plaats van een `<table>` (WCAG 1.3.1 Info and Relationships).
- Layout van label en waarde naast elkaar behouden via een tweekoloms-grid op de definitielijst, zonder de lijst-semantiek voor assistive technology te breken.
- In alle 19 foutcode-teksten verwijst de helpdesk-instructie nu naar "de URL in de adresbalk" in plaats van "de URL hierboven" (UIG-1103). De exacte copy is een contentkeuze — graag validatie door PO/content bij deze review.
- Regressietest toegevoegd die de definitielijst-structuur bewaakt; bestaande test-selectors bijgewerkt van tabel- naar definitielijst-markup.

## Backwards compatibility
Volledig backwards-compatible — geen breaking changes.

## Succescriteria
- [x] De debug-info wordt niet langer met `<table>/<tr>/<td>` weergegeven maar semantisch correct als `<dl>` met `<dt>` (label) en `<dd>` (waarde) — het `#info`-blok rendert nu een definitielijst met strikt alternerende `dt`/`dd`-paren.
- [x] De ids `#url`, `#time`, `#user-agent` blijven bestaan op de waarde-elementen, zodat `__setDebugInfo()` ongewijzigd blijft werken — de ids staan op de `<dd>`-elementen; de getters en `__setDebugInfo()` zijn onaangeraakt.
- [x] De styling van het info-blok blijft visueel gelijk aan de screenshot (kleine, dimgray tekst, label en waarde naast elkaar) — tweekoloms-grid met dezelfde 15px tussenruimte en kleur reproduceert de tabelpresentatie, ook op de bestaande breakpoints.
- [x] De foutcode-teksten verwijzen duidelijk naar waar de URL te vinden is ("in de adresbalk") — alle 19 foutcodes aangepast (het rapport vermeldde er 22; 19 is het werkelijke aantal).
- [x] Bestaande component-tests en e2e-stories blijven slagen — 27/27 Cypress-tests groen (incl. de axe-checks); de e2e-story gebruikt geen tabel-selectors en behoefde geen aanpassing.
