### PR TITLE
docs: FLUX-779 - vl-header-next / vl-footer-next - plaatsing t.o.v. vl-template gedocumenteerd

### DIFF
--- a/libs/components/src/block/template/stories/vl-template.stories.ts
+++ b/libs/components/src/block/template/stories/vl-template.stories.ts
@@ -4,9 +4,10 @@ import { html } from 'lit';
 import { VlContentHeaderComponent } from '../../content-header/vl-content-header.component';
 import '../vl-template.component';
 import { VlTitleComponent } from '../../../atom/title';
+import { VlFooter, VlHeader } from '../../../compliance/next';
 import { templateArgs, templateArgTypes } from './vl-template.stories-arg';
 
-registerWebComponents([VlContentHeaderComponent, VlTitleComponent]);
+registerWebComponents([VlContentHeaderComponent, VlTitleComponent, VlHeader, VlFooter]);
 
 export default {
     id: 'components-block-template',
@@ -54,11 +55,11 @@ const bodySimulation = (component: any, withClass: boolean) => html` <div class=
 export const templateDefault = ({ center, stretch }: typeof templateArgs) =>
     bodySimulation(
         html`
+            <vl-header-next identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb" development simple></vl-header-next>
             <vl-template ?v-center=${center} ?v-stretch=${stretch}>
-                <vl-header slot="header" identifier="59188ff6-662b-45b9-b23a-964ad48c2bfb" development></vl-header>
                 <div slot="main">${mainHtml}</div>
-                <vl-footer slot="footer" identifier="0337f8dc-3266-4e7a-8f4a-95fd65189e5b" development></vl-footer>
             </vl-template>
+            <vl-footer-next identifier="0337f8dc-3266-4e7a-8f4a-95fd65189e5b" development></vl-footer-next>
         `,
         true
     );

--- a/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
+++ b/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
@@ -39,6 +39,24 @@ import { VlFooter } from '@domg-wc/components/compliance/next';
 <FluxCanvasIframe height="166"/>
 
 
+## Plaatsing
+
+`vl-footer-next` rendert niets op de plaats van de tag zelf: de widget wordt altijd onderaan in het
+`<body>` element geïnjecteerd. De tag stuurt enkel de injectie en de configuratie aan.
+
+Plaats de tag daarom als sibling van `<vl-template>`, niet in de `footer` slot. Een plaatsing in de
+slot breekt technisch niets (de injectie gebeurt sowieso in `<body>`), maar zet een leeg element in
+de slot en wekt onterecht de indruk dat de footer binnen de template rendert.
+
+```html
+<vl-header-next identifier="..."></vl-header-next>
+<vl-template>
+    <div slot="main">...</div>
+</vl-template>
+<vl-footer-next identifier="..."></vl-footer-next>
+```
+
+
 ## Configuratie
 
 <ArgTypes of={VlFooterStories.FooterDefault}/>

--- a/libs/components/src/compliance/next/header/stories/vl-header.stories-doc.mdx
+++ b/libs/components/src/compliance/next/header/stories/vl-header.stories-doc.mdx
@@ -41,6 +41,24 @@ import { VlHeader } from '@domg-wc/components/compliance/next';
 <FluxCanvasIframe height="63" />
 
 
+## Plaatsing
+
+`vl-header-next` rendert niets op de plaats van de tag zelf: de widget wordt altijd bovenaan in het
+`<body>` element geïnjecteerd. De tag stuurt enkel de injectie en de configuratie aan.
+
+Plaats de tag daarom als sibling van `<vl-template>`, niet in de `header` slot. Een plaatsing in de
+slot breekt technisch niets (de injectie gebeurt sowieso in `<body>`), maar zet een leeg element in
+de slot en wekt onterecht de indruk dat de header binnen de template rendert.
+
+```html
+<vl-header-next identifier="..."></vl-header-next>
+<vl-template>
+    <div slot="main">...</div>
+</vl-template>
+<vl-footer-next identifier="..."></vl-footer-next>
+```
+
+
 ## Configuratie
 
 <ArgTypes of={VlHeaderStories.HeaderDefault} />


### PR DESCRIPTION
## FLUX-779

[Jira ticket](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-779)

### Wat

- `vl-header-next` en `vl-footer-next` documentatie: nieuwe sectie "Plaatsing" die uitlegt dat de tag als sibling van `vl-template` hoort, niet in de `header`/`footer` slot, met voorbeeld.
- `vl-template` story: gemoderniseerd van de oude `vl-header`/`vl-footer` in slots naar de next-componenten als siblings.

### Waarom

De next-componenten (net als de oude generatie) renderen niets op de plaats van de tag: de widget wordt in `body` geïnjecteerd (header vooraan, footer achteraan). Een slot-plaatsing breekt technisch niets, maar zet een leeg element in de slot en suggereert rendering binnen de template die er niet is. Sibling-plaatsing is het patroon van de MJV-referentie-implementatie en wordt nu expliciet gedocumenteerd. De eigen `vl-template` story toonde nog het misleidende slot-patroon.

### Verificatie

- Storybook lokaal: beide docs-pagina's tonen de sectie, template story rendert met `#header__container` bovenaan en `#footer__container` onderaan `body`, next-elementen zelf leeg zoals verwacht.
- Widget-mount zelf faalt lokaal met een 400 op de tni-identifiers; dit staat los van deze change en speelt ook in de bestaande next-stories.