### PR TITLE
fix: FLUX-794 - vl-upload - aria-invalid bij een validatiefout

### DIFF
--- a/apps/storybook/docs/e_richtlijnen/b_toegankelijkheid-praktijk/2_gekende-beperkingen.mdx
+++ b/apps/storybook/docs/e_richtlijnen/b_toegankelijkheid-praktijk/2_gekende-beperkingen.mdx
@@ -4,6 +4,18 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Gekende Beperkingen [WIP]
 
+## `aria-invalid` bij `vl-upload`
+
+Bij een validatiefout krijgt `vl-upload` als enige form control geen `aria-invalid` in de accessibility tree. Het
+enige focusbare element is de upload-knop, en `aria-invalid` wordt niet ondersteund op `role="button"`, dus de
+browser laat het attribuut daar vallen. De onderliggende `input type="file"` draagt het wel, maar Dropzone verbergt
+die met `visibility: hidden`, waardoor ze sowieso buiten de accessibility tree valt.
+
+De ongeldige toestand komt daarom niet van de control zelf, maar van de foutmelding: `vl-form-message` rendert ze in
+een `role="status"` regio met `aria-live="polite"`, zodat een screenreader ze voorleest zodra ze verschijnt. De
+gebruiker hoort dus wel wat er fout is, alleen niet dat het veld zelf ongeldig staat. Dit rechtzetten vraagt dat de
+file-input echt zichtbaar wordt voor screenreaders, wat raakt aan de manier waarop Dropzone haar input verbergt.
+
 ## Focus op niet-tekstuele inputs
 
 Op Safari is het niet mogelijk om, met standaard instellingen, focus te leggen op een niet-tekstuele input zoals

--- a/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.mdx
+++ b/apps/storybook/docs/f_patronen/formulier/5_blur-validatie/formulier-blur-validatie.mdx
@@ -54,7 +54,8 @@ ruis voor screenreaders tijdens het invullen.
 De foutmelding staat in een `aria-live="polite"` regio met `role="status"` (via `vl-form-message`), zodat
 screenreaders ze voorlezen zodra ze verschijnt of wijzigt. `aria-atomic="true"` zorgt dat telkens de
 volledige boodschap wordt voorgelezen. De control krijgt `aria-invalid="true"` zodat de ongeldige toestand
-ook los van de melding kenbaar is.
+ook los van de melding kenbaar is. Eén uitzondering: bij `vl-upload` haalt dat attribuut de accessibility
+tree niet, zie [Gekende Beperkingen](/docs/richtlijnen-toegankelijkheid-praktijk-gekende-beperkingen-wip--documentatie).
 
 Blur-validatie verplaatst de focus niet: het veld toont enkel zijn melding. Alleen bij submit springt de
 focus naar het eerste ongeldige veld.

--- a/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
+++ b/libs/components/src/form/upload/stories/vl-upload.stories-doc.mdx
@@ -87,6 +87,9 @@ Om deze functionaliteit te bekomen wordt er een `dropzoneValidator` gebruikt die
 [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) key.
 Via de `customError` ValidityState key kan je een error message linken aan de `dropzoneValidator`.
 
+De ongeldige toestand van dit veld bereikt een screenreader enkel via de foutmelding, niet via `aria-invalid` op de
+control zelf. Zie [Gekende Beperkingen](/docs/richtlijnen-toegankelijkheid-praktijk-gekende-beperkingen-wip--documentatie).
+
 ### Bestandsgrootte: MiB vs MB
 
 De `max-size`-waarde wordt achterliggend door Dropzone (`maxFilesize`) binair geïnterpreteerd, dus in **MiB**

--- a/libs/components/src/form/upload/vl-upload.component.cy.ts
+++ b/libs/components/src/form/upload/vl-upload.component.cy.ts
@@ -358,6 +358,42 @@ describe('cypress-component - form components - vl-upload - events', () => {
         cy.get('vl-form-message[state="valueMissing"]').should('not.have.attr', 'show');
     });
 
+    it('should mark the validation target invalid via aria-invalid when the error shows', () => {
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-upload id="foto" name="foto" required></vl-upload>
+                <vl-form-message for="foto" state="valueMissing">Kies een bestand.</vl-form-message>
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+        cy.get('vl-upload').shadow().find('input').should('not.have.attr', 'aria-invalid');
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-upload').shadow().find('input').should('have.attr', 'aria-invalid', 'true');
+
+        shouldAddPdfFiles(1);
+        cy.get('vl-upload').shadow().find('input').should('not.have.attr', 'aria-invalid');
+    });
+
+    it('should announce the error in a polite live region', () => {
+        cy.mount(html`
+            <form @submit=${(e: Event) => e.preventDefault()}>
+                <vl-upload id="foto" name="foto" required></vl-upload>
+                <vl-form-message for="foto" state="valueMissing">Kies een bestand.</vl-form-message>
+                <button type="submit">Verstuur</button>
+            </form>
+        `);
+
+        cy.get('button[type="submit"]').click();
+        cy.get('vl-form-message[state="valueMissing"]').should('have.attr', 'show');
+        cy.get('vl-form-message[state="valueMissing"]')
+            .shadow()
+            .find('[role="status"]')
+            .should('have.attr', 'aria-live', 'polite')
+            .and('have.attr', 'aria-atomic', 'true');
+    });
+
     it('should dispatch vl-change events when removing a file', () => {
         cy.mount(html` <vl-upload max-files="4"></vl-upload>`);
 

--- a/libs/components/src/form/upload/vl-upload.component.ts
+++ b/libs/components/src/form/upload/vl-upload.component.ts
@@ -188,6 +188,7 @@ export class VlUploadComponent extends FormControl {
 
         if (changedProperties.has('isInvalid')) {
             this.updateInputForAttribute('isInvalid');
+            this.updateAriaInvalid();
         }
 
         if (changedProperties.has('success')) {
@@ -400,6 +401,14 @@ export class VlUploadComponent extends FormControl {
                 </li>
             </template>
         `;
+    }
+
+    private updateAriaInvalid() {
+        if (this.isInvalid) {
+            this.validationTarget?.setAttribute('aria-invalid', 'true');
+        } else {
+            this.validationTarget?.removeAttribute('aria-invalid');
+        }
     }
 
     private updateInputForAttribute(attribute: string) {


### PR DESCRIPTION
## FLUX-794

[Jira ticket](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-794)

### Wat

`aria-invalid` staat nu op de `validationTarget`, consistent met de andere form controls.

Dat lost WCAG 3.3.1 niet op, en dat is bewust omdat dit anders een te grote wijziging zou zijn, het probleem is hier hoe Dropzone in elkaar zit. De `validationTarget` is de door Dropzone verborgen `input type=file`, en op de upload-knop kan het niet want `aria-invalid` wordt niet ondersteund op `role="button"`. De ongeldige toestand bereikt een screenreader dus enkel via de foutmelding.

Die beperking staat nu bij Gekende Beperkingen, met een verwijzing vanaf de pagina van `vl-upload` en vanaf blur-validatie, waar de claim tot nu onvoorwaardelijk was. 

Het echt oplossen is [FLUX-801](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-801).

### Verificatie

| | |
| :-: | --- |
| ✅ | cypress component-tests `vl-upload` 42/42 |
| ✅ | `aria-invalid` op de `validationTarget`, van pristine naar fout en terug |
| ✅ | foutmelding komt in de `role="status"` regio van `vl-form-message` |