### PR TITLE
fix: FLUX-795 - critical dependency waarschuwingen van cypress-axe onderdrukt

### DIFF
--- a/apps/storybook-e2e/cypress.config.ts
+++ b/apps/storybook-e2e/cypress.config.ts
@@ -25,6 +25,7 @@ const cypressConfig = defineConfig({
                 webpackPreprocessor({
                     webpackOptions: {
                         mode: 'development',
+                        ignoreWarnings: [{ module: /cypress-axe/, message: /Critical dependency/ }],
                         resolve: {
                             extensions: ['.ts', '.tsx', '.js'],
                             plugins: [

--- a/resources/cypress-component/cypress.config.ts
+++ b/resources/cypress-component/cypress.config.ts
@@ -28,6 +28,7 @@ const cypressConfig: any = {
             // @ts-ignore
             headers: { 'Cache-Control': 'no-store' },
             webpackConfig: {
+                ignoreWarnings: [{ module: /cypress-axe/, message: /Critical dependency/ }],
                 module: {
                     rules: [
                         {


### PR DESCRIPTION
[FLUX-795](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-795)

## Wat

### kort:
om test output iets leesbaarder te maken

### lang: 
Scoped `ignoreWarnings` in de twee webpack configs die cypress-axe bundelen (component tests, storybook-e2e). cypress-axe gebruikt `require?.resolve`; webpack kan dat niet statisch analyseren en toont bij elke run twee "Critical dependency" waarschuwingen. Upstream open sinds 2021 ([component-driven/cypress-axe#99](https://github.com/component-driven/cypress-axe/issues/99)), laatste release 1.7.0 bevat het patroon nog, dus niet lokaal fixbaar. De filter matcht op module en message samen; alle andere waarschuwingen blijven zichtbaar.

## Verificatie

Zelfde spec twee keer gedraaid: zonder de fix 4 keer "Critical dependency", met de fix 0 en `compiled successfully`, spec geslaagd.

Voor:
<img width="2320" height="1376" alt="before" src="https://github.com/user-attachments/assets/c3ff92e0-4d89-4242-aabd-8b337892d7c3" />

Na:
<img width="2320" height="892" alt="after" src="https://github.com/user-attachments/assets/7110dd22-e482-417f-bbec-9daec0cc83f4" />
