### PR TITLE
fix: FLUX-789 - ChunkLoadError in de Cypress component testen

### DIFF
--- a/resources/cypress-component/cypress.config.ts
+++ b/resources/cypress-component/cypress.config.ts
@@ -15,10 +15,19 @@ const cypressConfig = defineConfig({
         // @ts-ignore: Ignoring missing property 'framework'
         devServer: {
             bundler: 'webpack',
-            headers: {
-                'Cache-Control': 'no-store',
-            },
             webpackConfig: {
+                devServer: {
+                    // Tegen de sporadische "An uncaught error was detected outside of a test" / ChunkLoadError in
+                    // Jenkins (zie https://github.com/cypress-io/cypress/issues/28644). De Cypress-proxy stuurt de
+                    // chunk-requests (/__cypress/src/*) door naar de webpack-dev-server over keep-alive connecties
+                    // die ze zelf nooit sluit en niet opnieuw probeert bij een fout; de Node http-server van
+                    // webpack-dev-server sluit idle connecties standaard na 5s. Valt een request precies in dat
+                    // venster, dan faalt hij (ECONNRESET) en laadt de spec niet. keepAliveTimeout 0 = idle
+                    // connecties nooit sluiten; ze verdwijnen pas wanneer de dev-server stopt.
+                    onListening: (devServer) => {
+                        devServer.server.keepAliveTimeout = 0;
+                    },
+                },
                 module: {
                     rules: [
                         {

--- a/resources/docs-internal/nuttige-commandos.md
+++ b/resources/docs-internal/nuttige-commandos.md
@@ -74,12 +74,12 @@ git notes --ref semantic-release show 2231b72
 
 na een historiek herschrijving een tag opnieuw leggen + de notes toevoegen 
 ```
-git push --delete origin v1.37.0-develop.1
-git tag -d v1.37.0-develop.1
-git tag v1.37.0-develop.1 ce31ccb2
+git push --delete origin v1.50.0-develop-v1.1
+git tag -d v1.50.0-develop-v1.1
+git tag v1.50.0-develop-v1.1 ce31ccb2
 git push origin v1.37.0-develop.1
 
-git notes --ref semantic-release add -f -m '{"channels":["develop"]}' v1.37.0-develop.1
+git notes --ref semantic-release add -f -m '{"channels":["develop-v1"]}' v1.49.9
 git push --force origin refs/notes/semantic-release
 ```
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
         "baseUrl": ".",
         "outDir": "./build/tmp",
         "rootDirs": ["./libs", "./apps", "./resources"],
-        "types": ["cypress", "cypress-axe"],
+        "types": ["cypress", "cypress-axe", "node"],
         "paths": {
             "@domg-wc/common-storybook": ["libs/common/storybook/src/index.ts"],
             "@domg-wc/common-utilities": ["libs/common/utilities/src/index.ts"],


### PR DESCRIPTION
De component-test shards in Jenkins faalden af en toe met "An uncaught error was detected outside of a test" / ChunkLoadError bij het inladen van een (telkens andere) shared chunk via /__cypress/src/*. De Cypress-proxy stuurt die requests over keep-alive connecties naar de webpack-dev-server, zonder idle timeout en zonder retry; de Node http-server van webpack-dev-server sluit idle connecties na 5s. Met keepAliveTimeout 0 (via webpackConfig.devServer.onListening) sluit de dev-server ze niet meer. Zie cypress-io/cypress#28644.

De eerdere 'headers: Cache-Control no-store' stond op het verkeerde niveau (Cypress devServer-opties i.p.v. webpackConfig.devServer), werd genegeerd en gaf enkel een TS2353 in de webpack-output; verwijderd.

Daarnaast @types/node toegevoegd aan tsconfig.base.json: haalt de TS2591 ('process'/'require') en TS2307 ('path') meldingen van ts-loader uit de webpack-output van de component testen en storybook. Type-check van alle libs/apps/resources voor en na vergeleken: geen nieuwe fouten.