### PR TITLE
fix: FLUX-783 - vulnerabilities - package verhoging via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,9 +1941,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.8",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.23.8.tgz",
-            "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+            "version": "7.26.10",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.26.10.tgz",
+            "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+            "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -27322,9 +27323,10 @@
             }
         },
         "node_modules/validator": {
-            "version": "13.11.0",
-            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/validator/-/validator-13.11.0.tgz",
-            "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+            "version": "13.15.35",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/validator/-/validator-13.15.35.tgz",
+            "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,9 @@
     "overrides": {
         "color-parse": {
             "color-name": "2.0.0"
-        }
+        },
+        "validator": "13.15.35",
+        "@babel/runtime": "7.26.10"
     },
     "volta": {
         "node": "22.20.0"


### PR DESCRIPTION
Trivy meldde vulnerabilities op twee transitieve dependencies uit de package-lock.json:
- validator 13.11.0 -> 13.15.35 (via z-schema)
- @babel/runtime 7.23.8 -> 7.26.10 (via i18next, @testing-library/dom, fetch-mock)

Beide zijn geen directe dependencies, dus ze worden afgedwongen via overrides in de package.json - dezelfde aanpak als de bestaande color-parse/color-name override.