### PR TITLE
feat: FLUX-757 - vl-properties - value-bold attribuut + FLUX-760 mobiele spacing

### DIFF
--- a/apps/storybook-e2e/src/e2e/components/block/properties/vl-properties.stories.cy.ts
+++ b/apps/storybook-e2e/src/e2e/components/block/properties/vl-properties.stories.cy.ts
@@ -8,6 +8,8 @@ const propertiesStackedUrl =
     'http://localhost:8080/iframe.html?args=&id=components-block-properties--properties-stacked&viewMode=story';
 const propertiesColumnsUrl =
     'http://localhost:8080/iframe.html?args=&id=components-block-properties--properties-columns&viewMode=story';
+const propertiesValueBoldUrl =
+    'http://localhost:8080/iframe.html?args=&id=components-block-properties--properties-value-bold&viewMode=story';
 
 describe('cypress-e2e - block components - vl-properties - default story', () => {
     it('should render', () => {
@@ -44,6 +46,14 @@ describe('cypress-e2e - block components - vl-properties - stacked story', () =>
 describe('cypress-e2e - block components - vl-properties - columns story', () => {
     it('should render', () => {
         cy.visit(propertiesColumnsUrl);
+
+        cy.get('vl-properties').shadow().find('dl');
+    });
+});
+
+describe('cypress-e2e - block components - vl-properties - value bold story', () => {
+    it('should render', () => {
+        cy.visit(propertiesValueBoldUrl);
 
         cy.get('vl-properties').shadow().find('dl');
     });

--- a/libs/components/src/block/properties/stories/vl-properties.stories-arg.ts
+++ b/libs/components/src/block/properties/stories/vl-properties.stories-arg.ts
@@ -40,4 +40,13 @@ export const propertiesArgTypes: ArgTypes<PropertiesArgs> = {
             defaultValue: { summary: String(propertiesArgs.noPaddingBottom) },
         },
     },
+    valueBold: {
+        name: 'value-bold',
+        description: 'Toont de data in bold zodat deze visueel meer opvalt.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(propertiesArgs.valueBold) },
+        },
+    },
 };

--- a/libs/components/src/block/properties/stories/vl-properties.stories-doc.mdx
+++ b/libs/components/src/block/properties/stories/vl-properties.stories-doc.mdx
@@ -90,6 +90,13 @@ M.b.v. de `column` (en `column--full-width`) class kunnen er 2 kolommen gespecif
 
 <Canvas of={VlPropertiesStories.PropertiesColumns}/>
 
+### Value bold
+
+Via het `value-bold` attribuut wordt de waarde, de inhoud van `vl-property-data`, in bold getoond zodat ze visueel
+meer opvalt. Vergelijkbaar met de weergave van `vl-description-data`, maar met het label links en de waarde rechts.
+
+<Canvas of={VlPropertiesStories.PropertiesValueBold}/>
+
 
 ## Spacing aanpassen
 

--- a/libs/components/src/block/properties/stories/vl-properties.stories.ts
+++ b/libs/components/src/block/properties/stories/vl-properties.stories.ts
@@ -25,8 +25,13 @@ export default {
 
 const PropertiesTemplate = story(
     propertiesArgs,
-    ({ labelWidth, props, noPaddingBottom }) => html`
-        <vl-properties label-width=${labelWidth} .props=${props} ?no-padding-bottom=${noPaddingBottom}>
+    ({ labelWidth, props, noPaddingBottom, valueBold }) => html`
+        <vl-properties
+            label-width=${labelWidth}
+            .props=${props}
+            ?no-padding-bottom=${noPaddingBottom}
+            ?value-bold=${valueBold}
+        >
             <vl-property>Woonplaats</vl-property>
             <vl-property-data>Brussel</vl-property-data>
             <vl-property>Postcode</vl-property>
@@ -37,8 +42,13 @@ const PropertiesTemplate = story(
 
 const PropertiesEmptyTemplate = story(
     propertiesArgs,
-    ({ labelWidth, props, noPaddingBottom }) => html`
-        <vl-properties label-width=${labelWidth} .props=${props} ?no-padding-bottom=${noPaddingBottom}></vl-properties>
+    ({ labelWidth, props, noPaddingBottom, valueBold }) => html`
+        <vl-properties
+            label-width=${labelWidth}
+            .props=${props}
+            ?no-padding-bottom=${noPaddingBottom}
+            ?value-bold=${valueBold}
+        ></vl-properties>
     `,
 );
 
@@ -53,8 +63,13 @@ PropertiesWithProps.args = {
 
 export const PropertiesHtmlEnriched = story(
     propertiesArgs,
-    ({ labelWidth, props, noPaddingBottom }) => html`
-        <vl-properties label-width=${labelWidth} .props=${props} ?no-padding-bottom=${noPaddingBottom}>
+    ({ labelWidth, props, noPaddingBottom, valueBold }) => html`
+        <vl-properties
+            label-width=${labelWidth}
+            .props=${props}
+            ?no-padding-bottom=${noPaddingBottom}
+            ?value-bold=${valueBold}
+        >
             <vl-property>
                 <vl-icon icon="location" small right-margin=""></vl-icon>
                 Woonplaats
@@ -72,8 +87,13 @@ PropertiesHtmlEnriched.storyName = 'vl-properties - html enriched';
 
 export const PropertiesStacked = story(
     propertiesArgs,
-    ({ labelWidth, props, noPaddingBottom }) => html`
-        <vl-properties label-width=${labelWidth} .props=${props} ?no-padding-bottom=${noPaddingBottom}>
+    ({ labelWidth, props, noPaddingBottom, valueBold }) => html`
+        <vl-properties
+            label-width=${labelWidth}
+            .props=${props}
+            ?no-padding-bottom=${noPaddingBottom}
+            ?value-bold=${valueBold}
+        >
             <div class="stacked">
                 <vl-property>Woonplaats</vl-property>
                 <vl-property-data>Brussel</vl-property-data>
@@ -87,8 +107,13 @@ PropertiesStacked.storyName = 'vl-properties - stacked';
 
 export const PropertiesColumns = story(
     propertiesArgs,
-    ({ labelWidth, props, noPaddingBottom }) => html`
-        <vl-properties label-width=${labelWidth} .props=${props} ?no-padding-bottom=${noPaddingBottom}>
+    ({ labelWidth, props, noPaddingBottom, valueBold }) => html`
+        <vl-properties
+            label-width=${labelWidth}
+            .props=${props}
+            ?no-padding-bottom=${noPaddingBottom}
+            ?value-bold=${valueBold}
+        >
             <div class="column">
                 <vl-property>Woonplaats</vl-property>
                 <vl-property-data>Brussel</vl-property-data>
@@ -114,3 +139,9 @@ export const PropertiesColumns = story(
     `,
 );
 PropertiesColumns.storyName = 'vl-properties - columns';
+
+export const PropertiesValueBold = PropertiesTemplate.bind({});
+PropertiesValueBold.storyName = 'vl-properties - value bold';
+PropertiesValueBold.args = {
+    valueBold: true,
+};

--- a/libs/components/src/block/properties/vl-properties.component.cy.ts
+++ b/libs/components/src/block/properties/vl-properties.component.cy.ts
@@ -291,6 +291,87 @@ describe('cypress-component - block components - vl-properties', () => {
 
         cy.get('vl-properties').shadow().find('dl').should('have.css', 'padding-bottom', '20px');
     });
+
+    it('should render the data in bold when value-bold attribute is set', () => {
+        cy.mount(html`
+            <vl-properties value-bold>
+                <vl-property>Woonplaats</vl-property>
+                <vl-property-data>Brussel</vl-property-data>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').should('have.css', 'font-weight', '500');
+        cy.get('vl-properties').shadow().find('dt').should('have.css', 'font-weight', '400');
+    });
+
+    it('should render the data with default font-weight when value-bold attribute is not set', () => {
+        cy.mount(defaultPropertiesTemplate);
+
+        cy.get('vl-properties').shadow().find('dd').eq(0).should('have.css', 'font-weight', '400');
+    });
+
+    it('should render the data in bold when value-bold is combined with the stacked layout', () => {
+        cy.mount(html`
+            <vl-properties value-bold>
+                <div class="stacked">
+                    <vl-property>Woonplaats</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                </div>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').should('have.css', 'font-weight', '500');
+        cy.get('vl-properties').shadow().find('dt').should('have.css', 'font-weight', '400');
+    });
+
+    it('should render the data in bold when value-bold is combined with the column layout', () => {
+        cy.mount(html`
+            <vl-properties value-bold>
+                <div class="column">
+                    <vl-property>Woonplaats</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                </div>
+                <div class="column column--full-width">
+                    <vl-property>Gewest</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                </div>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').eq(0).should('have.css', 'font-weight', '500');
+        cy.get('vl-properties').shadow().find('dd').eq(1).should('have.css', 'font-weight', '500');
+    });
+
+    it('should render the data in bold on a small screen when value-bold attribute is set', () => {
+        cy.viewport(375, 667);
+        cy.mount(html`
+            <vl-properties value-bold>
+                <vl-property>Woonplaats</vl-property>
+                <vl-property-data>Brussel</vl-property-data>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dd').should('have.css', 'font-size', '16px');
+        cy.get('vl-properties').shadow().find('dd').should('have.css', 'font-weight', '500');
+    });
+
+    it('should update the data font-weight when the value-bold attribute is toggled', () => {
+        cy.mount(defaultPropertiesTemplate);
+
+        cy.get('vl-properties').shadow().find('dd').eq(0).should('have.css', 'font-weight', '400');
+
+        cy.runTestFor<VlPropertiesComponent>('vl-properties', (component) => {
+            component.setAttribute('value-bold', '');
+        });
+
+        cy.get('vl-properties').shadow().find('dd').eq(0).should('have.css', 'font-weight', '500');
+
+        cy.runTestFor<VlPropertiesComponent>('vl-properties', (component) => {
+            component.removeAttribute('value-bold');
+        });
+
+        cy.get('vl-properties').shadow().find('dd').eq(0).should('have.css', 'font-weight', '400');
+    });
 });
 
 describe('cypress-component - block components - vl-properties - deprecated no-clone attribute', () => {

--- a/libs/components/src/block/properties/vl-properties.component.cy.ts
+++ b/libs/components/src/block/properties/vl-properties.component.cy.ts
@@ -192,6 +192,7 @@ describe('cypress-component - block components - vl-properties', () => {
     });
 
     it('should have the same spacing between properties inside a column as between columns', () => {
+        cy.viewport(1280, 800);
         cy.mount(propertiesColumnWithTwoPropertiesTemplate);
 
         cy.get('vl-properties').shadow().find('dl').should('have.css', 'row-gap', '20px');
@@ -200,12 +201,14 @@ describe('cypress-component - block components - vl-properties', () => {
     });
 
     it('should not add spacing between multiple data values of one property', () => {
+        cy.viewport(1280, 800);
         cy.mount(propertiesWithPropsTemplate({ props: dummyProps }));
 
         cy.get('vl-properties').shadow().find('.column').find('dd').eq(1).should('have.css', 'margin-top', '0px');
     });
 
     it('should use the --vl-properties--row-gap custom property for the spacing between properties', () => {
+        cy.viewport(1280, 800);
         cy.mount(html`
             <vl-properties style="--vl-properties--row-gap: 4rem">
                 <div class="column">
@@ -219,6 +222,14 @@ describe('cypress-component - block components - vl-properties', () => {
 
         cy.get('vl-properties').shadow().find('dl').should('have.css', 'row-gap', '40px');
         cy.get('vl-properties').shadow().find('.column dt').eq(1).should('have.css', 'margin-top', '40px');
+    });
+
+    it('should keep the label next to its data in the layout below the small breakpoint', () => {
+        cy.viewport(600, 800);
+        cy.mount(propertiesColumnWithTwoPropertiesTemplate);
+
+        cy.get('vl-properties').shadow().find('.column dt').eq(1).should('have.css', 'margin-top', '0px');
+        cy.get('vl-properties').shadow().find('.column dd').eq(0).should('have.css', 'padding-bottom', '20px');
     });
 
     it("should contain a shadow DOM with dl, dt's and dd's specified through props", () => {

--- a/libs/components/src/block/properties/vl-properties.css.ts
+++ b/libs/components/src/block/properties/vl-properties.css.ts
@@ -44,6 +44,13 @@ export const sizeQueryStyles = css`
             display: block;
         }
 
+        .column > dd + dt,
+        .column > dd + dt + dd,
+        .column--full-width > dd + dt,
+        .column--full-width > dd + dt + dd {
+            margin-top: 0;
+        }
+
         dt {
             ${collapsedDt()};
         }

--- a/libs/components/src/block/properties/vl-properties.css.ts
+++ b/libs/components/src/block/properties/vl-properties.css.ts
@@ -73,6 +73,11 @@ export const propertiesStyles: CSSResult = css`
             padding-bottom: 0;
         }
     }
+    :host([value-bold]) {
+        dd {
+            font-weight: 500;
+        }
+    }
 
     dt,
     dd {

--- a/libs/components/src/block/properties/vl-properties.defaults.ts
+++ b/libs/components/src/block/properties/vl-properties.defaults.ts
@@ -4,4 +4,5 @@ export const propertiesDefaults = {
     labelWidth: 25,
     props: [] as Props,
     noPaddingBottom: false,
+    valueBold: false as boolean,
 } as const;


### PR DESCRIPTION
FLUX-757: https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-757
FLUX-760: https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-760

Twee commits:

- **FLUX-757**: `value-bold`-attribuut toont de waarde (dd) in font-weight 500, met het label links en de waarde rechts.
- **FLUX-760**: regressie uit PR #865 hersteld, de margin op de property-grens gold ook op mobiel bovenop de padding.