### PR TITLE
fix: FLUX-760 - vl-properties - whitespace tussen properties binnen een column

### DIFF
--- a/libs/components/src/block/properties/stories/vl-properties.stories-doc.mdx
+++ b/libs/components/src/block/properties/stories/vl-properties.stories-doc.mdx
@@ -91,6 +91,20 @@ M.b.v. de `column` (en `column--full-width`) class kunnen er 2 kolommen gespecif
 <Canvas of={VlPropertiesStories.PropertiesColumns}/>
 
 
+## Spacing aanpassen
+
+De verticale ruimte tussen properties staat in de custom property `--vl-properties--row-gap` (standaard `2rem`).
+Meerdere data-waardes onder eenzelfde label horen bij elkaar en krijgen die ruimte niet, ze blijven in de
+column-layout tegen elkaar staan. Wie een compactere of ruimere weergave nodig heeft, zet de property van buitenaf
+op de component:
+
+```css
+vl-properties {
+    --vl-properties--row-gap: 1rem;
+}
+```
+
+
 ## Gekende beperkingen
 
 Er is ondersteuning om meerdere labels en data op te geven in de lijst. 1 label met meerdere data waardes en

--- a/libs/components/src/block/properties/stories/vl-properties.stories.ts
+++ b/libs/components/src/block/properties/stories/vl-properties.stories.ts
@@ -92,14 +92,23 @@ export const PropertiesColumns = story(
             <div class="column">
                 <vl-property>Woonplaats</vl-property>
                 <vl-property-data>Brussel</vl-property-data>
-            </div>
-            <div class="column">
                 <vl-property>Postcode</vl-property>
                 <vl-property-data>1000</vl-property-data>
             </div>
+            <div class="column">
+                <vl-property>Straat</vl-property>
+                <vl-property-data>Havenlaan</vl-property-data>
+                <vl-property>Huisnummer</vl-property>
+                <vl-property-data>88</vl-property-data>
+            </div>
             <div class="column column--full-width">
                 <vl-property>Gewest</vl-property>
-                <vl-property-data>Brussel</vl-property-data>
+                <vl-property-data>Brussels Hoofdstedelijk Gewest</vl-property-data>
+                <vl-property>Omschrijving</vl-property>
+                <vl-property-data>
+                    Een wat langere omschrijving zodat meteen duidelijk is dat een property over meerdere regels correct
+                    wrapt binnen een column.
+                </vl-property-data>
             </div>
         </vl-properties>
     `,

--- a/libs/components/src/block/properties/vl-properties.component.cy.ts
+++ b/libs/components/src/block/properties/vl-properties.component.cy.ts
@@ -43,6 +43,17 @@ const propertiesColumnsTemplate = html`
     </vl-properties>
 `;
 
+const propertiesColumnWithTwoPropertiesTemplate = html`
+    <vl-properties>
+        <div class="column">
+            <vl-property>Woonplaats</vl-property>
+            <vl-property-data>Brussel</vl-property-data>
+            <vl-property>Postcode</vl-property>
+            <vl-property-data>1000</vl-property-data>
+        </div>
+    </vl-properties>
+`;
+
 const propertiesWithPropsTemplate = ({ props = [] }: PropertiesDefaultTypes = {}) => html`
     <vl-properties .props=${props}>
         <vl-property>Woonplaats</vl-property>
@@ -178,6 +189,36 @@ describe('cypress-component - block components - vl-properties', () => {
                         cy.get('dd').should('contain.text', 'Brussel');
                     });
             });
