### PR TITLE
fix: FLUX-791 - form-control - submit op Enter werkt ook met het numerieke klavier

### DIFF
--- a/libs/components/src/form/form-control/form-control.ts
+++ b/libs/components/src/form/form-control/form-control.ts
@@ -156,7 +156,7 @@ export abstract class FormControl extends FormControlMixin(BaseLitElement) {
     }
 
     protected onKeydown(event: KeyboardEvent) {
-        if (event.code === 'Enter') {
+        if (event.key === 'Enter') {
             if (this.form && this.submitFormOnEnter) {
                 submit(this.form);
             }

--- a/libs/components/src/form/input-field/vl-input-field.component.cy.ts
+++ b/libs/components/src/form/input-field/vl-input-field.component.cy.ts
@@ -194,6 +194,44 @@ describe('cypress-component - form components - vl-input-field', () => {
         cy.get('@vl-valid').should('have.been.calledOnce');
         cy.get('@vl-valid').its('firstCall.args.0.detail').should('deep.equal', { value: 'test' });
     });
+
+    it('should submit the form on Enter', () => {
+        const onSubmit = cy.stub().as('onSubmit');
+        cy.mount(html`
+            <form
+                @submit=${(e: Event) => {
+                    e.preventDefault();
+                    onSubmit();
+                }}
+            >
+                <vl-input-field id="enter-field" name="enter-field"></vl-input-field>
+            </form>
+        `);
+        cy.get('vl-input-field').shadow().find('input').type('waarde');
+        cy.get('vl-input-field').then(($el) => {
+            $el[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true }));
+        });
+        cy.get('@onSubmit').should('have.been.calledOnce');
+    });
+
+    it('should submit the form on Enter from the numeric keypad', () => {
+        const onSubmit = cy.stub().as('onSubmit');
+        cy.mount(html`
+            <form
+                @submit=${(e: Event) => {
+                    e.preventDefault();
+                    onSubmit();
+                }}
+            >
+                <vl-input-field id="numpad-field" name="numpad-field"></vl-input-field>
+            </form>
+        `);
+        cy.get('vl-input-field').shadow().find('input').type('waarde');
+        cy.get('vl-input-field').then(($el) => {
+            $el[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'NumpadEnter', bubbles: true }));
+        });
+        cy.get('@onSubmit').should('have.been.calledOnce');
+    });
 });
 
 describe('cypress-component - form components - vl-input-field - blur-validation attribuut', () => {


### PR DESCRIPTION
## FLUX-791

[Jira ticket](https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-791)

### Wat

De keydown-handler in `form-control` checkte op `event.code === 'Enter'`. De Enter van het numerieke klavier geeft `NumpadEnter` als code, dus die toets submitte het formulier nooit. De check gebruikt nu `event.key`, dat voor beide toetsen `'Enter'` is. De `submitFormOnEnter` opt-out per control (textarea, select-rich) blijft ongewijzigd.

### Verificatie

| | |
| :-: | --- |
| ✅ | cypress component-tests `vl-input-field` 47/47, waarvan twee nieuwe: submit op Enter en op NumpadEnter |
| ✅ | cypress component-tests `vl-textarea` 35/35, de opt-out via `submitFormOnEnter` blijft werken |
| ✅ | volledige cypress component-suite groen: 2566 passing, 2 pending, 0 failing |
| ✅ | `npm run libs:build` slaagt (tsc voor styles, common, components, map en integrations) |
| ✅ | lint: de repo heeft geen actieve eslint (`libs-eslint.sh` staat uitgecomment); als vervangende check is prettier gedraaid op de gewijzigde bestanden: de testfile is clean, `form-control.ts` bevat enkel afwijkingen die ook al op `develop-v2` staan en buiten deze diff vallen |
| ✅ | a11y: geen markup of DOM geraakt; de fix verbetert de toetsenbordbediening zelf, numpad-Enter gedraagt zich nu identiek aan de gewone Enter |
