### PR TITLE
fix: FLUX-658 - vl-composite-input - test zet disabled via het attribuut in plaats van de protected property

### DIFF
--- a/libs/integrations/src/form/composite-input/vl-composite-input.component.cy.ts
+++ b/libs/integrations/src/form/composite-input/vl-composite-input.component.cy.ts
@@ -126,9 +126,7 @@ describe('cypress-component - integrations - vl-composite-input (Mode A)', () =>
         cy.get('vl-input-field#lon').should('have.attr', 'disabled');
         cy.get('vl-input-field#lat').should('have.attr', 'disabled');
 
-        cy.get('vl-composite-input#geo').then(($composite) => {
-            ($composite[0] as CompositeInputComponent).disabled = false;
-        });
+        cy.get('vl-composite-input#geo').then(($composite) => $composite[0].removeAttribute('disabled'));
         cy.get('vl-input-field#lon').should('not.have.attr', 'disabled');
         cy.get('vl-input-field#lat').should('not.have.attr', 'disabled');
     });


### PR DESCRIPTION
Voor de fix (op develop-v2)

<img width="1232" height="386" alt="image" src="https://github.com/user-attachments/assets/99891b90-532d-4993-8cf9-a3da776c81e9" />

na de fix (deze commit)

<img width="931" height="443" alt="image" src="https://github.com/user-attachments/assets/fd5b210f-26f1-4204-a955-25434f29998e" />