### PR TITLE
feat: FLUX-773 - vl-select-rich - itemTemplate voor eigen optie-inhoud

### DIFF
--- a/libs/components/src/form/index.ts
+++ b/libs/components/src/form/index.ts
@@ -7,7 +7,12 @@ export { VlFormMessageComponent } from './form-message';
 export { VlInputFieldMaskedComponent } from './input-field-masked';
 export { VlRadioComponent, VlRadioGroupComponent } from './radio-group';
 export { VlSelectComponent, type SelectOption } from './select';
-export { VlSelectRichComponent, type SelectRichOption, SelectRichPosition } from './select-rich';
+export {
+    VlSelectRichComponent,
+    type SelectRichItemTemplateFn,
+    type SelectRichOption,
+    SelectRichPosition,
+} from './select-rich';
 export { VlTextareaComponent } from './textarea';
 export { VlTextareaRichComponent } from './textarea-rich';
 export { VlUploadComponent } from './upload';

--- a/libs/components/src/form/select-rich/index.ts
+++ b/libs/components/src/form/select-rich/index.ts
@@ -1,5 +1,10 @@
 export { VlSelectRichComponent } from './vl-select-rich.component';
-export { type SelectRichOption, SelectRichPosition, SelectSearchStrategy } from './vl-select-rich.model';
+export {
+    type SelectRichItemTemplateFn,
+    type SelectRichOption,
+    SelectRichPosition,
+    SelectSearchStrategy,
+} from './vl-select-rich.model';
 export {
     type SelectRichSearchMatcher,
     exactAndMatcher,

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-arg.ts
@@ -1,12 +1,19 @@
 import { CATEGORIES, CONTROLS, getSelectControlOptions, TYPES } from '@resources/utils-storybook';
 import { ArgTypes } from '@storybook/web-components-vite';
+import { html, nothing } from 'lit';
 import { formControlArgs, formControlArgTypes } from '../../form-control/stories/form-control.stories-arg';
 import { selectRichDefaults } from '../vl-select-rich.defaults';
-import { SelectRichPosition, SelectSearchStrategy } from '../vl-select-rich.model';
+import {
+    SelectRichItemTemplateFn,
+    SelectRichOption,
+    SelectRichPosition,
+    SelectSearchStrategy,
+} from '../vl-select-rich.model';
 import { action } from 'storybook/actions';
 
 type SelectRichArgs = typeof formControlArgs &
     typeof selectRichDefaults & {
+        itemTemplate: SelectRichItemTemplateFn | undefined;
         onVlChange: () => void;
         onVlInput: () => void;
         onVlSelectSearch: () => void;
@@ -16,11 +23,42 @@ type SelectRichArgs = typeof formControlArgs &
 export const selectRichArgs: SelectRichArgs = {
     ...formControlArgs,
     ...selectRichDefaults,
+    itemTemplate: undefined as SelectRichItemTemplateFn | undefined,
     onVlChange: action('vl-change'),
     onVlInput: action('vl-input'),
     onVlSelectSearch: action('vl-select-search'),
     onVlValid: action('vl-valid'),
 };
+
+export const vestigingOptions: SelectRichOption[] = [
+    {
+        label: '0123.456.789',
+        labelDescription: 'Industrieweg 123, 9876 Plaatsnaam',
+        value: '0123456789',
+        vestiging: 'Vestiging Hasselt',
+    },
+    {
+        label: '0987.654.321',
+        labelDescription: 'Nijverheidsstraat 45, 2300 Turnhout',
+        value: '0987654321',
+        vestiging: 'Vestiging Turnhout',
+    },
+    {
+        label: 'Niet van toepassing',
+        labelDescription: 'Er is geen bijhorende vestiging',
+        value: 'geen-vestiging',
+    },
+] as SelectRichOption[];
+
+export const vestigingItemTemplate: SelectRichItemTemplateFn = (option) => html`
+    <div class="vl-stacked">
+        <vl-text bold>${option.label}</vl-text>
+        ${(option as { vestiging?: string }).vestiging
+            ? html`<vl-text annotation>${(option as { vestiging?: string }).vestiging}</vl-text>`
+            : nothing}
+        <vl-text annotation>${option.labelDescription}</vl-text>
+    </div>
+`;
 
 export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
     ...formControlArgTypes,
@@ -31,6 +69,20 @@ export const selectRichArgTypes: ArgTypes<SelectRichArgs> = {
             type: { summary: TYPES.STRING },
             category: CATEGORIES.ATTRIBUTES,
             defaultValue: { summary: selectRichArgs.placeholder },
+        },
+    },
+    itemTemplate: {
+        name: 'itemTemplate',
+        description:
+            'Bepaalt zelf de inhoud van een optie in de dropdown.<br>Niet reactief en niet aanpasbaar in' +
+            ' Storybook.' +
+            '<br>Zie de [documentatie](/docs/components-form-select-rich--documentatie#itemtemplate)' +
+            ' voor meer info.',
+        control: false,
+        table: {
+            category: CATEGORIES.PROPERTIES,
+            type: { summary: TYPES.FUNCTION },
+            defaultValue: { summary: String(selectRichArgs.itemTemplate) },
         },
     },
     notDeletable: {

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories-doc.mdx
@@ -18,6 +18,7 @@ import FormControlPublicMethods from '../../form-control/stories/form-control.pu
  - [Select opties](#select-opties)
  - [Accessibility](#accessibility)
  - [Varianten](#varianten)
+ - [Eigen inhoud per optie](#eigen-inhoud-per-optie)
  - [Zoek strategieën](#zoek-strategieën)
  - [Validatie](#validatie)
  - [Referenties](#referenties)
@@ -307,6 +308,62 @@ Indien de 'required' boolean op true staat, moet je een value programmatorisch s
         { label: 'Rio Piedras', value: 'rio piedras', disabled: true }
 ]`} language="ts" dark={true} />
 </details>
+
+
+## Eigen inhoud per optie
+
+Een optie toont standaard haar `label` als platte tekst op een regel. Voor rijkere opties zijn er twee
+mogelijkheden.
+
+### Beschrijving bij een optie
+
+Voor een titel met een regel eronder volstaat `labelDescription`. De component zet die in een
+`vl-select__option-subtitle` en legt de `aria-describedby` koppeling met het label.
+
+<Canvas of={VlSelectRichStories.SelectRichOptionDescription} />
+
+<details>
+    <summary>options</summary>
+    <Source code={`
+    [
+        {
+            label: '0123.456.789',
+            labelDescription: 'Industrieweg 123, 9876 Plaatsnaam',
+            value: '0123456789',
+        },
+        {
+            label: 'Niet van toepassing',
+            labelDescription: 'Er is geen bijhorende vestiging',
+            value: 'geen-vestiging',
+        }
+]`} language="ts" dark={true} />
+</details>
+
+### itemTemplate
+
+Volstaat `labelDescription` niet, dan stel je de `itemTemplate`-property in. Die functie krijgt de optie
+mee en geeft een lit `TemplateResult` terug, die de inhoud van de optie in de dropdown wordt. De optie
+zelf (rol, klik-afhandeling, data-attributen) blijft in beheer van de component. Eens gekozen toont het
+gesloten veld het `label`, zodat het compact blijft.
+
+```ts
+const itemTemplate = (option) => html`
+    <div class="vl-stacked">
+        <vl-text bold>${option.label}</vl-text>
+        <vl-text annotation>${option.vestiging}</vl-text>
+        <vl-text annotation>${option.labelDescription}</vl-text>
+    </div>
+`;
+
+html`<vl-select-rich .options=${options} .itemTemplate=${itemTemplate}></vl-select-rich>`;
+```
+
+> Zet geen links of knoppen in de template, handel zulke acties af via het `vl-change`-event. Een
+> [`option`](https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational) verbergt zijn kinderen voor
+> hulptechnologie ([4.1.2](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)) en het toetsenbord
+> ([2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)).
+
+<Canvas of={VlSelectRichStories.SelectRichItemTemplate} />
 
 
 ## Zoek strategieën

--- a/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
+++ b/libs/components/src/form/select-rich/stories/vl-select-rich.stories.ts
@@ -1,5 +1,10 @@
 import { story } from '@resources/utils-storybook';
-import { selectRichArgs, selectRichArgTypes } from './vl-select-rich.stories-arg';
+import {
+    selectRichArgs,
+    selectRichArgTypes,
+    vestigingItemTemplate,
+    vestigingOptions,
+} from './vl-select-rich.stories-arg';
 import { Meta } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import selectRichDocs from './vl-select-rich.stories-doc.mdx';
@@ -168,6 +173,29 @@ SelectRichNotDeletable.args = {
         { label: 'Rio Piedras', value: 'rio piedras' },
     ],
 };
+
+export const SelectRichOptionDescription = SelectRichTemplate.bind({});
+SelectRichOptionDescription.storyName = 'vl-select-rich - option description';
+SelectRichOptionDescription.args = {
+    id: 'vestigingsnummer',
+    name: 'vestigingsnummer',
+    placeholder: 'Selecteer een optie',
+    options: vestigingOptions,
+};
+
+export const SelectRichItemTemplate = story(
+    selectRichArgs,
+    () =>
+        html`<vl-select-rich
+            id="vestigingsnummer"
+            name="vestigingsnummer"
+            label="vestigingsnummer"
+            placeholder="Selecteer een optie"
+            .options=${vestigingOptions}
+            .itemTemplate=${vestigingItemTemplate}
+        ></vl-select-rich>`
+);
+SelectRichItemTemplate.storyName = 'vl-select-rich - item template';
 
 export const SelectRichGroups = SelectRichTemplate.bind({});
 SelectRichGroups.storyName = 'vl-select-rich - groups';

--- a/libs/components/src/form/select-rich/vl-select-rich.component.css.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.css.ts
@@ -601,4 +601,35 @@ export const vlSelectRichComponentStyles: CSSResult = css`
         line-height: 1;
         font-weight: bold;
     }
+
+    .js-vl-select .vl-select__list--dropdown .vl-select__item:has(.vl-select__option-subtitle),
+    .js-vl-select .vl-select__list--dropdown .vl-select__item--rich {
+        display: block;
+        height: auto;
+        min-height: calc(3.5rem - 1.2rem);
+    }
+
+    .js-vl-select .vl-select__list--dropdown .vl-select__item:has(.vl-select__option-subtitle) span,
+    .js-vl-select .vl-select__list--dropdown .vl-select__item--rich span {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
+    .js-vl-select[data-type*='select-one']
+        .vl-select__list--dropdown
+        .vl-select__item--selectable:has(.vl-select__option-subtitle),
+    .js-vl-select[data-type*='select-one']
+        .vl-select__list--dropdown
+        .vl-select__item--selectable.vl-select__item--rich {
+        height: auto;
+    }
+
+    .js-vl-select .vl-select__option-subtitle {
+        display: block;
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+        color: var(--vl-color--text-subtle);
+    }
 `;

--- a/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.cy.ts
@@ -1,7 +1,7 @@
 import { registerWebComponents } from '@domg-wc/common';
 import { html } from 'lit';
 import { parseFormData } from '../utils';
-import { SelectRichOption } from './index';
+import { SelectRichItemTemplateFn, SelectRichOption } from './index';
 import { VlSelectRichComponent } from './vl-select-rich.component';
 import { VlFormMessageComponent } from '../form-message/vl-form-message.component';
 
@@ -2308,5 +2308,285 @@ describe('cypress-component - form components - vl-select-rich - blur-validation
         cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
         cy.get('vl-select-rich').shadow().find('.vl-select__list .vl-select__item').first().click();
         cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
+    });
+});
+
+describe('cypress-component - form components - vl-select-rich - option description', () => {
+    const options: SelectRichOption[] = [
+        { label: '0123.456.789', labelDescription: 'Industrieweg 123, 9876 Plaatsnaam', value: '0123456789' },
+        { label: '0987.654.321', labelDescription: 'Nijverheidsstraat 45, 2300 Turnhout', value: '0987654321' },
+        { label: 'Niet van toepassing', labelDescription: 'Er is geen bijhorende vestiging', value: 'geen-vestiging' },
+    ];
+
+    beforeEach(() => {
+        cy.viewport(1200, 800);
+    });
+
+    it('should render the description of an option in the dropdown', () => {
+        cy.mount(html`
+            <div class="snapshot-wrapper" style="width: 400px; height: 420px; padding: 20px; background: white;">
+                <vl-select-rich
+                    label="vestigingsnummer"
+                    placeholder="Selecteer een optie"
+                    .options=${options}
+                ></vl-select-rich>
+            </div>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .find('.vl-select__option-subtitle')
+            .should('have.text', 'Industrieweg 123, 9876 Plaatsnaam');
+
+        cy.checkA11y('vl-select-rich');
+        cy.document().then((doc) => doc.fonts.ready);
+        cy.wait(100);
+        cy.get('.snapshot-wrapper').matchImageSnapshot('select-rich-option-description');
+    });
+
+    it('should link the description to the option with aria-describedby', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="vestigingsnummer"
+                placeholder="Selecteer een optie"
+                .options=${options}
+            ></vl-select-rich>`
+        );
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .then(($item) => {
+                const describedBy = $item.attr('aria-describedby');
+                expect(describedBy).to.match(/\S/);
+                cy.get('vl-select-rich')
+                    .shadow()
+                    .find(`#${describedBy}`)
+                    .should('have.text', 'Industrieweg 123, 9876 Plaatsnaam');
+            });
+    });
+});
+
+describe('cypress-component - form components - vl-select-rich - item template', () => {
+    const options: SelectRichOption[] = [
+        {
+            label: '0123.456.789',
+            labelDescription: 'Industrieweg 123, 9876 Plaatsnaam',
+            value: '0123456789',
+            vestiging: 'Vestiging Hasselt',
+        },
+        {
+            label: '0987.654.321',
+            labelDescription: 'Nijverheidsstraat 45, 2300 Turnhout',
+            value: '0987654321',
+            vestiging: 'Vestiging Turnhout',
+        },
+        {
+            label: 'Niet van toepassing',
+            labelDescription: 'Er is geen bijhorende vestiging',
+            value: 'geen-vestiging',
+        },
+    ] as SelectRichOption[];
+
+    const itemTemplate: SelectRichItemTemplateFn = (option) => html`
+        <div class="vl-stacked">
+            <vl-text bold>${option.label}</vl-text>
+            ${(option as { vestiging?: string }).vestiging
+                ? html`<vl-text annotation>${(option as { vestiging?: string }).vestiging}</vl-text>`
+                : ''}
+            <vl-text annotation>${option.labelDescription}</vl-text>
+        </div>
+    `;
+
+    beforeEach(() => {
+        cy.viewport(1200, 800);
+    });
+
+    it('should render the item template in the dropdown', () => {
+        cy.mount(html`
+            <div class="snapshot-wrapper" style="width: 400px; height: 420px; padding: 20px; background: white;">
+                <vl-select-rich
+                    label="vestigingsnummer"
+                    placeholder="Selecteer een optie"
+                    .options=${options}
+                    .itemTemplate=${itemTemplate}
+                ></vl-select-rich>
+            </div>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .find('vl-text[bold]')
+            .should('have.text', '0123.456.789');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .find('vl-text[annotation]')
+            .should('have.length', 2);
+
+        cy.checkA11y('vl-select-rich');
+        cy.document().then((doc) => doc.fonts.ready);
+        cy.wait(100);
+        cy.get('.snapshot-wrapper').matchImageSnapshot('select-rich-item-template-dropdown');
+    });
+
+    it('should render a template built with vl-text and vl-stacked', () => {
+        const vlTextTemplate: SelectRichItemTemplateFn = (option) => html`
+            <div class="vl-stacked">
+                <vl-text bold>${option.label}</vl-text>
+                <vl-text annotation>${option.labelDescription}</vl-text>
+            </div>
+        `;
+
+        cy.mount(html`
+            <div class="snapshot-wrapper" style="width: 400px; height: 420px; padding: 20px; background: white;">
+                <vl-select-rich
+                    label="vestigingsnummer"
+                    placeholder="Selecteer een optie"
+                    .options=${options}
+                    .itemTemplate=${vlTextTemplate}
+                ></vl-select-rich>
+            </div>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .find('vl-text')
+            .should('have.length', 2);
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item vl-text[bold]')
+            .first()
+            .should('have.text', '0123.456.789')
+            .shadow()
+            .find('span.vl-text--bold')
+            .should('exist');
+
+        cy.checkA11y('vl-select-rich');
+        cy.document().then((doc) => doc.fonts.ready);
+        cy.wait(100);
+        cy.get('.snapshot-wrapper').matchImageSnapshot('select-rich-item-template-vl-text');
+    });
+
+    it('should keep the data attributes of choices.js on the option', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="vestigingsnummer"
+                placeholder="Selecteer een optie"
+                .options=${options}
+                .itemTemplate=${itemTemplate}
+            ></vl-select-rich>`
+        );
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .first()
+            .should('have.attr', 'data-value', '0123456789')
+            .and('have.attr', 'role', 'option')
+            .and('have.class', 'vl-select__item--selectable');
+    });
+
+    it('should not apply the item template to the selected option', () => {
+        cy.mount(html`
+            <div class="snapshot-wrapper" style="width: 400px; padding: 20px; background: white;">
+                <vl-select-rich
+                    label="vestigingsnummer"
+                    placeholder="Selecteer een optie"
+                    .options=${options}
+                    .itemTemplate=${itemTemplate}
+                ></vl-select-rich>
+            </div>
+        `);
+        cy.injectAxe();
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich').shadow().find('.vl-select__list--dropdown .vl-select__item').first().click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__inner .vl-input-field .vl-select__item')
+            .should('contain.text', '0123.456.789')
+            .find('vl-text')
+            .should('not.exist');
+
+        cy.checkA11y('vl-select-rich');
+        cy.document().then((doc) => doc.fonts.ready);
+        cy.wait(100);
+        cy.get('.snapshot-wrapper').matchImageSnapshot('select-rich-item-template-selected');
+    });
+
+    it('should use the plain text label in the aria-label of the remove button', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="vestigingsnummer"
+                placeholder="Selecteer een optie"
+                .options=${options}
+                .itemTemplate=${itemTemplate}
+            ></vl-select-rich>`
+        );
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich').shadow().find('.vl-select__list--dropdown .vl-select__item').first().click();
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__inner .vl-input-field .vl-select__item .vl-pill__close')
+            .should('have.attr', 'aria-label', 'verwijder 0123.456.789');
+    });
+
+    it('should keep searching on the plain text label', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="vestigingsnummer"
+                placeholder="Selecteer een optie"
+                search
+                search-strategy="exact-and"
+                result-limit="20"
+                .options=${options}
+                .itemTemplate=${itemTemplate}
+            ></vl-select-rich>`
+        );
+
+        cy.get('vl-select-rich').shadow().find('.vl-select__inner').click();
+        cy.get('vl-select-rich').shadow().find('input').type('0987.654.321');
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__list--dropdown .vl-select__item')
+            .should('have.length', 1)
+            .find('vl-text[bold]')
+            .should('have.text', '0987.654.321');
+    });
+
+    it('should not apply the item template to the placeholder', () => {
+        cy.mount(
+            html`<vl-select-rich
+                label="vestigingsnummer"
+                placeholder="Selecteer een optie"
+                .options=${options}
+                .itemTemplate=${itemTemplate}
+            ></vl-select-rich>`
+        );
+
+        cy.get('vl-select-rich')
+            .shadow()
+            .find('.vl-select__inner .vl-select__placeholder')
+            .should('contain.text', 'Selecteer een optie')
+            .find('vl-text[bold]')
+            .should('not.exist');
     });
 });

--- a/libs/components/src/form/select-rich/vl-select-rich.component.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.component.ts
@@ -1,26 +1,34 @@
-import { webComponent } from '@domg-wc/common';
-import { vlResetStyles } from '@domg-wc/styles';
+import { registerWebComponents, webComponent } from '@domg-wc/common';
+import { VlTextComponent } from '@domg-wc/components/atom';
+import { vlGroupStyles, vlResetStyles, vlStackedStyles } from '@domg-wc/styles';
 import { FormValue } from '@open-wc/form-control/src/types';
 import Choices, { Options } from 'choices.js';
-import { CSSResult, html, nothing, PropertyDeclarations, TemplateResult } from 'lit';
+import { ChoiceFull } from 'choices.js/src/scripts/interfaces/choice-full';
+import { CSSResult, html, nothing, PropertyDeclarations, render, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { vlIconStyles } from '../../atom/icon-style/vl-icon-style.css';
 import { FormControl } from '../form-control';
 import { vlSelectRichComponentStyles } from './vl-select-rich.component.css';
 import { selectRichDefaults } from './vl-select-rich.defaults';
-import { SelectRichOption } from './vl-select-rich.model';
+import { SelectRichItemTemplateFn, SelectRichOption } from './vl-select-rich.model';
 import { getSearchMatcher, SelectRichSearchMatcher } from './vl-select-rich.search-matchers';
 
 @webComponent('vl-select-rich')
 export class VlSelectRichComponent extends FormControl {
+    static {
+        registerWebComponents([VlTextComponent]);
+    }
+
     // Properties
     options = selectRichDefaults.options;
     initialOptions = selectRichDefaults.initialOptions;
+    itemTemplate?: SelectRichItemTemplateFn;
     protected placeholder = selectRichDefaults.placeholder;
     protected search = selectRichDefaults.search;
     protected searchPlaceholder = selectRichDefaults.searchPlaceholder;
     // Variables
     protected choices: Choices | null = null;
+    private optionsByValue = new Map<string, SelectRichOption>();
     // Attributes
     private notDeletable = selectRichDefaults.notDeletable;
     private multiple = selectRichDefaults.multiple;
@@ -45,7 +53,7 @@ export class VlSelectRichComponent extends FormControl {
     }
 
     static get styles(): CSSResult[] {
-        return [vlResetStyles, vlIconStyles, vlSelectRichComponentStyles];
+        return [vlResetStyles, vlIconStyles, vlGroupStyles, vlStackedStyles, vlSelectRichComponentStyles];
     }
 
     static get properties(): PropertyDeclarations {
@@ -63,6 +71,7 @@ export class VlSelectRichComponent extends FormControl {
                 },
             },
             placeholder: { type: String },
+            itemTemplate: { attribute: false },
             notDeletable: { type: Boolean, attribute: 'not-deletable' },
             multiple: { type: Boolean },
             search: { type: Boolean },
@@ -93,6 +102,7 @@ export class VlSelectRichComponent extends FormControl {
         super.connectedCallback();
 
         if (this.initialised) {
+            this.indexOptions();
             this.choices = new Choices(this.validationTarget!, this.getChoicesConfig());
             this.initialOptions = structuredClone(this.options);
         }
@@ -103,6 +113,7 @@ export class VlSelectRichComponent extends FormControl {
     async firstUpdated(changedProperties: Map<string, unknown>) {
         super.firstUpdated(changedProperties);
 
+        this.indexOptions();
         this.choices = new Choices(this.validationTarget!, this.getChoicesConfig());
         this.initialOptions = structuredClone(this.options);
     }
@@ -149,6 +160,7 @@ export class VlSelectRichComponent extends FormControl {
         }
 
         if (changedProperties.has('options')) {
+            this.indexOptions();
             if (this.choices.initialised) {
                 this.choices.clearStore();
                 this.choices.setChoices(this.options, 'value', 'label', true);
@@ -395,6 +407,21 @@ export class VlSelectRichComponent extends FormControl {
             : null;
     }
 
+    private indexOptions(): void {
+        this.optionsByValue = new Map(
+            this.options
+                .flatMap((option) => (option.choices?.length ? (option.choices as SelectRichOption[]) : [option]))
+                .map((option) => [String(option.value), option])
+        );
+    }
+
+    private renderItemTemplate(itemElement: HTMLElement, contentHost: HTMLElement, data: SelectRichOption): void {
+        const original = this.optionsByValue.get(String(data.value));
+        itemElement.classList.add('vl-select__item--rich');
+        contentHost.replaceChildren();
+        render(this.itemTemplate!(original ? { ...original, ...data } : data), contentHost);
+    }
+
     private getChoicesElement(): HTMLElement | null {
         return this.shadowRoot?.querySelector('.js-vl-select') as HTMLElement | null;
     }
@@ -432,8 +459,9 @@ export class VlSelectRichComponent extends FormControl {
                 group: 'vl-select__group',
                 groupHeading: 'vl-select__heading',
                 button: 'vl-select__button',
+                description: 'vl-select__option-subtitle',
             },
-            callbackOnCreateTemplates: (template) => {
+            callbackOnCreateTemplates: (template, escapeForTemplate) => {
                 return {
                     containerOuter: () => {
                         return template(
@@ -457,8 +485,9 @@ export class VlSelectRichComponent extends FormControl {
                     },
                     item: (_config: Partial<Options>, data: SelectRichOption) => {
                         const isPlaceholder = data.placeholder === true;
+                        const label = escapeForTemplate(false, data.label ?? '');
                         if (this.notDeletable) {
-                            return template(`
+                            const notDeletableElement = template(`
                             <div class="vl-select__item
                                 ${data.highlighted ? 'is-highlighted' : 'vl-select__item--selectable'}
                                 ${this.multiple ? 'vl-pill' : ''}
@@ -469,12 +498,14 @@ export class VlSelectRichComponent extends FormControl {
                                 data-value="${data.value}"
                                 ${data.disabled ? 'aria-disabled="true"' : ''}
                             >
-                                ${data.label}
+                                ${label}
                             </div>
                         `) as HTMLDivElement;
+
+                            return notDeletableElement;
                         }
 
-                        return template(
+                        const element = template(
                             `<div class="
                                     vl-select__item
                                     ${data.highlighted ? 'is-highlighted' : ''}
@@ -487,12 +518,12 @@ export class VlSelectRichComponent extends FormControl {
                                             ${isPlaceholder ? 'role="option"' : ''}
                                     ${data.disabled ? 'aria-disabled="true"' : 'data-deletable'}
                                 >
-                                    <span>${data.label}</span>
+                                    <span>${label}</span>
                                     <button type="button"
                                     ${isPlaceholder ? '' : 'role="option"'}
                                      class="vl-pill__close ${
                                          !this.multiple ? 'vl-icon vl-icon--close' : ''
-                                     }" data-button aria-label="verwijder ${data.label}">
+                                     }" data-button aria-label="verwijder ${label}">
                                         ${
                                             this.multiple
                                                 ? `<span class="vl-pill__close__icon vl-icon vl-icon--close" aria-hidden="true"></span>`
@@ -501,6 +532,27 @@ export class VlSelectRichComponent extends FormControl {
                                     </button>
                                 </div>`
                         ) as HTMLDivElement;
+
+                        return element;
+                    },
+                    choice: (
+                        config: Partial<Options>,
+                        data: ChoiceFull,
+                        selectText: string,
+                        groupName?: string
+                    ) => {
+                        const element = Choices.defaults.templates.choice(
+                            config as Parameters<typeof Choices.defaults.templates.choice>[0],
+                            data,
+                            selectText,
+                            groupName
+                        );
+
+                        if (this.itemTemplate && !data.placeholder) {
+                            this.renderItemTemplate(element, element, data);
+                        }
+
+                        return element;
                     },
                     itemList: () =>
                         template(

--- a/libs/components/src/form/select-rich/vl-select-rich.model.ts
+++ b/libs/components/src/form/select-rich/vl-select-rich.model.ts
@@ -1,11 +1,16 @@
 import { InputChoice } from 'choices.js/src/scripts/interfaces/input-choice';
 import { InputGroup } from 'choices.js/src/scripts/interfaces/input-group';
+import { TemplateResult } from 'lit';
 
 type MergeToOptional<T, U> = Pick<T, Extract<keyof T, keyof U>> & // gedeelde velden blijven required
     Partial<Omit<T, keyof U>> & // velden enkel in T (optioneel)
     Partial<Omit<U, keyof T>>; // velden enkel in U (optioneel)
 
 export type SelectRichOption = MergeToOptional<InputChoice, InputGroup>;
+
+export interface SelectRichItemTemplateFn {
+    (option: SelectRichOption): TemplateResult;
+}
 
 export const SelectRichPosition = {
     AUTO: 'auto',


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-773

Met de itemTemplate-property bepaal je zelf de inhoud van een optie, voor de gevallen waarin een plat label niet volstaat. De functie krijgt de optie mee en geeft een lit TemplateResult terug, die zowel in de dropdown als in het geselecteerde item gerenderd wordt. Naam en vorm gelijk aan die van vl-autocomplete.

Het label blijft platte tekst, zodat zoeken, de aria-label van de verwijderknop en de onderliggende option correct blijven. Het label van een geselecteerde optie wordt nu wel geescaped; voordien belandde het ongefilterd in de template-string.

labelDescription en labelClass werkten al via choices.js maar waren ongedocumenteerd en ongestyled, en zijn dat nu niet meer.