### PR TITLE
feat: FLUX-782 - vl-autocomplete - itemTemplate property toegevoegd

### DIFF
--- a/libs/components/src/block/autocomplete/index.ts
+++ b/libs/components/src/block/autocomplete/index.ts
@@ -1,1 +1,2 @@
 export { VlAutocomplete } from './vl-autocomplete.component';
+export { type AutocompleteItem, type AutocompleteItemTemplateFn } from './vl-autocomplete.model';

--- a/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories-arg.ts
+++ b/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories-arg.ts
@@ -1,4 +1,5 @@
-import { CAPTION_FORMAT, GROUP_BY } from '../vl-autocomplete.model';
+import { html } from 'lit';
+import { AutocompleteItemTemplateFn, CAPTION_FORMAT, GROUP_BY } from '../vl-autocomplete.model';
 import {
     CATEGORIES,
     CONTROLS,
@@ -20,6 +21,37 @@ export const complexItems = [
     { title: 'Buurtshuis Watersportbaan Gent', subtitle: 'Project', value: '7' },
 ];
 
+export const dossierItems = [
+    {
+        title: 'PV.ANB.2026.00412',
+        value: '1',
+        createdOn: '08.05.2026',
+        owner: 'Jane Smith',
+        status: 'Nog niet opnemen',
+    },
+    {
+        title: 'ANB-2026-00412-bis',
+        value: '2',
+        createdOn: '02.04.2026',
+        owner: 'Bob Johnson',
+        status: 'Wel opnemen',
+    },
+    {
+        title: 'ANB 2026 00412',
+        value: '3',
+        createdOn: '15.01.2026',
+        owner: 'Alice Brown',
+        status: 'Niet opnemen',
+    },
+];
+
+export const dossierItemTemplate: AutocompleteItemTemplateFn = (item) => html`
+    <div class="vl-stacked">
+        <vl-text bold>${item.title}</vl-text>
+        <vl-text annotation>Aangemaakt op ${item.createdOn}, eigenaar: ${item.owner}, status: ${item.status}</vl-text>
+    </div>
+`;
+
 export const autocompleteArgs = {
     ...defaultArgs,
     placeholder: '',
@@ -35,6 +67,7 @@ export const autocompleteArgs = {
     clearTooltip: 'Wissen',
     noMatchesText: 'Geen resultaat',
     items: [],
+    itemTemplate: undefined as AutocompleteItemTemplateFn | undefined,
     search: action('search'),
     selectedAutocomplete: action('selected-autocomplete'),
     clear: action('clear'),
@@ -181,6 +214,20 @@ export const autocompleteArgTypes: ArgTypes<typeof autocompleteArgs> = {
             category: CATEGORIES.PROPERTIES,
             type: { summary: TYPES.ARRAY },
             defaultValue: { summary: String(autocompleteArgs.items) },
+        },
+    },
+    itemTemplate: {
+        name: 'itemTemplate',
+        description:
+            'Gebruik deze property om zelf te bepalen hoe de inhoud van een suggestie gerenderd wordt.' +
+            ' De functie krijgt het volledige item mee en geeft een lit `TemplateResult` terug.' +
+            ' Wordt deze property ingesteld, dan valt `caption-format` weg voor de suggesties.' +
+            '\n\nKan niet aangepast worden in Storybook.',
+        control: false,
+        table: {
+            category: CATEGORIES.PROPERTIES,
+            type: { summary: TYPES.FUNCTION },
+            defaultValue: { summary: String(autocompleteArgs.itemTemplate) },
         },
     },
     search: {

--- a/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories-doc.mdx
+++ b/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories-doc.mdx
@@ -38,6 +38,35 @@ import { VlAutocomplete } from '@domg-wc/components/block';
 
 <Canvas of={VlAutocompleteStories.AutocompleteGroupBySubtitle} />
 
+### Suggesties met een eigen item-template
+
+Moet een suggestie meer tonen dan `title`, `subtitle` en `value`, dan volstaat `caption-format` niet. Stel dan
+`itemTemplate` in: die functie krijgt het item en levert de inhoud van de `<li>`. De `<li>` zelf (id, klik,
+`role="option"`) blijft van de component.
+
+Vindt de zoekopdracht niets, dan roept de component je `itemTemplate` niet aan. Ze toont dan één suggestie met de
+tekst uit het `no-matches-text`-attribuut, standaard "Geen resultaat".
+
+```ts
+const itemTemplate = (item) => html`
+    <div class="vl-stacked">
+        <vl-text bold>${item.title}</vl-text>
+        <vl-text annotation>Aangemaakt op ${item.createdOn}, eigenaar: ${item.owner}</vl-text>
+    </div>
+`;
+```
+
+```html
+<vl-autocomplete .items="${items}" .itemTemplate="${itemTemplate}"></vl-autocomplete>
+```
+
+> Zet geen links of knoppen in de template, handel zulke acties af via het `selected-autocomplete`-event. Een
+> [`option`](https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational) verbergt zijn kinderen voor
+> hulptechnologie ([4.1.2](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)) en het toetsenbord
+> ([2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)).
+
+<Canvas of={VlAutocompleteStories.AutocompleteWithItemTemplate} />
+
 ### Voorbeeld met location API
 
 Om te werken met een API, luister je naar het `search`-event dat opgeworpen wordt wanneer de gebruiker begint te typen.

--- a/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories.ts
+++ b/libs/components/src/block/autocomplete/stories/vl-autocomplete.stories.ts
@@ -7,7 +7,13 @@ import { VlSideSheet } from '../../side-sheet';
 import { CAPTION_FORMAT, GROUP_BY } from '../vl-autocomplete.model';
 import { fetchDataFromApiCall } from './vl-autocomplete-api.stories-util';
 import { fetchDataFromMockedApiCall } from './vl-autocomplete-mocked-api.stories-util';
-import { autocompleteArgs, autocompleteArgTypes, complexItems } from './vl-autocomplete.stories-arg';
+import {
+    autocompleteArgs,
+    autocompleteArgTypes,
+    complexItems,
+    dossierItems,
+    dossierItemTemplate,
+} from './vl-autocomplete.stories-arg';
 import autocompleteDoc from './vl-autocomplete.stories-doc.mdx';
 
 registerWebComponents([VlSideSheet]);
@@ -100,6 +106,22 @@ export const AutocompleteCustomCaptionFormatter = story(
         `
 );
 AutocompleteCustomCaptionFormatter.storyName = 'vl-autocomplete - custom caption formatter';
+
+export const AutocompleteWithItemTemplate = story(
+    autocompleteArgs,
+    () =>
+        html`
+            <vl-autocomplete
+                min-chars="1"
+                label="Doorzoek PV's"
+                placeholder="Hint: typ ANB"
+                show-clear
+                .items=${dossierItems}
+                .itemTemplate=${dossierItemTemplate}
+            ></vl-autocomplete>
+        `
+);
+AutocompleteWithItemTemplate.storyName = 'vl-autocomplete - item template';
 
 export const AutocompleteInputAndApiCall = story(
     autocompleteArgs,

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.cy.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.cy.ts
@@ -1,6 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
 import { VlAutocomplete } from './vl-autocomplete.component';
+import { AutocompleteItemTemplateFn } from './vl-autocomplete.model';
 
 registerWebComponents([VlAutocomplete]);
 
@@ -52,6 +53,93 @@ describe('cypress-component - block components - vl-autocomplete', () => {
             .should('deep.equal', { title: 'Gentbos, Merelbeke', subtitle: 'Adres', value: '2', custom: 'custom' });
     });
 
+    it('should render the suggestion content with the item template when set', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+                .itemTemplate=${itemTemplate}
+            ></vl-autocomplete>
+        `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('Gentbos');
+        cy.get('vl-autocomplete')
+            .shadow()
+            .find('#suggestions')
+            .find('li')
+            .first()
+            .find('.custom-item')
+            .should('have.text', 'Gentbos, Merelbeke - custom');
+    });
+
+    it('should keep the caption format for the suggestion content when no item template is set', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+            ></vl-autocomplete>
+        `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('Gentbos');
+        cy.get('vl-autocomplete').shadow().find('#suggestions').find('.custom-item').should('not.exist');
+        cy.get('vl-autocomplete')
+            .shadow()
+            .find('#suggestions')
+            .find('li')
+            .first()
+            .find('.flux-autocomplete_title')
+            .should('have.text', 'Gentbos, Merelbeke');
+    });
+
+    it('should not apply the item template to the no matches suggestion', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                no-matches-text="Geen resultaat"
+                .items=${complexItems}
+                .itemTemplate=${itemTemplate}
+            ></vl-autocomplete>
+        `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('xyz');
+        cy.get('vl-autocomplete').shadow().find('#suggestions').find('li').should('have.length', 1);
+        cy.get('vl-autocomplete').shadow().find('#suggestions').find('.custom-item').should('not.exist');
+        cy.get('vl-autocomplete')
+            .shadow()
+            .find('#suggestions')
+            .find('li')
+            .first()
+            .should('contain.text', 'Geen resultaat');
+    });
+
+    it('should upgrade vl-text inside an item template without the consumer registering it', () => {
+        cy.mount(html`
+            <vl-autocomplete
+                placeholder="Hint: typ Gent"
+                min-chars="1"
+                max-suggestions="5"
+                .items=${complexItems}
+                .itemTemplate=${textItemTemplate}
+            ></vl-autocomplete>
+        `);
+
+        cy.get('vl-autocomplete').shadow().find('input').type('Gentbos');
+        cy.get('vl-autocomplete')
+            .shadow()
+            .find('#suggestions')
+            .find('vl-text[bold]')
+            .should('have.text', 'Gentbos, Merelbeke')
+            .and(($el) => {
+                expect($el[0].shadowRoot, 'vl-text is upgraded').to.not.be.null;
+            });
+    });
+
     it('should show loading animation when typing without suggestions by default', () => {
         cy.mount(html` <vl-autocomplete min-chars="1" placeholder="Hint: typ Gent"></vl-autocomplete> `);
 
@@ -68,6 +156,16 @@ describe('cypress-component - block components - vl-autocomplete', () => {
         cy.get('vl-autocomplete').shadow().find('div.vl-autocomplete__loader').should('have.attr', 'hidden');
     });
 });
+
+const itemTemplate: AutocompleteItemTemplateFn = (item) =>
+    html`<span class="custom-item">${item.title} - ${item.custom ?? 'geen'}</span>`;
+
+const textItemTemplate: AutocompleteItemTemplateFn = (item) => html`
+    <div class="vl-stacked">
+        <vl-text bold>${item.title}</vl-text>
+        <vl-text annotation>${item.subtitle}</vl-text>
+    </div>
+`;
 
 export const complexItems = [
     { title: 'Gent', subtitle: 'Gemeente', value: '1' },

--- a/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.component.ts
@@ -1,20 +1,34 @@
-import { BaseLitElement } from '@domg-wc/common';
+import { BaseLitElement, registerWebComponents } from '@domg-wc/common';
 import { baseStyle, resetStyle } from '@domg/govflanders-style/common';
 import { autocompleteStyle, inputFieldStyle } from '@domg/govflanders-style/component';
+import { vlStackedStyles } from '@domg-wc/styles';
 import { html, PropertyValues } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import 'reflect-metadata';
 import { DEFAULT_CAPTION_FORMAT, DEFAULT_MAX_MATCHES, DEFAULT_MIN_CHARS } from './vl-autocomplete.defaults';
-import { CAPTION_FORMAT } from './vl-autocomplete.model';
+import { AutocompleteItemTemplateFn, CAPTION_FORMAT } from './vl-autocomplete.model';
 import { vlAutocompleteFluxStyles } from './vl-autocomplete.flux-css';
 import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
+import { VlTextComponent } from '../../atom/text';
 
 @customElement('vl-autocomplete')
 // eslint-disable-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export class VlAutocomplete extends BaseLitElement {
+    static {
+        registerWebComponents([VlTextComponent]);
+    }
+
     static get styles() {
-        return [resetStyle, baseStyle, autocompleteStyle, inputFieldStyle, vlAutocompleteFluxStyles, vlIconStyles];
+        return [
+            resetStyle,
+            baseStyle,
+            autocompleteStyle,
+            inputFieldStyle,
+            vlAutocompleteFluxStyles,
+            vlIconStyles,
+            vlStackedStyles,
+        ];
     }
 
     static get properties() {
@@ -51,8 +65,11 @@ export class VlAutocomplete extends BaseLitElement {
             labelSmall: { type: Boolean, attribute: 'label-small', reflect: true },
             clearTooltip: { type: String, attribute: 'clear-tooltip', reflect: true },
             disableLoading: { type: Boolean, attribute: 'disable-loading', reflect: true },
+            itemTemplate: { attribute: false },
         };
     }
+
+    itemTemplate?: AutocompleteItemTemplateFn;
 
     private initialised: boolean;
     private initialValue: string;
@@ -402,7 +419,7 @@ export class VlAutocomplete extends BaseLitElement {
             role="option"
             aria-selected="${id === this._highlightedEl?.id ? 'true' : 'false'}"
         >
-            ${this.formatCaption(item)}
+            ${this.itemTemplate && item.value != null ? this.itemTemplate(item) : this.formatCaption(item)}
         </li>`;
     }
 

--- a/libs/components/src/block/autocomplete/vl-autocomplete.model.ts
+++ b/libs/components/src/block/autocomplete/vl-autocomplete.model.ts
@@ -1,3 +1,16 @@
+import { TemplateResult } from 'lit';
+
+export interface AutocompleteItem {
+    title?: string;
+    subtitle?: string;
+    value?: string | null;
+    [key: string]: unknown;
+}
+
+export interface AutocompleteItemTemplateFn {
+    (item: AutocompleteItem): TemplateResult;
+}
+
 export const CAPTION_FORMAT = {
     TITLE: 'title-only',
     SUBTITLE: 'subtitle-only',

--- a/libs/components/src/block/index.ts
+++ b/libs/components/src/block/index.ts
@@ -1,6 +1,6 @@
 export { VlAccordionComponent } from './accordion';
 export { ALERT_ICON, ALERT_SIZE, ALERT_TYPE, VlAlert, VlAlertClosedEvent } from './alert';
-export { VlAutocomplete } from './autocomplete';
+export { VlAutocomplete, type AutocompleteItem, type AutocompleteItemTemplateFn } from './autocomplete';
 export { VlBreadcrumbComponent, VlBreadcrumbItemComponent } from './breadcrumb';
 export {
     VlCascaderComponent,


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-782

Nieuwe property `itemTemplate` op `vl-autocomplete`: een functie die het item krijgt en de inhoud van de `<li>` levert, voor suggesties die `caption-format` niet aankan. Bestaande afnemers wijzigen niet.

De component registreert `VlTextComponent` en neemt `vlStackedStyles` op, zodat een template `vl-text` en `vl-stacked` kan gebruiken binnen de shadow DOM. Zoals `vl-select-rich` bij FLUX-773.

De link "Open dossier" uit het design zit er niet in: een `option` verbergt zijn kinderen voor hulptechnologie en toetsenbord. Af te stemmen met de reporter.

Story: `vl-autocomplete - item template`.