### PR TITLE
fix: FLUX-796 - vl-side-navigation-next - auto-sectie rescan bij slotchange verbeterd

### DIFF
--- a/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
+++ b/libs/components/src/block/next/side-navigation/vl-side-navigation.component.ts
@@ -138,7 +138,9 @@ export class VlSideNavigationComponent extends BaseLitElement {
             if (hasAutoSection) {
                 this.sectionsRescanRafHandle = requestAnimationFrame(() => {
                     this.sectionsRescanRafHandle = undefined;
-                    this.refreshSections(slottedElements);
+                    if (this.mode !== 'sections') return;
+                    const currentSlot = this.shadowRoot?.querySelector('slot') as HTMLSlotElement;
+                    this.refreshSections(currentSlot?.assignedElements() ?? []);
                 });
             }
         } else if (this.mode === 'custom') {
@@ -736,6 +738,11 @@ export class VlSideNavigationComponent extends BaseLitElement {
     }
 
     private handleTocSlotChange(event: Event): void {
+        if (this.sectionsRescanRafHandle !== undefined) {
+            cancelAnimationFrame(this.sectionsRescanRafHandle);
+            this.sectionsRescanRafHandle = undefined;
+        }
+
         const slot = event.target as HTMLSlotElement;
         const slottedElements = slot.assignedElements();
 


### PR DESCRIPTION
## Wat

De uitgestelde rescan in `firstUpdated` draaide `refreshSections` met een stale closure-snapshot en kon een losgekoppelde auto-sectie opnieuw vol renderen nadat de `slotchange`-cleanup ze had leeggemaakt. Op een trage CI-pod vuurde die frame steevast na de cleanup, waardoor één component-test daar consistent faalde terwijl dezelfde spec lokaal groen was. De rescan leest nu de actuele slotted elements en stopt zodra de mode niet langer `sections` is; de `slotchange`-handler annuleert daarnaast een openstaande rescan-frame.

Context: FLUX-796 (https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-796).

## Verificatie

- [x] cypress component-spec `vl-side-navigation.component.cy.ts` 85/85 groen, na rebase op `develop-v2`
- [x] zuster-specs groen: `vl-side-navigation-layout` 87/0, `vl-side-navigation.benchmark` 17/0
- [x] A/B-bewijs: met een gesimuleerde trage frame faalt de oude code alle 5 attempts, de gefixte code slaagt 85/85
- [x] a11y: geen markup- of template-wijziging (enkel lifecycle-timing), render-output identiek; de `checkA11y`-cases in de spec blijven groen
- [ ] lint/build niet apart gedraaid; de spec bundelt de component via webpack zonder fouten
