### PR TITLE
fix: FLUX-788 - vl-header-next / vl-footer-next - flaky testen en ready-event

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -47,7 +47,7 @@ const cleanupDecorator: Decorator = (Story) => {
             .querySelectorAll(
                 `
                     body > #header__container,
-                    body > #header__container__skeleton,
+                    body > #header__skeleton,
                     body > #footer__container
                 `
             )

--- a/libs/components/src/compliance/header/vl-header.component.ts
+++ b/libs/components/src/compliance/header/vl-header.component.ts
@@ -85,7 +85,7 @@ export class VlHeader extends BaseLitElement {
     }
 
     private get headerContainerSkeleton(): Element | null {
-        return document.querySelector('#header__container__skeleton');
+        return document.querySelector('#header__skeleton');
     }
 
     connectedCallback() {

--- a/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
+++ b/libs/components/src/compliance/next/footer/stories/vl-footer.stories-doc.mdx
@@ -44,6 +44,26 @@ import { VlFooter } from '@domg-wc/components/compliance/next';
 <ArgTypes of={VlFooterStories.FooterDefault}/>
 
 
+## Ready event
+
+De component vuurt het `ready` event af zodra de global footer widget in de DOM gemount is.
+
+Het event wordt afgevuurd **op het `<vl-footer-next>` element zelf**. Het bubbelt niet en gaat niet door shadow
+boundaries, dus registreer de listener op het element:
+
+```js
+document.querySelector('vl-footer-next').addEventListener('ready', () => {
+    // de widget staat in de DOM
+});
+```
+
+In een lit-template:
+
+```js
+html`<vl-footer-next identifier="..." @ready=${onReady}></vl-footer-next>`;
+```
+
+
 ## Sticky footer bar
 
 In collapsible modus toont de widget een `position: fixed` bar onderaan de pagina. Zonder

--- a/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.cy.ts
@@ -94,14 +94,9 @@ describe('cypress-component - compliance components - vl-footer-next - propertie
 
 describe('cypress-component - compliance components - vl-footer-next - events', () => {
     it('should emit ready event', () => {
-        // De component luistert op window naar het mounted-event van de widget en vuurt van daaruit 'ready' af.
-        // Die handler is niet gebonden, dus de dispatcher is window - vandaar de listener op window en niet op het
-        // element. Hij moet geregistreerd zijn voor er gemount wordt, want het event volgt meteen op het script.
-        cy.window().then((win) => {
-            win.addEventListener('ready', cy.stub().as('ready'));
-        });
-
-        mountDefault({ ...props, development: true });
+        // mountDefault hangt de listener via @ready op het element zelf;
+        // de component vuurt 'ready' af zodra de widget gemount is
+        mountDefault({ ...props, development: true, onReady: cy.stub().as('ready') });
 
         cy.get('@ready').should('have.been.calledOnce');
     });

--- a/libs/components/src/compliance/next/footer/vl-footer.component.ts
+++ b/libs/components/src/compliance/next/footer/vl-footer.component.ts
@@ -56,9 +56,13 @@ export class VlFooter extends BaseLitElement {
         );
     }
 
-    private onReady() {
+    // class field met pijlfunctie, geen methode !
+    // -> window.addEventListener krijgt hier enkel een functiereferentie mee
+    // -> als gewone methode is 'this' bij het afvuren het window, en dan komt het ready-event op window
+    //    terecht in plaats van op de component - afnemers die op het element luisteren zien het dan nooit
+    private onReady = () => {
         this.dispatchEvent(new CustomEvent('ready'));
-    }
+    };
 
     private async loadWidget() {
         try {

--- a/libs/components/src/compliance/next/header/stories/vl-header.stories-doc.mdx
+++ b/libs/components/src/compliance/next/header/stories/vl-header.stories-doc.mdx
@@ -45,6 +45,26 @@ import { VlHeader } from '@domg-wc/components/compliance/next';
 
 <ArgTypes of={VlHeaderStories.HeaderDefault} />
 
+## Ready event
+
+De component vuurt het `ready` event af zodra de global header widget in de DOM gemount is. Vanaf dat moment is de
+widget-inhoud beschikbaar en levert `height` de effectieve hoogte van de header op.
+
+Het event wordt afgevuurd **op het `<vl-header-next>` element zelf**. Het bubbelt niet en gaat niet door shadow
+boundaries, dus registreer de listener op het element:
+
+```js
+document.querySelector('vl-header-next').addEventListener('ready', () => {
+    // de widget staat in de DOM
+});
+```
+
+In een lit-template:
+
+```js
+html`<vl-header-next identifier="..." @ready=${onReady}></vl-header-next>`;
+```
+
 
 ## Sessies
 

--- a/libs/components/src/compliance/next/header/vl-header.component.cy.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.cy.ts
@@ -1,5 +1,5 @@
 import { registerWebComponents } from '@domg-wc/common';
-import { html } from 'lit';
+import { html, TemplateResult } from 'lit';
 import { ApplicationLink, VlHeader } from './index';
 
 registerWebComponents([VlHeader]);
@@ -13,13 +13,34 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    // awaitScript slaat het laden over als er al een script met dit id staat, dus zonder opkuis krijgt de volgende
+    // test geen widget meer. Via document i.p.v. cy.get: het script hoeft er niet te zijn als een test vroeg faalt.
     document.querySelector('script#vl-header-widget')?.remove();
+    // De component ruimt zijn container zelf op bij disconnect; deze regel vangt de gevallen op waarin dat niet
+    // gebeurde, zodat een volgende test nooit twee #header__container-elementen ziet.
     document.querySelector('#header__container')?.remove();
+    // Weg met de client en de opgevangen setProfile-calls van deze test: anders is de wachtvoorwaarde in
+    // mountHeader meteen voldaan met de widget van de vorige test en lezen we diens configuratie uit.
+    delete (window as unknown as Record<string, unknown>).globalHeaderClient;
+    delete (window as unknown as Record<string, unknown>).__setProfileCalls;
 });
+
+/**
+ * Alle tests van dit bestand delen eenzelfde window. Een test die eindigt terwijl zijn widget-script nog onderweg
+ * is, laat dat script in de volgende test uitvoeren: dat vuurt daar een tweede 'widget.global_header.mounted' af
+ * en overschrijft window.globalHeaderClient (inclusief de opgevangen setProfile-calls). Vandaar dat elke mount
+ * hier wacht tot het script van deze test effectief uitgevoerd is - wachten op de response alleen volstaat niet.
+ */
+const mountHeader = (template: TemplateResult) => {
+    cy.mount(template);
+    cy.wait('@widgetScript');
+
+    return cy.window().its('globalHeaderClient').should('exist');
+};
 
 describe('cypress-component - compliance components - vl-header-next - default', () => {
     beforeEach(() => {
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next development identifier="${identifier}"></vl-header-next>
             </body>
@@ -51,15 +72,14 @@ describe('cypress-component - compliance components - vl-header-next - default',
 
 describe('cypress-component - compliance components - vl-header-next - ready event', () => {
     it('should dispatch ready event when ready', () => {
-        cy.window().then((win) => {
-            win.addEventListener('ready', cy.stub().as('ready'));
-        });
-        cy.mount(html`
+        const onReady = cy.stub().as('ready');
+
+        mountHeader(html`
             <body>
-                <vl-header-next development identifier="${identifier}"></vl-header-next>
+                <vl-header-next development identifier="${identifier}" @ready=${onReady}></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
+
         cy.get('@ready').should('have.been.calledOnce');
     });
 });
@@ -83,7 +103,7 @@ describe('cypress-component - compliance components - vl-header-next - applicati
             'widgetScript',
         );
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -93,7 +113,6 @@ describe('cypress-component - compliance components - vl-header-next - applicati
             </body>
         `);
 
-        cy.wait('@widgetScript');
         cy.get('#header__container > div').shadow().find('button.access-menu-toggle__button').click();
         cy.get('#header__container > div')
             .shadow()
@@ -108,7 +127,7 @@ describe('cypress-component - compliance components - vl-header-next - applicati
 
 describe('cypress-component - compliance components - vl-header-next - skeleton', () => {
     it('should render the skeleton container', () => {
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next development identifier="${identifier}" skeleton></vl-header-next>
             </body>
@@ -133,7 +152,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             .then((calls: Record<string, unknown>[]) => calls[calls.length - 1]);
 
     it('should pass idpProfileToken via JS property when set', () => {
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -142,7 +161,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
 
         lastSetProfileCall().should((config) => {
@@ -157,7 +175,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             body: 'token-from-url',
         }).as('tokenFetch');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -166,7 +184,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
         cy.wait('@tokenFetch');
 
@@ -182,7 +199,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             body: 'token-from-url',
         }).as('tokenFetch');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -192,7 +209,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
 
         lastSetProfileCall().should((config) => {
@@ -203,7 +219,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
     it('should not include idpProfileToken when user is not authenticated', () => {
         cy.intercept('GET', '/sso/ingelogde_gebruiker', { statusCode: 401, body: '' }).as('authInactive');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -212,7 +228,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authInactive');
 
         lastSetProfileCall().should((config) => {
@@ -226,12 +241,11 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             user: { firstName: 'John', name: 'Doe' },
         };
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next development identifier="${identifier}" .idpData=${mockIdpData}></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
 
         lastSetProfileCall().should((config) => {
@@ -245,12 +259,11 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             body: { user: { firstName: 'Jane', name: 'Smith' } },
         }).as('idpDataFetch');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next development identifier="${identifier}" idp-data-url="/api/idp-data"></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
         cy.wait('@idpDataFetch');
 
@@ -264,7 +277,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             user: { firstName: 'John', name: 'Doe' },
         };
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -274,7 +287,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
 
         lastSetProfileCall().should((config) => {
@@ -290,12 +302,11 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             body: { user: { firstName: 'Jane', name: 'Smith' } },
         }).as('idpDataFetch');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next development identifier="${identifier}" idp-data-url="/api/idp-data"></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authInactive');
 
         lastSetProfileCall().should((config) => {
@@ -312,7 +323,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             body: 'token-from-url',
         }).as('tokenFetch');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -321,7 +332,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
         cy.wait('@tokenFetch');
 
@@ -340,7 +350,7 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
             delay: 500,
         }).as('slowToken');
 
-        cy.mount(html`
+        mountHeader(html`
             <body>
                 <vl-header-next
                     development
@@ -349,7 +359,6 @@ describe('cypress-component - compliance components - vl-header-next - PAPI prof
                 ></vl-header-next>
             </body>
         `);
-        cy.wait('@widgetScript');
         cy.wait('@authActive');
 
         cy.get('vl-header-next').then(($el) => {

--- a/libs/components/src/compliance/next/header/vl-header.component.ts
+++ b/libs/components/src/compliance/next/header/vl-header.component.ts
@@ -74,7 +74,7 @@ export class VlHeader extends BaseLitElement {
     }
 
     private get headerContainerSkeleton(): HTMLDivElement | null {
-        return document.querySelector<HTMLDivElement>('#header__container__skeleton');
+        return document.querySelector<HTMLDivElement>('#header__skeleton');
     }
 
     connectedCallback() {
@@ -130,7 +130,7 @@ export class VlHeader extends BaseLitElement {
 
         (document.querySelector('body') || document.body).insertAdjacentHTML(
             'afterbegin',
-            '<header id="header__container"><div id="header"></div></header>'
+            '<header id="header__container"><div id="header"></div></header>',
         );
         document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerContainerStyles.styleSheet!];
     }
@@ -146,9 +146,13 @@ export class VlHeader extends BaseLitElement {
         return response.status === 200;
     }
 
-    private onReady() {
+    // class field met pijlfunctie, geen methode !
+    // -> window.addEventListener krijgt hier enkel een functiereferentie mee
+    // -> als gewone methode is 'this' bij het afvuren het window, en dan komt het ready-event op window
+    //    terecht in plaats van op de component - afnemers die op het element luisteren zien het dan nooit
+    private onReady = () => {
         this.dispatchEvent(new CustomEvent('ready'));
-    }
+    };
 
     private async loadWidget() {
         try {
@@ -156,8 +160,10 @@ export class VlHeader extends BaseLitElement {
 
             await awaitScript(
                 'vl-header-widget',
-                `https://widgets.${this.development ? 'tni-' : ''}vlaanderen.be/api/v2/widget/${this.identifier}/entry`
+                `https://widgets.${this.development ? 'tni-' : ''}vlaanderen.be/api/v2/widget/${this.identifier}/entry`,
             );
+
+            if (!this.isConnected) return;
 
             if (!window.globalHeaderClient) {
                 console.error('De global header client werd niet geladen.');
@@ -168,8 +174,14 @@ export class VlHeader extends BaseLitElement {
 
             await window.globalHeaderClient.mount(headerElement);
 
+            if (!this.isConnected) return;
+
             if (this.applicationLinks.length > 0) {
                 await window.globalHeaderClient.accessMenu.setApplicationMenuLinks(this.applicationLinks);
+
+                if (!this.isConnected) {
+                    return;
+                }
             }
 
             if (this.simple) {
@@ -214,9 +226,10 @@ export class VlHeader extends BaseLitElement {
 
     private async configureSession(): Promise<void> {
         const generation = ++this.configureSessionGeneration;
+        const isStale = () => generation !== this.configureSessionGeneration || !this.isConnected;
 
         const active = await this.isUserAuthenticated();
-        if (generation !== this.configureSessionGeneration) return;
+        if (isStale()) return;
 
         const config: Partial<ProfileConfig> = {
             active,
@@ -227,18 +240,18 @@ export class VlHeader extends BaseLitElement {
 
         if (active) {
             const token = await this.resolveProfileToken();
-            if (generation !== this.configureSessionGeneration) return;
+            if (isStale()) return;
 
             if (token) {
                 config.idpProfileToken = token;
             } else {
                 const idpData = await this.resolveIdpData();
-                if (generation !== this.configureSessionGeneration) return;
+                if (isStale()) return;
                 if (idpData) config.idpData = idpData;
             }
         }
 
-        if (generation !== this.configureSessionGeneration) return;
+        if (isStale()) return;
         window.globalHeaderClient?.accessMenu?.setProfile(config);
     }
 


### PR DESCRIPTION
De component-tests van vl-header-next faalden geregeld in Jenkins. Oorzaak: tests eindigden terwijl hun widget-script nog onderweg was. Dat script voert dan uit tijdens een volgende test, vuurt daar een extra widget.global_header.mounted af en overschrijft window.globalHeaderClient plus de opgevangen setProfile-calls.

vl-header-next stopt nu met werken zodra hij uit de DOM is: isConnected-guards na awaitScript, na mount() en na setApplicationMenuLinks(), en configureSession() checkt dat naast de bestaande generation-guard. Een verdwenen header plaatst de widget dus niet meer in een verwijderde container en schrijft geen profiel meer weg. In de specs wacht elke mount voortaan tot het widget-script van die test effectief uitgevoerd is, en ruimt afterEach globalHeaderClient en __setProfileCalls op.

Daarnaast vuurden vl-header-next en vl-footer-next hun ready-event af op window in plaats van op het element: window.addEventListener kreeg een ongebonden prototype-methode mee, waardoor this bij het afvuren het window was. Daardoor deed @ready in een template niets en luisterden vl-side-navigation en vl-functional-header vergeefs op het element. onReady is nu een class field met arrow-functie; de oude vl-header en vl-footer waren niet getroffen. Afnemers die vandaag op window luisteren moeten overschakelen naar het element - dat staat gedocumenteerd op de Storybook docs-pagina's van beide componenten.

Tot slot zocht de skeleton-getter #header__container__skeleton terwijl het geinjecteerde element #header__skeleton heet, waardoor de skeleton na disconnect bleef staan. Zowel in de oude vl-header als in de cleanup-decorator van Storybook rechtgezet.