+    });
+
+    it('should have the same spacing between properties inside a column as between columns', () => {
+        cy.mount(propertiesColumnWithTwoPropertiesTemplate);
+
+        cy.get('vl-properties').shadow().find('dl').should('have.css', 'row-gap', '20px');
+        cy.get('vl-properties').shadow().find('.column dt').eq(0).should('have.css', 'margin-top', '0px');
+        cy.get('vl-properties').shadow().find('.column dt').eq(1).should('have.css', 'margin-top', '20px');
+    });
+
+    it('should not add spacing between multiple data values of one property', () => {
+        cy.mount(propertiesWithPropsTemplate({ props: dummyProps }));
+
+        cy.get('vl-properties').shadow().find('.column').find('dd').eq(1).should('have.css', 'margin-top', '0px');
+    });
+
+    it('should use the --vl-properties--row-gap custom property for the spacing between properties', () => {
+        cy.mount(html`
+            <vl-properties style="--vl-properties--row-gap: 4rem">
+                <div class="column">
+                    <vl-property>Woonplaats</vl-property>
+                    <vl-property-data>Brussel</vl-property-data>
+                    <vl-property>Postcode</vl-property>
+                    <vl-property-data>1000</vl-property-data>
+                </div>
+            </vl-properties>
+        `);
+
+        cy.get('vl-properties').shadow().find('dl').should('have.css', 'row-gap', '40px');
+        cy.get('vl-properties').shadow().find('.column dt').eq(1).should('have.css', 'margin-top', '40px');
     });
 
     it("should contain a shadow DOM with dl, dt's and dd's specified through props", () => {

--- a/libs/components/src/block/properties/vl-properties.css.ts
+++ b/libs/components/src/block/properties/vl-properties.css.ts
@@ -1,5 +1,6 @@
 import { vlMediaScreenSmall } from '@domg-wc/styles';
-import { css, CSSResult } from 'lit';
+import { css, CSSResult, unsafeCSS } from 'lit';
+import propertiesRawCss from './vl-properties.raw.css?raw';
 
 const collapsedDt = (): CSSResult => {
     return css`
@@ -11,7 +12,7 @@ const collapsedDd = (): CSSResult => {
     return css`
         font-size: 1.6rem;
         &:has(+ dt) {
-            padding-bottom: 2rem;
+            padding-bottom: var(--vl-properties--row-gap);
         }
     `;
 };
@@ -34,7 +35,7 @@ export const sizeQueryStyles = css`
         dl {
             display: flex;
             flex-direction: column;
-            row-gap: 2rem;
+            row-gap: var(--vl-properties--row-gap);
         }
 
         dl:has(> dt),
@@ -54,6 +55,8 @@ export const sizeQueryStyles = css`
 `;
 
 export const propertiesStyles: CSSResult = css`
+    ${unsafeCSS(propertiesRawCss)}
+
     :host {
         display: block;
     }
@@ -62,7 +65,7 @@ export const propertiesStyles: CSSResult = css`
         display: grid;
         word-break: break-word;
         grid-template-columns: 1fr 1fr;
-        gap: 2rem 0;
+        gap: var(--vl-properties--row-gap) 0;
         padding-bottom: 2rem;
     }
     :host([no-padding-bottom]) {
@@ -100,6 +103,10 @@ export const propertiesStyles: CSSResult = css`
         }
         & > dd {
             grid-column: 2;
+        }
+        & > dd + dt,
+        & > dd + dt + dd {
+            margin-top: var(--vl-properties--row-gap);
         }
     }
 

--- a/libs/components/src/block/properties/vl-properties.raw.css
+++ b/libs/components/src/block/properties/vl-properties.raw.css
@@ -1,0 +1,4 @@
+:host {
+    /* Spacing */
+    --vl-properties--row-gap: 2rem;
+}


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-760

Properties binnen eenzelfde column plakten tegen elkaar: de spacing hing aan de dl en telde daardoor enkel tussen de columns onderling. Een nieuw label krijgt nu dezelfde 2rem, zodat het resultaat gelijk is aan de layout zonder columns. Meerdere data-waardes onder eenzelfde label blijven wel tegen elkaar staan, zoals voordien (opmerking van Kris, gecontroleerd tegen de 2.17.0 release).

De waarde staat in de nieuwe custom property --vl-properties--row-gap (default 2rem), zodat afnemers de spacing van buitenaf kunnen aanpassen. Ze geldt ook voor de layout zonder columns, stacked en onder de small-breakpoint.

De columns-story had maar 1 property per column, waardoor de bug in Storybook niet zichtbaar was; die is uitgebreid naar 2 properties per column.
