### PR TITLE
feat: FLUX-772 - vl-header-next / vl-footer-next - header, footer toegevoegd die aansluit bij global header v5

### DIFF
--- a/libs/common/utilities/src/css/base/accessibility/vl-accessibility.css.ts
+++ b/libs/common/utilities/src/css/base/accessibility/vl-accessibility.css.ts
@@ -1,8 +1,10 @@
 import { css, CSSResult } from 'lit';
+import { vlFocusOutlineMixin } from '../mixin/vl-outlines.css';
 import { vlMediaScreenSmall } from '../var/vl-media-screen.css';
 
 export const vlAccessibilityStyles: CSSResult = css`
-    .vl-visually-hidden {
+    .vl-visually-hidden,
+    .vl-skip-link {
         position: absolute;
         height: 1px;
         width: 1px;
@@ -13,5 +15,18 @@ export const vlAccessibilityStyles: CSSResult = css`
         border: 0;
         left: 0;
         top: 0;
+    }
+
+    .vl-skip-link:focus {
+        position: absolute;
+        height: unset;
+        width: unset;
+        overflow: unset;
+        clip: unset;
+        margin: unset;
+        cursor: pointer;
+        background: white;
+        z-index: var(--vl-z-layer--skip-link);
+        ${vlFocusOutlineMixin()};
     }
 `;

--- a/libs/common/utilities/src/css/base/var/vl-z-layer.raw.css
+++ b/libs/common/utilities/src/css/base/var/vl-z-layer.raw.css
@@ -17,4 +17,5 @@
     --vl-z-layer--side-sheet: 1001;
     --vl-z-layer--side-sheet-open: 1002;
     --vl-z-layer--popover: 10010;
+    --vl-z-layer--skip-link: 10100;
 }

--- a/libs/common/utilities/src/index.ts
+++ b/libs/common/utilities/src/index.ts
@@ -33,3 +33,10 @@ export {
 } from './util/utils';
 export { onChildListChange } from './util/mutation-utils';
 export { buildSpan, buildDiv, buildLabel, buildData } from './util/html-element.builder';
+export { legacyCore, legacyBreakpoint } from './util/legacy-initialisation';
+export {
+    createSkipToContentLink,
+    SKIP_TO_CONTENT_LINK_TEXT,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
+} from './util/skip-link';
+export { vlAccessibilityStyles } from './css/base/accessibility/vl-accessibility.css';

--- a/libs/common/utilities/src/util/anchor-navigation.ts
+++ b/libs/common/utilities/src/util/anchor-navigation.ts
@@ -1,0 +1,150 @@
+import { scrollIntoViewBelowSticky } from './sticky-scroll';
+import { findDeepestElementThroughShadowRoot } from './utils';
+
+/**
+ * Naam van het event waarmee eender welke link of component, op eender welke plaats (ook diep in een
+ * shadow DOM), naar een same-page anchor kan navigeren. Het event is `composed` zodat het vanuit een
+ * shadow root tot bij de centrale document-listener bubbelt.
+ */
+export const NAVIGATE_TO_ANCHOR_EVENT = 'vl-navigate-to-anchor';
+
+export type NavigateToAnchorDetail = { hash: string; updateHash?: boolean };
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        [NAVIGATE_TO_ANCHOR_EVENT]: CustomEvent<NavigateToAnchorDetail>;
+    }
+}
+
+/**
+ * Navigeert naar een same-page anchor en zoekt het doel pagina-breed door alle (open) shadow roots
+ * én de light DOM. Bij een treffer wordt er gescrold - onder eventuele sticky of fixed page chrome,
+ * zie {@link scrollIntoViewBelowSticky} - de focus mee verplaatst (WCAG 2.4.3) en optioneel de
+ * URL-hash bijgewerkt.
+ *
+ * @param hash - de hash of het id van het doel (met of zonder leidende `#`)
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden via `history.pushState` (default false).
+ *   Bewust expliciet: automatisch de hash bijwerken kan botsen met bv. een SPA-router, daarom moet dit
+ *   expliciet geactiveerd worden.
+ * @return `true` als er een doel gevonden en aangedaan werd, anders `false`
+ */
+export const navigateToAnchor = (hash: string, { updateHash = false }: { updateHash?: boolean } = {}): boolean => {
+    const id = decodeURIComponent((hash ?? '').replace(/^#/, ''));
+    if (!id) {
+        return false;
+    }
+
+    const target = findDeepestElementThroughShadowRoot(document.body, `#${CSS.escape(id)}`) as HTMLElement | null;
+    if (!target) {
+        return false;
+    }
+
+    scrollIntoViewBelowSticky(target);
+
+    // Verplaats focus naar het doel zodat toetsenbord-/screenreader-context meeschuift (WCAG 2.4.3).
+    if (target.tabIndex < 0) {
+        target.tabIndex = -1;
+    }
+    target.focus({ preventScroll: true });
+
+    if (updateHash && location.hash !== `#${id}`) {
+        history.pushState(null, '', `#${id}`);
+    }
+
+    return true;
+};
+
+let installed = false;
+
+/**
+ * Installeert (één keer, voor de paginalevensduur) de centrale anchor-navigatie:
+ * - een document-listener op {@link NAVIGATE_TO_ANCHOR_EVENT} die {@link navigateToAnchor} aanroept;
+ * - een `hashchange`-listener voor back/forward en deep-links (zonder een extra pushState te triggeren);
+ * - een initiële deep-link-poging bij een reeds aanwezige `location.hash`.
+ *
+ * Idempotent: meerdere aanroepen (bv. door meerdere componenten) installeren slechts één keer.
+ */
+export const enableAnchorNavigation = (): void => {
+    if (installed) {
+        return;
+    }
+    installed = true;
+
+    document.addEventListener(NAVIGATE_TO_ANCHOR_EVENT, (event) => {
+        if (navigateToAnchor(event.detail?.hash, { updateHash: event.detail?.updateHash })) {
+            // Markeer het event als afgehandeld zodat de bron de native navigatie kan onderdrukken.
+            event.preventDefault();
+        }
+    });
+
+    window.addEventListener('hashchange', () => {
+        navigateToAnchor(location.hash, { updateHash: false });
+    });
+
+    if (location.hash) {
+        navigateToAnchor(location.hash, { updateHash: false });
+    }
+};
+
+/**
+ * Dispatcht het {@link NAVIGATE_TO_ANCHOR_EVENT} vanaf een bron-element zodat de centrale listener
+ * de cross-shadow-navigatie afhandelt. Omdat `dispatchEvent` synchroon is, geeft de retourwaarde
+ * meteen aan of er een doel gevonden werd (`event.defaultPrevented`), zodat de aanroeper de native
+ * navigatie enkel onderdrukt wanneer er effectief genavigeerd is.
+ *
+ * @param source - het element van waaruit het event gedispatcht wordt (mag in een shadow root zitten)
+ * @param hash - de hash of het id van het doel
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden (default false, zie {@link navigateToAnchor})
+ * @return `true` als de navigatie afgehandeld werd, anders `false`
+ */
+export const dispatchNavigateToAnchor = (
+    source: EventTarget,
+    hash: string,
+    { updateHash = false }: { updateHash?: boolean } = {}
+): boolean => {
+    const event = new CustomEvent<NavigateToAnchorDetail>(NAVIGATE_TO_ANCHOR_EVENT, {
+        detail: { hash, updateHash },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+    });
+    source.dispatchEvent(event);
+    return event.defaultPrevented;
+};
+
+/**
+ * Herbruikbare click-handler die een echte klik op een same-page anchor (`<a href="#...">`) vertaalt
+ * naar {@link dispatchNavigateToAnchor}. Hang hem aan een shadow root (voor een component dat zijn
+ * content in shadow DOM rendert) óf aan `document` (om álle anchors op de pagina cross-shadow te laten
+ * werken). Modifier-/middenklikken en links naar een ander pad blijven ongemoeid.
+ *
+ * @param event - het click-event
+ * @param options.updateHash - of de URL-hash bijgewerkt mag worden (default false, zie {@link navigateToAnchor})
+ * @example shadow.addEventListener('click', handleAnchorClick as EventListener);
+ */
+export const handleAnchorClick = (event: MouseEvent, { updateHash = false }: { updateHash?: boolean } = {}): void => {
+    // Laat modifier-/middenklikken (open in nieuw tabblad/venster) met rust, anders breken we native gedrag.
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+    }
+
+    // composedPath() vindt de <a> ook wanneer die in een shadow root zit, ongeacht of de handler op een
+    // shadow root of op document hangt.
+    const anchor = event
+        .composedPath()
+        .find((target): target is HTMLAnchorElement => target instanceof HTMLAnchorElement);
+    if (!anchor) {
+        return;
+    }
+
+    const url = new URL(anchor.href, document.baseURI);
+    const isSamePage = url.pathname === location.pathname && url.search === location.search;
+    if (!url.hash || !isSamePage) {
+        return;
+    }
+
+    // Enkel wanneer er effectief genavigeerd is onderdrukken we de native navigatie.
+    if (dispatchNavigateToAnchor(anchor, url.hash, { updateHash })) {
+        event.preventDefault();
+    }
+};

--- a/libs/common/utilities/src/util/legacy-breakpoint.js
+++ b/libs/common/utilities/src/util/legacy-breakpoint.js
@@ -1,0 +1,50 @@
+class Breakpoint {
+    constructor() {
+        this.value = null;
+    }
+
+    // Private functions
+    _getBreakpoint() {
+        // transfer css breakpoints to JS
+        return window.getComputedStyle(document.body, ':before').getPropertyValue('content').replace(/"/g, '');
+    }
+
+    // Public functions
+    dress() {
+        this.value = this._getBreakpoint();
+
+        /**
+         * Add eventlisteners to window
+         */
+        window.addEventListener(
+            'resize',
+            vl.util.debounce(() => {
+                this.refreshValue();
+            }),
+            50
+        );
+    }
+
+    refreshValue() {
+        const breakpoint = this._getBreakpoint();
+        const shouldDispatch = this.value !== breakpoint;
+        this.value = breakpoint;
+
+        // FLUX-92: dispatch event wanneer het breakpoint verandert
+        // Dit werkt gedetailleerder dan te luisteren naar resize events
+        if (shouldDispatch) {
+            window.dispatchEvent(new CustomEvent('vl-breakpoint-changed', {
+                detail: {
+                    breakpoint
+                }
+            }))
+        }
+    }
+}
+
+if (!('breakpoint' in vl)) {
+    vl.breakpoint = new Breakpoint();
+    vl.breakpoint.dress();
+}
+
+export default Breakpoint;

--- a/libs/common/utilities/src/util/legacy-core.js
+++ b/libs/common/utilities/src/util/legacy-core.js
@@ -1,0 +1,2123 @@
+(function (factory) {
+    typeof define === 'function' && define.amd ? define(factory) : factory();
+})(function () {
+    'use strict';
+
+    function _typeof(obj) {
+        '@babel/helpers - typeof';
+
+        return (
+            (_typeof =
+                'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+                    ? function (obj) {
+                          return typeof obj;
+                      }
+                    : function (obj) {
+                          return obj &&
+                              'function' == typeof Symbol &&
+                              obj.constructor === Symbol &&
+                              obj !== Symbol.prototype
+                              ? 'symbol'
+                              : typeof obj;
+                      }),
+            _typeof(obj)
+        );
+    }
+
+    function _classCallCheck(instance, Constructor) {
+        if (!(instance instanceof Constructor)) {
+            throw new TypeError('Cannot call a class as a function');
+        }
+    }
+
+    function _defineProperties(target, props) {
+        for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ('value' in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+        }
+    }
+
+    function _createClass(Constructor, protoProps, staticProps) {
+        if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+        if (staticProps) _defineProperties(Constructor, staticProps);
+        Object.defineProperty(Constructor, 'prototype', {
+            writable: false,
+        });
+        return Constructor;
+    }
+
+    window.vl = window.vl || {
+        ns: 'vl-',
+    }; // Returns a function, that, as long as it continues to be invoked, will not
+    // be triggered. The function will be called after it stops being called for
+    // N milliseconds. If `immediate` is passed, trigger the function on the
+    // leading edge, instead of the trailing.
+
+    var debounce = function debounce(func, wait) {
+        var immediate = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+        var timeout;
+        return function () {
+            var context = this,
+                args = arguments,
+                later,
+                callNow;
+
+            later = function later() {
+                timeout = null;
+
+                if (!immediate) {
+                    func.apply(context, args);
+                }
+            };
+
+            callNow = immediate && !timeout;
+            window.clearTimeout(timeout);
+            timeout = window.setTimeout(later, wait);
+
+            if (callNow) {
+                func.apply(context, args);
+            }
+        };
+    };
+
+    var throttle = function throttle(func) {
+        var threshhold = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 250;
+        var scope = arguments.length > 2 ? arguments[2] : undefined;
+        var last, deferTimer;
+        return function () {
+            var context = scope || this,
+                now = Number(new Date()),
+                args = arguments;
+
+            if (last && now < last + threshhold) {
+                // hold on to it
+                window.clearTimeout(deferTimer);
+                deferTimer = window.setTimeout(function () {
+                    last = now;
+                    func.apply(context, args);
+                }, threshhold);
+            } else {
+                last = now;
+                func.apply(context, args);
+            }
+        };
+    };
+
+    var addClass = function addClass(el, classes) {
+        el.classList.add(classes);
+    };
+
+    var removeClass = function removeClass(el, classes) {
+        el.classList.remove(classes);
+    };
+
+    var hasClass = function hasClass(el, classes) {
+        return el.classList.contains(classes);
+    };
+
+    var toggleClass = function toggleClass(el, classes) {
+        el.classList.toggle(classes);
+    };
+
+    var addClassFor = function addClassFor(el, classes, duration) {
+        addClass(el, classes);
+        window.setTimeout(function () {
+            removeClass(el, classes);
+        }, duration);
+    }; // Helper function that takes an HTML string & an object to use for
+    // "binding" its properties to the HTML template above.
+
+    var parseTemplate = function parseTemplate(str, data) {
+        return str.replace(/\$\{(\w+)\}/gi, function (match, parensMatch) {
+            if (typeof data[parensMatch] !== 'undefined') {
+                return data[parensMatch];
+            }
+
+            return match;
+        });
+    }; // trigger a custom event on an object
+
+    var triggerEvent = function triggerEvent(obj, evt) {
+        var fireOnThis = obj,
+            evtObj;
+
+        if (document.createEvent) {
+            evtObj = document.createEvent('MouseEvents');
+            evtObj.initEvent(evt, true, false);
+            fireOnThis.dispatchEvent(evtObj);
+        } else if (document.createEventObject) {
+            evtObj = document.createEventObject();
+            fireOnThis.fireEvent('on'.concat(evt), evtObj);
+        }
+    };
+
+    var unique = function unique(array) {
+        return array.filter(function (elem, pos, arr) {
+            return arr.indexOf(elem) === pos;
+        });
+    };
+
+    var closest = function closest(value, to) {
+        return Math.round(value / to) * to;
+    }; // Current position of an element relative to the document.
+
+    var offset = function offset(el) {
+        var rect = el.getBoundingClientRect(),
+            doc = el.ownerDocument,
+            win = doc.defaultView || doc.parentWindow,
+            docElem = doc.documentElement,
+            xOff = win.pageXOffset; // getBoundingClientRect contains left scroll in Chrome on Android.
+        // I haven't found a feature detection that proves this. Worst case
+        // scenario on mis-match: the 'tap' feature on horizontal sliders breaks.
+
+        if (/webkit.*Chrome.*Mobile/i.test(navigator.userAgent)) {
+            xOff = 0;
+        }
+
+        return {
+            top: rect.top + win.pageYOffset - docElem.clientTop,
+            left: rect.left + xOff - docElem.clientLeft,
+        };
+    }; // Insert after
+
+    var insertAfter = function insertAfter(newElement, targetElement) {
+        var parent = targetElement.parentNode; // If targetElement is the parents last-child
+
+        if (parent.lastchild === targetElement) {
+            // Add the newElement after the target element
+            parent.appendChild(newElement);
+        } else {
+            // Target has siblings, insert the new element between the target and its next sibling
+            parent.insertBefore(newElement, targetElement.nextSibling);
+        }
+    };
+
+    var removeElement = function removeElement(targetElement) {
+        var parent = targetElement.parentNode;
+        parent.removeChild(targetElement);
+    };
+
+    var isNumeric = function isNumeric(number) {
+        return !isNaN(parseFloat(number)) && isFinite(number);
+    };
+
+    var wrap = function wrap(el, wrapper) {
+        // Cache the current parent and sibling
+        var parent = el.parentNode,
+            sibling = el.nextSibling;
+        wrapper.appendChild(el);
+        /**
+         * If the element had a sibling, insert the wrapper before
+         * the sibling to maintain the HTML structure; otherwise, just
+         * append it to the parent.
+         */
+
+        if (sibling) {
+            parent.insertBefore(wrapper, sibling);
+        } else {
+            parent.appendChild(wrapper);
+        }
+    }; // Strip tags from element
+
+    var stripTags = function stripTags(html) {
+        var tmp = document.createElement('div');
+        tmp.innerHTML = html;
+        return tmp.textContent || tmp.innerText;
+    }; // Create a unique ID
+
+    var uniqueId = function uniqueId() {
+        // Desired length of Id
+        // Always start with a letter -- base 36 makes for a nice shortcut
+        var idStrLen = 32,
+            idStr = ''.concat((Math.floor(Math.random() * 25) + 10).toString(36), '_'); // Add a timestamp in milliseconds (base 36 again) as the base
+
+        idStr += ''.concat(new Date().getTime().toString(36), '_'); // Similar to above, complete the Id using random, alphanumeric characters
+
+        do {
+            idStr += Math.floor(Math.random() * 35).toString(36);
+        } while (idStr.length < idStrLen);
+
+        return idStr;
+    }; // Create a unique name
+
+    var uniqueName = function uniqueName() {
+        return Math.random().toString(36).substring(2, 5);
+    }; // Rounds a number to 7 supported decimals
+
+    var accurateNumber = function accurateNumber(number) {
+        var p = Math.pow(10, 7);
+        return Number((Math.round(number * p) / p).toFixed(7));
+    }; // Limits a value to 0 - 100
+
+    var limit = function limit(a) {
+        return Math.max(Math.min(a, 100), 0);
+    }; // Wraps a variable as an array, if it isn't one yet.
+
+    var asArray = function asArray(a) {
+        return Array.isArray(a) ? a : [a];
+    }; // Count decimals
+
+    var countDecimals = function countDecimals(numStr) {
+        var pieces = numStr.split('.');
+        return pieces.length > 0 ? pieces[1].length : 0;
+    }; // Scroll element to specific position
+    // TODO: use element.scrollIntoView instead, maybe with fallback if you want old browser to have a smooth scroll
+
+    var scrollTo = function scrollTo(el, to, duration) {
+        var callback = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : function () {};
+        var scrollTop = el.scrollTop,
+            difference = to - scrollTop,
+            perTick;
+
+        if (duration < 0) {
+            return;
+        }
+
+        perTick = (difference / duration) * 10;
+        window.setTimeout(function () {
+            if (scrollTop === to || duration <= 0) {
+                callback();
+            } else {
+                el.scrollTop = scrollTop + perTick;
+                scrollTo(el, to, duration - 10, callback);
+            }
+        }, 10);
+    }; // Gets a random number between min and max
+
+    var randomIntFromInterval = function randomIntFromInterval(min, max) {
+        return Math.floor(Math.random() * (max - min + 1) + min);
+    }; // Much faster each loop than a forEach loop
+
+    var each = function each(arr, fn) {
+        var l = arr.length,
+            i = 0;
+
+        for (; i < l; i++) {
+            fn(arr[i], i);
+        }
+    };
+    /**
+     * Determines if a certain value exists, is not null, and not empty
+     * @method exists
+     * @param  {type}  value value to check
+     * @param  {Boolean} [nullAllowed = false] optional parameter to allow null
+     * @param  {Boolean} [emptyAllowed = false] optional paramet to allow empty values
+     * @return {Boolean}
+     */
+
+    var exists = function exists(value) {
+        var nullAllowed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+        var emptyAllowed = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+
+        if (typeof value !== 'undefined') {
+            if (nullAllowed || value !== null) {
+                if (emptyAllowed || value !== '') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    };
+
+    var bytesToSize = function bytesToSize(bytes) {
+        var addUnits = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+        var base = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 1024;
+        var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'],
+            value = null,
+            i;
+
+        if (bytes === 0) {
+            value = addUnits ? '0 bytes' : 0;
+        } else {
+            i = parseInt(Math.floor(Math.log(bytes) / Math.log(base)), 10);
+
+            if (!addUnits) {
+                value = Math.round(bytes / Math.pow(base, i), 2);
+            }
+
+            value = addUnits
+                ? Math.round(bytes / Math.pow(base, i), 2) + ' ' + sizes[i]
+                : Math.round(bytes / Math.pow(base, i), 2);
+        }
+
+        return value;
+    };
+
+    var getJson = function getJson(url, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('get', url, true);
+        xhr.responseType = 'json';
+
+        xhr.onload = function () {
+            var status = xhr.status;
+
+            if (status === 200) {
+                callback(null, xhr.response);
+            } else {
+                callback(status);
+            }
+        };
+
+        xhr.send();
+    };
+    /**
+     * Get all DOM element up the tree that contain a class, ID, or data attribute
+     * @param  {Node} elem The base element
+     * @param  {String} selector The class, id, data attribute, or tag to look for
+     * @return {Array} Null if no match
+     */
+
+    var getParents = function getParents(elem, selector) {
+        var parents = [],
+            firstChar;
+
+        if (selector) {
+            firstChar = selector.charAt(0);
+        } // Get matches
+
+        for (; elem && elem !== document; elem = elem.parentNode) {
+            if (selector) {
+                // If selector is a class
+                if (firstChar === '.') {
+                    if (elem.classList.contains(selector.substr(1))) {
+                        parents.push(elem);
+                    }
+                } // If selector is an ID
+
+                if (firstChar === '#') {
+                    if (elem.id === selector.substr(1)) {
+                        parents.push(elem);
+                    }
+                } // If selector is a data attribute
+
+                if (firstChar === '[') {
+                    if (elem.hasAttribute(selector.substr(1, selector.length - 1))) {
+                        parents.push(elem);
+                    }
+                } // If selector is a tag
+
+                if (elem.tagName.toLowerCase() === selector) {
+                    parents.push(elem);
+                }
+            } else {
+                parents.push(elem);
+            }
+        } // Return parents if any exist
+
+        if (parents.length === 0) {
+            return null;
+        }
+
+        return parents;
+    };
+
+    var getParentsUntil = function getParentsUntil(elem, parent, selector) {
+        var parents = [],
+            parentType,
+            selectorType;
+
+        if (parent) {
+            parentType = parent.charAt(0);
+        }
+
+        if (selector) {
+            selectorType = selector.charAt(0);
+        } // Get matches
+
+        for (; elem && elem !== document; elem = elem.parentNode) {
+            // Check if parent has been reached
+            if (parent) {
+                // If parent is a class
+                if (parentType === '.') {
+                    if (elem.classList.contains(parent.substr(1))) {
+                        break;
+                    }
+                } // If parent is an ID
+
+                if (parentType === '#') {
+                    if (elem.id === parent.substr(1)) {
+                        break;
+                    }
+                } // If parent is a data attribute
+
+                if (parentType === '[') {
+                    if (elem.hasAttribute(parent.substr(1, parent.length - 1))) {
+                        break;
+                    }
+                } // If parent is a tag
+
+                if (elem.tagName.toLowerCase() === parent) {
+                    break;
+                }
+            }
+
+            if (selector) {
+                // If selector is a class
+                if (selectorType === '.') {
+                    if (elem.classList.contains(selector.substr(1))) {
+                        parents.push(elem);
+                    }
+                } // If selector is an ID
+
+                if (selectorType === '#') {
+                    if (elem.id === selector.substr(1)) {
+                        parents.push(elem);
+                    }
+                } // If selector is a data attribute
+
+                if (selectorType === '[') {
+                    if (elem.hasAttribute(selector.substr(1, selector.length - 1))) {
+                        parents.push(elem);
+                    }
+                } // If selector is a tag
+
+                if (elem.tagName.toLowerCase() === selector) {
+                    parents.push(elem);
+                }
+            } else {
+                parents.push(elem);
+            }
+        } // Return parents if any exist
+
+        if (parents.length === 0) {
+            return null;
+        }
+
+        return parents;
+    };
+
+    var Util = /*#__PURE__*/ _createClass(function Util() {
+        _classCallCheck(this, Util);
+
+        this.addClass = addClass;
+        this.removeClass = removeClass;
+        this.hasClass = hasClass;
+        this.toggleClass = toggleClass;
+        this.addClassFor = addClassFor;
+        this.parseTemplate = parseTemplate;
+        this.triggerEvent = triggerEvent;
+        this.unique = unique;
+        this.closest = closest;
+        this.offset = offset;
+        this.insertAfter = insertAfter;
+        this.removeElement = removeElement;
+        this.isNumeric = isNumeric;
+        this.wrap = wrap;
+        this.stripTags = stripTags;
+        this.uniqueId = uniqueId;
+        this.uniqueName = uniqueName;
+        this.accurateNumber = accurateNumber;
+        this.limit = limit;
+        this.asArray = asArray;
+        this.countDecimals = countDecimals;
+        this.scrollTo = scrollTo;
+        this.randomIntFromInterval = randomIntFromInterval;
+        this.debounce = debounce;
+        this.throttle = throttle;
+        this.each = each;
+        this.exists = exists;
+        this.bytesToSize = bytesToSize;
+        this.getJson = getJson;
+        this.getParents = getParents;
+        this.getParentsUntil = getParentsUntil;
+    });
+
+    vl.util = new Util(); // Export single utils
+
+    var noJsClass = 'no-js',
+        jSclass = 'js'; // Remove no-js class, add js class
+
+    var _jsDetection = function _jsDetection() {
+        if (vl.util.hasClass(document.documentElement, noJsClass)) {
+            vl.util.removeClass(document.documentElement, noJsClass);
+        }
+
+        vl.util.addClass(document.documentElement, jSclass);
+    };
+
+    _jsDetection();
+
+    // Store setTimeout reference so promise-polyfill will be unaffected by
+    // other code modifying setTimeout (like sinon.useFakeTimers())
+    var setTimeoutFunc = setTimeout;
+
+    function noop() {} // Polyfill for Function.prototype.bind
+
+    function bind(fn, thisArg) {
+        return function () {
+            fn.apply(thisArg, arguments);
+        };
+    }
+
+    function handle(self, deferred) {
+        while (self._state === 3) {
+            self = self._value;
+        }
+
+        if (self._state === 0) {
+            self._deferreds.push(deferred);
+
+            return;
+        }
+
+        self._handled = true;
+
+        Promise$1._immediateFn(function () {
+            var cb = self._state === 1 ? deferred.onFulfilled : deferred.onRejected;
+
+            if (cb === null) {
+                (self._state === 1 ? resolve : reject)(deferred.promise, self._value);
+                return;
+            }
+
+            var ret;
+
+            try {
+                ret = cb(self._value);
+            } catch (e) {
+                reject(deferred.promise, e);
+                return;
+            }
+
+            resolve(deferred.promise, ret);
+        });
+    }
+
+    function resolve(self, newValue) {
+        try {
+            // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+            if (newValue === self) throw new TypeError('A promise cannot be resolved with itself.');
+
+            if (newValue && (_typeof(newValue) === 'object' || typeof newValue === 'function')) {
+                var then = newValue.then;
+
+                if (newValue instanceof Promise$1) {
+                    self._state = 3;
+                    self._value = newValue;
+                    finale(self);
+                    return;
+                } else if (typeof then === 'function') {
+                    doResolve(bind(then, newValue), self);
+                    return;
+                }
+            }
+
+            self._state = 1;
+            self._value = newValue;
+            finale(self);
+        } catch (e) {
+            reject(self, e);
+        }
+    }
+
+    function reject(self, newValue) {
+        self._state = 2;
+        self._value = newValue;
+        finale(self);
+    }
+
+    function finale(self) {
+        if (self._state === 2 && self._deferreds.length === 0) {
+            Promise$1._immediateFn(function () {
+                if (!self._handled) {
+                    Promise$1._unhandledRejectionFn(self._value);
+                }
+            });
+        }
+
+        for (var i = 0, len = self._deferreds.length; i < len; i++) {
+            handle(self, self._deferreds[i]);
+        }
+
+        self._deferreds = null;
+    }
+
+    function Handler(onFulfilled, onRejected, promise) {
+        this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
+        this.onRejected = typeof onRejected === 'function' ? onRejected : null;
+        this.promise = promise;
+    }
+
+    /**
+     * Take a potentially misbehaving resolver function and make sure
+     * onFulfilled and onRejected are only called once.
+     *
+     * Makes no guarantees about asynchrony.
+     */
+
+    function doResolve(fn, self) {
+        var done = false;
+
+        try {
+            fn(
+                function (value) {
+                    if (done) return;
+                    done = true;
+                    resolve(self, value);
+                },
+                function (reason) {
+                    if (done) return;
+                    done = true;
+                    reject(self, reason);
+                }
+            );
+        } catch (ex) {
+            if (done) return;
+            done = true;
+            reject(self, ex);
+        }
+    }
+
+    function Promise$1(fn) {
+        if (!(this instanceof Promise$1)) throw new TypeError('Promises must be constructed via new');
+        if (typeof fn !== 'function') throw new TypeError('not a function');
+        this._state = 0;
+        this._handled = false;
+        this._value = undefined;
+        this._deferreds = [];
+        doResolve(fn, this);
+    }
+
+    var _proto = Promise$1.prototype;
+
+    _proto.catch = function (onRejected) {
+        return this.then(null, onRejected);
+    };
+
+    _proto.then = function (onFulfilled, onRejected) {
+        var prom = new this.constructor(noop);
+        handle(this, new Handler(onFulfilled, onRejected, prom));
+        return prom;
+    };
+
+    Promise$1.all = function (arr) {
+        return new Promise$1(function (resolve, reject) {
+            if (!arr || typeof arr.length === 'undefined') throw new TypeError('Promise.all accepts an array');
+            var args = Array.prototype.slice.call(arr);
+            if (args.length === 0) return resolve([]);
+            var remaining = args.length;
+
+            function res(i, val) {
+                try {
+                    if (val && (_typeof(val) === 'object' || typeof val === 'function')) {
+                        var then = val.then;
+
+                        if (typeof then === 'function') {
+                            then.call(
+                                val,
+                                function (val) {
+                                    res(i, val);
+                                },
+                                reject
+                            );
+                            return;
+                        }
+                    }
+
+                    args[i] = val;
+
+                    if (--remaining === 0) {
+                        resolve(args);
+                    }
+                } catch (ex) {
+                    reject(ex);
+                }
+            }
+
+            for (var i = 0; i < args.length; i++) {
+                res(i, args[i]);
+            }
+        });
+    };
+
+    Promise$1.resolve = function (value) {
+        if (value && _typeof(value) === 'object' && value.constructor === Promise$1) {
+            return value;
+        }
+
+        return new Promise$1(function (resolve) {
+            resolve(value);
+        });
+    };
+
+    Promise$1.reject = function (value) {
+        return new Promise$1(function (resolve, reject) {
+            reject(value);
+        });
+    };
+
+    Promise$1.race = function (values) {
+        return new Promise$1(function (resolve, reject) {
+            for (var i = 0, len = values.length; i < len; i++) {
+                values[i].then(resolve, reject);
+            }
+        });
+    }; // Use polyfill for setImmediate for performance gains
+
+    Promise$1._immediateFn =
+        (typeof setImmediate === 'function' &&
+            function (fn) {
+                setImmediate(fn);
+            }) ||
+        function (fn) {
+            setTimeoutFunc(fn, 0);
+        };
+
+    Promise$1._unhandledRejectionFn = function _unhandledRejectionFn(err) {
+        if (typeof console !== 'undefined' && console) {
+            console.warn('Possible Unhandled Promise Rejection:', err); // eslint-disable-line no-console
+        }
+    };
+
+    /**
+     * Copyright 2016 Google Inc. All Rights Reserved.
+     *
+     * Licensed under the W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE.
+     *
+     *  https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+     *
+     */
+    (function (window, document) {
+        // features are natively supported.
+
+        if (
+            'IntersectionObserver' in window &&
+            'IntersectionObserverEntry' in window &&
+            'intersectionRatio' in window.IntersectionObserverEntry.prototype
+        ) {
+            // Minimal polyfill for Edge 15's lack of `isIntersecting`
+            // See: https://github.com/w3c/IntersectionObserver/issues/211
+            if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
+                Object.defineProperty(window.IntersectionObserverEntry.prototype, 'isIntersecting', {
+                    get: function get() {
+                        return this.intersectionRatio > 0;
+                    },
+                });
+            }
+
+            return;
+        }
+
+        /**
+         * Creates the global IntersectionObserverEntry constructor.
+         * https://w3c.github.io/IntersectionObserver/#intersection-observer-entry
+         * @param {Object} entry A dictionary of instance properties.
+         * @constructor
+         */
+
+        function IntersectionObserverEntry(entry) {
+            this.time = entry.time;
+            this.target = entry.target;
+            this.rootBounds = entry.rootBounds;
+            this.boundingClientRect = entry.boundingClientRect;
+            this.intersectionRect = entry.intersectionRect || getEmptyRect();
+            this.isIntersecting = !!entry.intersectionRect; // Calculates the intersection ratio.
+
+            var targetRect = this.boundingClientRect;
+            var targetArea = targetRect.width * targetRect.height;
+            var intersectionRect = this.intersectionRect;
+            var intersectionArea = intersectionRect.width * intersectionRect.height; // Sets intersection ratio.
+
+            if (targetArea) {
+                // Round the intersection ratio to avoid floating point math issues:
+                // https://github.com/w3c/IntersectionObserver/issues/324
+                this.intersectionRatio = Number((intersectionArea / targetArea).toFixed(4));
+            } else {
+                // If area is zero and is intersecting, sets to 1, otherwise to 0
+                this.intersectionRatio = this.isIntersecting ? 1 : 0;
+            }
+        }
+
+        /**
+         * Creates the global IntersectionObserver constructor.
+         * https://w3c.github.io/IntersectionObserver/#intersection-observer-interface
+         * @param {Function} callback The function to be invoked after intersection
+         *     changes have queued. The function is not invoked if the queue has
+         *     been emptied by calling the `takeRecords` method.
+         * @param {Object=} opt_options Optional configuration options.
+         * @constructor
+         */
+
+        function IntersectionObserver(callback, opt_options) {
+            var options = opt_options || {};
+
+            if (typeof callback != 'function') {
+                throw new Error('callback must be a function');
+            }
+
+            if (options.root && options.root.nodeType != 1) {
+                throw new Error('root must be an Element');
+            } // Binds and throttles `this._checkForIntersections`.
+
+            this._checkForIntersections = throttle(this._checkForIntersections.bind(this), this.THROTTLE_TIMEOUT); // Private properties.
+
+            this._callback = callback;
+            this._observationTargets = [];
+            this._queuedEntries = [];
+            this._rootMarginValues = this._parseRootMargin(options.rootMargin); // Public properties.
+
+            this.thresholds = this._initThresholds(options.threshold);
+            this.root = options.root || null;
+            this.rootMargin = this._rootMarginValues
+                .map(function (margin) {
+                    return margin.value + margin.unit;
+                })
+                .join(' ');
+        }
+
+        /**
+         * The minimum interval within which the document will be checked for
+         * intersection changes.
+         */
+
+        IntersectionObserver.prototype.THROTTLE_TIMEOUT = 100;
+        /**
+         * The frequency in which the polyfill polls for intersection changes.
+         * this can be updated on a per instance basis and must be set prior to
+         * calling `observe` on the first target.
+         */
+
+        IntersectionObserver.prototype.POLL_INTERVAL = null;
+        /**
+         * Use a mutation observer on the root element
+         * to detect intersection changes.
+         */
+
+        IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
+        /**
+         * Starts observing a target element for intersection changes based on
+         * the thresholds values.
+         * @param {Element} target The DOM element to observe.
+         */
+
+        IntersectionObserver.prototype.observe = function (target) {
+            var isTargetAlreadyObserved = this._observationTargets.some(function (item) {
+                return item.element == target;
+            });
+
+            if (isTargetAlreadyObserved) {
+                return;
+            }
+
+            if (!(target && target.nodeType == 1)) {
+                throw new Error('target must be an Element');
+            }
+
+            this._registerInstance();
+
+            this._observationTargets.push({
+                element: target,
+                entry: null,
+            });
+
+            this._monitorIntersections();
+
+            this._checkForIntersections();
+        };
+        /**
+         * Stops observing a target element for intersection changes.
+         * @param {Element} target The DOM element to observe.
+         */
+
+        IntersectionObserver.prototype.unobserve = function (target) {
+            this._observationTargets = this._observationTargets.filter(function (item) {
+                return item.element != target;
+            });
+
+            if (!this._observationTargets.length) {
+                this._unmonitorIntersections();
+
+                this._unregisterInstance();
+            }
+        };
+        /**
+         * Stops observing all target elements for intersection changes.
+         */
+
+        IntersectionObserver.prototype.disconnect = function () {
+            this._observationTargets = [];
+
+            this._unmonitorIntersections();
+
+            this._unregisterInstance();
+        };
+        /**
+         * Returns any queue entries that have not yet been reported to the
+         * callback and clears the queue. This can be used in conjunction with the
+         * callback to obtain the absolute most up-to-date intersection information.
+         * @return {Array} The currently queued entries.
+         */
+
+        IntersectionObserver.prototype.takeRecords = function () {
+            var records = this._queuedEntries.slice();
+
+            this._queuedEntries = [];
+            return records;
+        };
+        /**
+         * Accepts the threshold value from the user configuration object and
+         * returns a sorted array of unique threshold values. If a value is not
+         * between 0 and 1 and error is thrown.
+         * @private
+         * @param {Array|number=} opt_threshold An optional threshold value or
+         *     a list of threshold values, defaulting to [0].
+         * @return {Array} A sorted list of unique and valid threshold values.
+         */
+
+        IntersectionObserver.prototype._initThresholds = function (opt_threshold) {
+            var threshold = opt_threshold || [0];
+            if (!Array.isArray(threshold)) threshold = [threshold];
+            return threshold.sort().filter(function (t, i, a) {
+                if (typeof t != 'number' || isNaN(t) || t < 0 || t > 1) {
+                    throw new Error('threshold must be a number between 0 and 1 inclusively');
+                }
+
+                return t !== a[i - 1];
+            });
+        };
+        /**
+         * Accepts the rootMargin value from the user configuration object
+         * and returns an array of the four margin values as an object containing
+         * the value and unit properties. If any of the values are not properly
+         * formatted or use a unit other than px or %, and error is thrown.
+         * @private
+         * @param {string=} opt_rootMargin An optional rootMargin value,
+         *     defaulting to '0px'.
+         * @return {Array<Object>} An array of margin objects with the keys
+         *     value and unit.
+         */
+
+        IntersectionObserver.prototype._parseRootMargin = function (opt_rootMargin) {
+            var marginString = opt_rootMargin || '0px';
+            var margins = marginString.split(/\s+/).map(function (margin) {
+                var parts = /^(-?\d*\.?\d+)(px|%)$/.exec(margin);
+
+                if (!parts) {
+                    throw new Error('rootMargin must be specified in pixels or percent');
+                }
+
+                return {
+                    value: parseFloat(parts[1]),
+                    unit: parts[2],
+                };
+            }); // Handles shorthand.
+
+            margins[1] = margins[1] || margins[0];
+            margins[2] = margins[2] || margins[0];
+            margins[3] = margins[3] || margins[1];
+            return margins;
+        };
+        /**
+         * Starts polling for intersection changes if the polling is not already
+         * happening, and if the page's visibility state is visible.
+         * @private
+         */
+
+        IntersectionObserver.prototype._monitorIntersections = function () {
+            if (!this._monitoringIntersections) {
+                this._monitoringIntersections = true; // If a poll interval is set, use polling instead of listening to
+                // resize and scroll events or DOM mutations.
+
+                if (this.POLL_INTERVAL) {
+                    this._monitoringInterval = setInterval(this._checkForIntersections, this.POLL_INTERVAL);
+                } else {
+                    addEvent(window, 'resize', this._checkForIntersections, true);
+                    addEvent(document, 'scroll', this._checkForIntersections, true);
+
+                    if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in window) {
+                        this._domObserver = new MutationObserver(this._checkForIntersections);
+
+                        this._domObserver.observe(document, {
+                            attributes: true,
+                            childList: true,
+                            characterData: true,
+                            subtree: true,
+                        });
+                    }
+                }
+            }
+        };
+        /**
+         * Stops polling for intersection changes.
+         * @private
+         */
+
+        IntersectionObserver.prototype._unmonitorIntersections = function () {
+            if (this._monitoringIntersections) {
+                this._monitoringIntersections = false;
+                clearInterval(this._monitoringInterval);
+                this._monitoringInterval = null;
+                removeEvent(window, 'resize', this._checkForIntersections, true);
+                removeEvent(document, 'scroll', this._checkForIntersections, true);
+
+                if (this._domObserver) {
+                    this._domObserver.disconnect();
+
+                    this._domObserver = null;
+                }
+            }
+        };
+        /**
+         * Scans each observation target for intersection changes and adds them
+         * to the internal entries queue. If new entries are found, it
+         * schedules the callback to be invoked.
+         * @private
+         */
+
+        IntersectionObserver.prototype._checkForIntersections = function () {
+            var rootIsInDom = this._rootIsInDom();
+
+            var rootRect = rootIsInDom ? this._getRootRect() : getEmptyRect();
+
+            this._observationTargets.forEach(function (item) {
+                var target = item.element;
+                var targetRect = getBoundingClientRect(target);
+
+                var rootContainsTarget = this._rootContainsTarget(target);
+
+                var oldEntry = item.entry;
+
+                var intersectionRect =
+                    rootIsInDom && rootContainsTarget && this._computeTargetAndRootIntersection(target, rootRect);
+
+                var newEntry = (item.entry = new IntersectionObserverEntry({
+                    time: now(),
+                    target: target,
+                    boundingClientRect: targetRect,
+                    rootBounds: rootRect,
+                    intersectionRect: intersectionRect,
+                }));
+
+                if (!oldEntry) {
+                    this._queuedEntries.push(newEntry);
+                } else if (rootIsInDom && rootContainsTarget) {
+                    // If the new entry intersection ratio has crossed any of the
+                    // thresholds, add a new entry.
+                    if (this._hasCrossedThreshold(oldEntry, newEntry)) {
+                        this._queuedEntries.push(newEntry);
+                    }
+                } else {
+                    // If the root is not in the DOM or target is not contained within
+                    // root but the previous entry for this target had an intersection,
+                    // add a new record indicating removal.
+                    if (oldEntry && oldEntry.isIntersecting) {
+                        this._queuedEntries.push(newEntry);
+                    }
+                }
+            }, this);
+
+            if (this._queuedEntries.length) {
+                this._callback(this.takeRecords(), this);
+            }
+        };
+        /**
+         * Accepts a target and root rect computes the intersection between then
+         * following the algorithm in the spec.
+         * TODO(philipwalton): at this time clip-path is not considered.
+         * https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo
+         * @param {Element} target The target DOM element
+         * @param {Object} rootRect The bounding rect of the root after being
+         *     expanded by the rootMargin value.
+         * @return {?Object} The final intersection rect object or undefined if no
+         *     intersection is found.
+         * @private
+         */
+
+        IntersectionObserver.prototype._computeTargetAndRootIntersection = function (target, rootRect) {
+            // If the element isn't displayed, an intersection can't happen.
+            if (window.getComputedStyle(target).display == 'none') return;
+            var targetRect = getBoundingClientRect(target);
+            var intersectionRect = targetRect;
+            var parent = getParentNode(target);
+            var atRoot = false;
+
+            while (!atRoot) {
+                var parentRect = null;
+                var parentComputedStyle = parent.nodeType == 1 ? window.getComputedStyle(parent) : {}; // If the parent isn't displayed, an intersection can't happen.
+
+                if (parentComputedStyle.display == 'none') return;
+
+                if (parent == this.root || parent == document) {
+                    atRoot = true;
+                    parentRect = rootRect;
+                } else {
+                    // If the element has a non-visible overflow, and it's not the <body>
+                    // or <html> element, update the intersection rect.
+                    // Note: <body> and <html> cannot be clipped to a rect that's not also
+                    // the document rect, so no need to compute a new intersection.
+                    if (
+                        parent != document.body &&
+                        parent != document.documentElement &&
+                        parentComputedStyle.overflow != 'visible'
+                    ) {
+                        parentRect = getBoundingClientRect(parent);
+                    }
+                } // If either of the above conditionals set a new parentRect,
+                // calculate new intersection data.
+
+                if (parentRect) {
+                    intersectionRect = computeRectIntersection(parentRect, intersectionRect);
+                    if (!intersectionRect) break;
+                }
+
+                parent = getParentNode(parent);
+            }
+
+            return intersectionRect;
+        };
+        /**
+         * Returns the root rect after being expanded by the rootMargin value.
+         * @return {Object} The expanded root rect.
+         * @private
+         */
+
+        IntersectionObserver.prototype._getRootRect = function () {
+            var rootRect;
+
+            if (this.root) {
+                rootRect = getBoundingClientRect(this.root);
+            } else {
+                // Use <html>/<body> instead of window since scroll bars affect size.
+                var html = document.documentElement;
+                var body = document.body;
+                rootRect = {
+                    top: 0,
+                    left: 0,
+                    right: html.clientWidth || body.clientWidth,
+                    width: html.clientWidth || body.clientWidth,
+                    bottom: html.clientHeight || body.clientHeight,
+                    height: html.clientHeight || body.clientHeight,
+                };
+            }
+
+            return this._expandRectByRootMargin(rootRect);
+        };
+        /**
+         * Accepts a rect and expands it by the rootMargin value.
+         * @param {Object} rect The rect object to expand.
+         * @return {Object} The expanded rect.
+         * @private
+         */
+
+        IntersectionObserver.prototype._expandRectByRootMargin = function (rect) {
+            var margins = this._rootMarginValues.map(function (margin, i) {
+                return margin.unit == 'px' ? margin.value : (margin.value * (i % 2 ? rect.width : rect.height)) / 100;
+            });
+
+            var newRect = {
+                top: rect.top - margins[0],
+                right: rect.right + margins[1],
+                bottom: rect.bottom + margins[2],
+                left: rect.left - margins[3],
+            };
+            newRect.width = newRect.right - newRect.left;
+            newRect.height = newRect.bottom - newRect.top;
+            return newRect;
+        };
+        /**
+         * Accepts an old and new entry and returns true if at least one of the
+         * threshold values has been crossed.
+         * @param {?IntersectionObserverEntry} oldEntry The previous entry for a
+         *    particular target element or null if no previous entry exists.
+         * @param {IntersectionObserverEntry} newEntry The current entry for a
+         *    particular target element.
+         * @return {boolean} Returns true if a any threshold has been crossed.
+         * @private
+         */
+
+        IntersectionObserver.prototype._hasCrossedThreshold = function (oldEntry, newEntry) {
+            // To make comparing easier, an entry that has a ratio of 0
+            // but does not actually intersect is given a value of -1
+            var oldRatio = oldEntry && oldEntry.isIntersecting ? oldEntry.intersectionRatio || 0 : -1;
+            var newRatio = newEntry.isIntersecting ? newEntry.intersectionRatio || 0 : -1; // Ignore unchanged ratios
+
+            if (oldRatio === newRatio) return;
+
+            for (var i = 0; i < this.thresholds.length; i++) {
+                var threshold = this.thresholds[i]; // Return true if an entry matches a threshold or if the new ratio
+                // and the old ratio are on the opposite sides of a threshold.
+
+                if (threshold == oldRatio || threshold == newRatio || threshold < oldRatio !== threshold < newRatio) {
+                    return true;
+                }
+            }
+        };
+        /**
+         * Returns whether or not the root element is an element and is in the DOM.
+         * @return {boolean} True if the root element is an element and is in the DOM.
+         * @private
+         */
+
+        IntersectionObserver.prototype._rootIsInDom = function () {
+            return !this.root || containsDeep(document, this.root);
+        };
+        /**
+         * Returns whether or not the target element is a child of root.
+         * @param {Element} target The target element to check.
+         * @return {boolean} True if the target element is a child of root.
+         * @private
+         */
+
+        IntersectionObserver.prototype._rootContainsTarget = function (target) {
+            return containsDeep(this.root || document, target);
+        };
+        /**
+         * Adds the instance to the global IntersectionObserver registry if it isn't
+         * already present.
+         * @private
+         */
+
+        IntersectionObserver.prototype._registerInstance = function () {};
+        /**
+         * Removes the instance from the global IntersectionObserver registry.
+         * @private
+         */
+
+        IntersectionObserver.prototype._unregisterInstance = function () {};
+
+        /**
+         * Returns the result of the performance.now() method or null in browsers
+         * that don't support the API.
+         * @return {number} The elapsed time since the page was requested.
+         */
+
+        function now() {
+            return window.performance && performance.now && performance.now();
+        }
+
+        /**
+         * Throttles a function and delays its execution, so it's only called at most
+         * once within a given time period.
+         * @param {Function} fn The function to throttle.
+         * @param {number} timeout The amount of time that must pass before the
+         *     function can be called again.
+         * @return {Function} The throttled function.
+         */
+
+        function throttle(fn, timeout) {
+            var timer = null;
+            return function () {
+                if (!timer) {
+                    timer = setTimeout(function () {
+                        fn();
+                        timer = null;
+                    }, timeout);
+                }
+            };
+        }
+
+        /**
+         * Adds an event handler to a DOM node ensuring cross-browser compatibility.
+         * @param {Node} node The DOM node to add the event handler to.
+         * @param {string} event The event name.
+         * @param {Function} fn The event handler to add.
+         * @param {boolean} opt_useCapture Optionally adds the even to the capture
+         *     phase. Note: this only works in modern browsers.
+         */
+
+        function addEvent(node, event, fn, opt_useCapture) {
+            if (typeof node.addEventListener == 'function') {
+                node.addEventListener(event, fn, opt_useCapture || false);
+            } else if (typeof node.attachEvent == 'function') {
+                node.attachEvent('on' + event, fn);
+            }
+        }
+
+        /**
+         * Removes a previously added event handler from a DOM node.
+         * @param {Node} node The DOM node to remove the event handler from.
+         * @param {string} event The event name.
+         * @param {Function} fn The event handler to remove.
+         * @param {boolean} opt_useCapture If the event handler was added with this
+         *     flag set to true, it should be set to true here in order to remove it.
+         */
+
+        function removeEvent(node, event, fn, opt_useCapture) {
+            if (typeof node.removeEventListener == 'function') {
+                node.removeEventListener(event, fn, opt_useCapture || false);
+            } else if (typeof node.detatchEvent == 'function') {
+                node.detatchEvent('on' + event, fn);
+            }
+        }
+
+        /**
+         * Returns the intersection between two rect objects.
+         * @param {Object} rect1 The first rect.
+         * @param {Object} rect2 The second rect.
+         * @return {?Object} The intersection rect or undefined if no intersection
+         *     is found.
+         */
+
+        function computeRectIntersection(rect1, rect2) {
+            var top = Math.max(rect1.top, rect2.top);
+            var bottom = Math.min(rect1.bottom, rect2.bottom);
+            var left = Math.max(rect1.left, rect2.left);
+            var right = Math.min(rect1.right, rect2.right);
+            var width = right - left;
+            var height = bottom - top;
+            return (
+                width >= 0 &&
+                height >= 0 && {
+                    top: top,
+                    bottom: bottom,
+                    left: left,
+                    right: right,
+                    width: width,
+                    height: height,
+                }
+            );
+        }
+
+        /**
+         * Shims the native getBoundingClientRect for compatibility with older IE.
+         * @param {Element} el The element whose bounding rect to get.
+         * @return {Object} The (possibly shimmed) rect of the element.
+         */
+
+        function getBoundingClientRect(el) {
+            var rect;
+
+            try {
+                rect = el.getBoundingClientRect();
+            } catch (err) {
+                // Ignore Windows 7 IE11 "Unspecified error"
+                // https://github.com/w3c/IntersectionObserver/pull/205
+            }
+
+            if (!rect) return getEmptyRect(); // Older IE
+
+            if (!(rect.width && rect.height)) {
+                rect = {
+                    top: rect.top,
+                    right: rect.right,
+                    bottom: rect.bottom,
+                    left: rect.left,
+                    width: rect.right - rect.left,
+                    height: rect.bottom - rect.top,
+                };
+            }
+
+            return rect;
+        }
+
+        /**
+         * Returns an empty rect object. An empty rect is returned when an element
+         * is not in the DOM.
+         * @return {Object} The empty rect.
+         */
+
+        function getEmptyRect() {
+            return {
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+                width: 0,
+                height: 0,
+            };
+        }
+
+        /**
+         * Checks to see if a parent element contains a child element (including inside
+         * shadow DOM).
+         * @param {Node} parent The parent element.
+         * @param {Node} child The child element.
+         * @return {boolean} True if the parent node contains the child node.
+         */
+
+        function containsDeep(parent, child) {
+            var node = child;
+
+            while (node) {
+                if (node == parent) return true;
+                node = getParentNode(node);
+            }
+
+            return false;
+        }
+
+        /**
+         * Gets the parent node of an element or its host element if the parent node
+         * is a shadow root.
+         * @param {Node} node The node whose parent to get.
+         * @return {Node|null} The parent node or null if no parent exists.
+         */
+
+        function getParentNode(node) {
+            var parent = node.parentNode;
+
+            if (parent && parent.nodeType == 11 && parent.host) {
+                // If the parent is a shadow root, return the host element.
+                return parent.host;
+            }
+
+            return parent;
+        } // Exposes the constructors globally.
+
+        window.IntersectionObserver = IntersectionObserver;
+        window.IntersectionObserverEntry = IntersectionObserverEntry;
+    })(window, document);
+
+    /*
+     * classList.js: Cross-browser full element.classList implementation.
+     * 1.1.20170427
+     *
+     * By Eli Grey, http://eligrey.com
+     * License: Dedicated to the public domain.
+     *   See https://github.com/eligrey/classList.js/blob/master/LICENSE.md
+     */
+
+    /*global self, document, DOMException */
+
+    /*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js */
+    if ('document' in window.self) {
+        // Full polyfill for browsers with no classList support
+        // Including IE < Edge missing SVGElement.classList
+        if (
+            !('classList' in document.createElement('_')) ||
+            (document.createElementNS && !('classList' in document.createElementNS('http://www.w3.org/2000/svg', 'g')))
+        ) {
+            (function (view) {
+                if (!('Element' in view)) return;
+
+                var classListProp = 'classList',
+                    protoProp = 'prototype',
+                    elemCtrProto = view.Element[protoProp],
+                    objCtr = Object,
+                    strTrim =
+                        String[protoProp].trim ||
+                        function () {
+                            return this.replace(/^\s+|\s+$/g, '');
+                        },
+                    arrIndexOf =
+                        Array[protoProp].indexOf ||
+                        function (item) {
+                            var i = 0,
+                                len = this.length;
+
+                            for (; i < len; i++) {
+                                if (i in this && this[i] === item) {
+                                    return i;
+                                }
+                            }
+
+                            return -1;
+                        }, // Vendors: please allow content code to instantiate DOMExceptions
+                    DOMEx = function DOMEx(type, message) {
+                        this.name = type;
+                        this.code = DOMException[type];
+                        this.message = message;
+                    },
+                    checkTokenAndGetIndex = function checkTokenAndGetIndex(classList, token) {
+                        if (token === '') {
+                            throw new DOMEx('SYNTAX_ERR', 'An invalid or illegal string was specified');
+                        }
+
+                        if (/\s/.test(token)) {
+                            throw new DOMEx('INVALID_CHARACTER_ERR', 'String contains an invalid character');
+                        }
+
+                        return arrIndexOf.call(classList, token);
+                    },
+                    ClassList = function ClassList(elem) {
+                        var trimmedClasses = strTrim.call(elem.getAttribute('class') || ''),
+                            classes = trimmedClasses ? trimmedClasses.split(/\s+/) : [],
+                            i = 0,
+                            len = classes.length;
+
+                        for (; i < len; i++) {
+                            this.push(classes[i]);
+                        }
+
+                        this._updateClassName = function () {
+                            elem.setAttribute('class', this.toString());
+                        };
+                    },
+                    classListProto = (ClassList[protoProp] = []),
+                    classListGetter = function classListGetter() {
+                        return new ClassList(this);
+                    }; // Most DOMException implementations don't allow calling DOMException's toString()
+                // on non-DOMExceptions. Error's toString() is sufficient here.
+
+                DOMEx[protoProp] = Error[protoProp];
+
+                classListProto.item = function (i) {
+                    return this[i] || null;
+                };
+
+                classListProto.contains = function (token) {
+                    token += '';
+                    return checkTokenAndGetIndex(this, token) !== -1;
+                };
+
+                classListProto.add = function () {
+                    var tokens = arguments,
+                        i = 0,
+                        l = tokens.length,
+                        token,
+                        updated = false;
+
+                    do {
+                        token = tokens[i] + '';
+
+                        if (checkTokenAndGetIndex(this, token) === -1) {
+                            this.push(token);
+                            updated = true;
+                        }
+                    } while (++i < l);
+
+                    if (updated) {
+                        this._updateClassName();
+                    }
+                };
+
+                classListProto.remove = function () {
+                    var tokens = arguments,
+                        i = 0,
+                        l = tokens.length,
+                        token,
+                        updated = false,
+                        index;
+
+                    do {
+                        token = tokens[i] + '';
+                        index = checkTokenAndGetIndex(this, token);
+
+                        while (index !== -1) {
+                            this.splice(index, 1);
+                            updated = true;
+                            index = checkTokenAndGetIndex(this, token);
+                        }
+                    } while (++i < l);
+
+                    if (updated) {
+                        this._updateClassName();
+                    }
+                };
+
+                classListProto.toggle = function (token, force) {
+                    token += '';
+                    var result = this.contains(token),
+                        method = result ? force !== true && 'remove' : force !== false && 'add';
+
+                    if (method) {
+                        this[method](token);
+                    }
+
+                    if (force === true || force === false) {
+                        return force;
+                    } else {
+                        return !result;
+                    }
+                };
+
+                classListProto.toString = function () {
+                    return this.join(' ');
+                };
+
+                if (objCtr.defineProperty) {
+                    var classListPropDesc = {
+                        get: classListGetter,
+                        enumerable: true,
+                        configurable: true,
+                    };
+
+                    try {
+                        objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+                    } catch (ex) {
+                        // IE 8 doesn't support enumerable:true
+                        // adding undefined to fight this issue https://github.com/eligrey/classList.js/issues/36
+                        // modernie IE8-MSW7 machine has IE8 8.0.6001.18702 and is affected
+                        if (ex.number === undefined || ex.number === -0x7ff5ec54) {
+                            classListPropDesc.enumerable = false;
+                            objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+                        }
+                    }
+                } else if (objCtr[protoProp].__defineGetter__) {
+                    elemCtrProto.__defineGetter__(classListProp, classListGetter);
+                }
+            })(window.self);
+        } // There is full or partial native classList support, so just check if we need
+        // to normalize the add/remove and toggle APIs.
+
+        (function () {
+            var testElement = document.createElement('_');
+            testElement.classList.add('c1', 'c2'); // Polyfill for IE 10/11 and Firefox <26, where classList.add and
+            // classList.remove exist but support only one argument at a time.
+
+            if (!testElement.classList.contains('c2')) {
+                var createMethod = function createMethod(method) {
+                    var original = DOMTokenList.prototype[method];
+
+                    DOMTokenList.prototype[method] = function (token) {
+                        var i,
+                            len = arguments.length;
+
+                        for (i = 0; i < len; i++) {
+                            token = arguments[i];
+                            original.call(this, token);
+                        }
+                    };
+                };
+
+                createMethod('add');
+                createMethod('remove');
+            }
+
+            testElement.classList.toggle('c3', false); // Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+            // support the second argument.
+
+            if (testElement.classList.contains('c3')) {
+                var _toggle = DOMTokenList.prototype.toggle;
+
+                DOMTokenList.prototype.toggle = function (token, force) {
+                    if (1 in arguments && !this.contains(token) === !force) {
+                        return force;
+                    } else {
+                        return _toggle.call(this, token);
+                    }
+                };
+            }
+
+            testElement = null;
+        })();
+    }
+
+    /* eslint-disable */
+    // Production steps of ECMA-262, Edition 6, 22.1.2.1
+    if (!Array.from) {
+        Array.from = (function () {
+            var toStr = Object.prototype.toString;
+
+            var isCallable = function isCallable(fn) {
+                return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+            };
+
+            var toInteger = function toInteger(value) {
+                var number = Number(value);
+
+                if (isNaN(number)) {
+                    return 0;
+                }
+
+                if (number === 0 || !isFinite(number)) {
+                    return number;
+                }
+
+                return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+            };
+
+            var maxSafeInteger = Math.pow(2, 53) - 1;
+
+            var toLength = function toLength(value) {
+                var len = toInteger(value);
+                return Math.min(Math.max(len, 0), maxSafeInteger);
+            }; // The length property of the from method is 1.
+
+            return function from(
+                arrayLike
+                /*, mapFn, thisArg */
+            ) {
+                // 1. Let C be the this value.
+                var C = this; // 2. Let items be ToObject(arrayLike).
+
+                var items = Object(arrayLike); // 3. ReturnIfAbrupt(items).
+
+                if (arrayLike == null) {
+                    throw new TypeError('Array.from requires an array-like object - not null or undefined');
+                } // 4. If mapfn is undefined, then let mapping be false.
+
+                var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+                var T;
+
+                if (typeof mapFn !== 'undefined') {
+                    // 5. else
+                    // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+                    if (!isCallable(mapFn)) {
+                        throw new TypeError('Array.from: when provided, the second argument must be a function');
+                    } // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+
+                    if (arguments.length > 2) {
+                        T = arguments[2];
+                    }
+                } // 10. Let lenValue be Get(items, "length").
+                // 11. Let len be ToLength(lenValue).
+
+                var len = toLength(items.length); // 13. If IsConstructor(C) is true, then
+                // 13. a. Let A be the result of calling the [[Construct]] internal method
+                // of C with an argument list containing the single item len.
+                // 14. a. Else, Let A be ArrayCreate(len).
+
+                var A = isCallable(C) ? Object(new C(len)) : new Array(len); // 16. Let k be 0.
+
+                var k = 0; // 17. Repeat, while k < len… (also steps a - h)
+
+                var kValue;
+
+                while (k < len) {
+                    kValue = items[k];
+
+                    if (mapFn) {
+                        A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+                    } else {
+                        A[k] = kValue;
+                    }
+
+                    k += 1;
+                } // 18. Let putStatus be Put(A, "length", len, true).
+
+                A.length = len; // 20. Return A.
+
+                return A;
+            };
+        })();
+    }
+
+    /* eslint-disable */
+    // closest polyfill
+    (function (ElementProto) {
+        if (typeof ElementProto.matches !== 'function') {
+            ElementProto.matches =
+                ElementProto.msMatchesSelector ||
+                ElementProto.mozMatchesSelector ||
+                ElementProto.webkitMatchesSelector ||
+                function matches(selector) {
+                    var element = this;
+                    var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
+                    var index = 0;
+
+                    while (elements[index] && elements[index] !== element) {
+                        ++index;
+                    }
+
+                    return Boolean(elements[index]);
+                };
+        }
+
+        if (typeof ElementProto.closest !== 'function') {
+            ElementProto.closest = function closest(selector) {
+                var element = this;
+
+                while (element && element.nodeType === 1) {
+                    if (element.matches(selector)) {
+                        return element;
+                    }
+
+                    element = element.parentNode;
+                }
+
+                return null;
+            };
+        }
+    })(window.Element.prototype);
+
+    /* eslint-disable no-extend-native */
+    // falback for foreach
+    if (!Array.prototype.forEach) {
+        Array.prototype.forEach = function (callback, thisArg) {
+            var T, k;
+
+            if (this === null) {
+                throw new TypeError(' this is null or not defined');
+            } // 1. Let O be the result of calling ToObject passing the |this| value as the argument.
+
+            var O = Object(this); // 2. Let lenValue be the result of calling the Get internal method of O with the argument "length".
+            // 3. Let len be ToUint32(lenValue).
+
+            var len = O.length >>> 0; // 4. If IsCallable(callback) is false, throw a TypeError exception.
+            // See: http://es5.github.com/#x9.11
+
+            if (typeof callback !== 'function') {
+                throw new TypeError(''.concat(callback, ' is not a function'));
+            } // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+
+            if (arguments.length > 1) {
+                T = thisArg;
+            } // 6. Let k be 0
+
+            k = 0; // 7. Repeat, while k < len
+
+            while (k < len) {
+                var kValue = void 0; // a. Let Pk be ToString(k).
+                //   This is implicit for LHS operands of the in operator
+                // b. Let kPresent be the result of calling the HasProperty internal method of O with argument Pk.
+                //   This step can be combined with c
+                // c. If kPresent is true, then
+
+                if (k in O) {
+                    // i. Let kValue be the result of calling the Get internal method of O with argument Pk.
+                    kValue = O[k]; // ii. Call the Call internal method of callback with T as the this value and
+                    // argument list containing kValue, k, and O.
+
+                    callback.call(T, kValue, k, O);
+                } // d. Increase k by 1.
+
+                k++;
+            } // 8. return undefined
+        };
+    }
+
+    /* eslint-disable */
+    // Array.prototype.map polyfill
+    // code from https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map
+    if (!Array.prototype.map) {
+        Array.prototype.map = function (
+            fun
+            /* , thisArg */
+        ) {
+            if (this === void 0 || this === null) {
+                throw new TypeError();
+            }
+
+            var t = Object(this);
+            var len = t.length >>> 0;
+
+            if (typeof fun !== 'function') {
+                throw new TypeError();
+            }
+
+            var res = new Array(len);
+            var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+
+            for (var i = 0; i < len; i++) {
+                // NOTE: Absolute correctness would demand Object.defineProperty
+                //       be used.  But this method is fairly new, and failure is
+                //       possible only if Object.prototype or Array.prototype
+                //       has a property |i| (very unlikely), so use a less-correct
+                //       but more portable alternative.
+                if (i in t) {
+                    res[i] = fun.call(thisArg, t[i], i, t);
+                }
+            }
+
+            return res;
+        };
+    }
+
+    /* eslint-disable */
+    if (typeof Object.assign !== 'function') {
+        // Must be writable: true, enumerable: false, configurable: true
+        Object.defineProperty(Object, 'assign', {
+            value: function assign(target, varArgs) {
+                // .length of function is 2
+                if (target == null) {
+                    // TypeError if undefined or null
+                    throw new TypeError('Cannot convert undefined or null to object');
+                }
+
+                var to = Object(target);
+
+                for (var index = 1; index < arguments.length; index++) {
+                    var nextSource = arguments[index];
+
+                    if (nextSource != null) {
+                        // Skip over if undefined or null
+                        for (var nextKey in nextSource) {
+                            // Avoid bugs when hasOwnProperty is shadowed
+                            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                                to[nextKey] = nextSource[nextKey];
+                            }
+                        }
+                    }
+                }
+
+                return to;
+            },
+            writable: true,
+            configurable: true,
+        });
+    }
+
+    /* eslint-disable */
+    (function () {
+        if ('content' in document.createElement('template')) {
+            return false;
+        }
+
+        var templates = document.getElementsByTagName('template');
+        var plateLen = templates.length;
+
+        for (var x = 0; x < plateLen; ++x) {
+            var template = templates[x];
+            var content = template.childNodes;
+            var fragment = document.createDocumentFragment();
+
+            while (content[0]) {
+                fragment.appendChild(content[0]);
+            }
+
+            template.content = fragment;
+        }
+    })();
+
+    // trunc polyfill
+    Math.trunc =
+        Math.trunc ||
+        function (x) {
+            return x < 0 ? Math.ceil(x) : Math.floor(x);
+        };
+
+    // source: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+    (function () {
+        if (typeof window.CustomEvent === 'function') {
+            return false;
+        }
+
+        function CustomEvent(event, params) {
+            params = params || {
+                bubbles: false,
+                cancelable: false,
+                detail: undefined,
+            };
+            var evt = document.createEvent('CustomEvent');
+            evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+            return evt;
+        }
+
+        CustomEvent.prototype = window.Event.prototype;
+        window.CustomEvent = CustomEvent;
+    })();
+
+    if (!Array.prototype.includes) {
+        Array.prototype.includes = function (el) {
+            var returnValue = false;
+
+            if (this.indexOf(el) !== -1) {
+                returnValue = true;
+            }
+
+            return returnValue;
+        };
+    }
+
+    // https://tc39.github.io/ecma262/#sec-array.prototype.find
+    if (!Array.prototype.find) {
+        Object.defineProperty(Array.prototype, 'find', {
+            value: function value(predicate) {
+                // 1. Let O be ? ToObject(this value).
+                if (this == null) {
+                    throw TypeError('"this" is null or not defined');
+                }
+
+                var o = Object(this); // 2. Let len be ? ToLength(? Get(O, "length")).
+
+                var len = o.length >>> 0; // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+
+                if (typeof predicate !== 'function') {
+                    throw TypeError('predicate must be a function');
+                } // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+
+                var thisArg = arguments[1]; // 5. Let k be 0.
+
+                var k = 0; // 6. Repeat, while k < len
+
+                while (k < len) {
+                    // a. Let Pk be ! ToString(k).
+                    // b. Let kValue be ? Get(O, Pk).
+                    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                    // d. If testResult is true, return kValue.
+                    var kValue = o[k];
+
+                    if (predicate.call(thisArg, kValue, k, o)) {
+                        return kValue;
+                    } // e. Increase k by 1.
+
+                    k++;
+                } // 7. Return undefined.
+
+                return undefined;
+            },
+            configurable: true,
+            writable: true,
+        });
+    }
+
+    var nl = {
+        'generic.are': 'zijn',
+        'generic.is': 'is',
+        'drilldown.close_menu': 'Sluit menu',
+        'drilldown.search': 'Zoek',
+        'drilldown.back_to_level': 'Terug naar niveau $1',
+        'drilldown.no_results': 'Geen resultaten gevonden',
+        'slider.next_slide': 'volgende slide',
+        'slider.prev_slide': 'vorige slide',
+        'lightbox.next_slide': 'Volgende (Pijltje naar rechts)',
+        'lightbox.prev_slide': 'Vorige (Pijltje naar links)',
+        'lightbox.zoom_in_out': 'Zoom in/uit',
+        'lightbox.close': 'Esc/sluiten',
+        'codepreview.copy': 'Copy',
+        'codepreview.copied': 'Copied',
+        'codepreview.copy_to_clipboard': 'Copy to clipboard',
+        'autocomplete.my_location': 'Mijn Locatie',
+        'autocomplete.loading_location': 'Locatie ophalen...',
+        'autocomplete.no_results': 'Geen resultaten',
+        'autocomplete.no_results_found': 'Er zijn geen resultaten beschikbaar',
+        'autocomplete.results_found': 'Er $2 $1 beschikbaar',
+        'autocomplete.results': 'resultaten',
+        'autocomplete.result': 'resultaat',
+        'select.search_placeholder_value': 'Zoek item',
+        'select.placeholder_value': 'Selecteer item',
+        'select.no_results': 'Geen resultaten gevonden',
+        'select.no_more_options': 'Geen resterende opties gevonden',
+        'upload.add_files': 'Bijlage toevoegen',
+        'upload.add_files_subtitle': 'Sleep de bijlage naar hier om toe te voegen',
+        'upload.file_to_big': 'Het bestand mag maximaal $1 zijn.',
+        'upload.file-type_not_allowed': 'Dit bestandstype is niet toegestaan.',
+        'upload.to_many_files': 'Je kan maximaal $1 bestand(en) uploaden.',
+        'upload.response_error': 'Er liep iets fout bij het uploaden.',
+    };
+
+    var Translation = /*#__PURE__*/ (function () {
+        function Translation() {
+            _classCallCheck(this, Translation);
+
+            this.i18n = nl;
+        }
+
+        _createClass(Translation, [
+            {
+                key: 't',
+                value: function t(key) {
+                    var trans = this.i18n[key];
+
+                    if (trans) {
+                        var i = 0;
+
+                        for (
+                            var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1;
+                            _key < _len;
+                            _key++
+                        ) {
+                            args[_key - 1] = arguments[_key];
+                        }
+
+                        for (var _i = 0, _args = args; _i < _args.length; _i++) {
+                            var arg = _args[_i];
+                            i++;
+                            trans = trans.replace('$' + i, arg.toString());
+                        }
+                    } else {
+                        return key;
+                    }
+
+                    return trans;
+                },
+            },
+        ]);
+
+        return Translation;
+    })();
+
+    window.vl = window.vl || {};
+    vl.ns = vl.ns || 'vl-'; // To add to window
+
+    if (!window.Promise) {
+        window.Promise = Promise$1;
+    }
+
+    vl.i18n = new Translation();
+});

--- a/libs/common/utilities/src/util/legacy-initialisation.ts
+++ b/libs/common/utilities/src/util/legacy-initialisation.ts
@@ -1,0 +1,13 @@
+import './legacy-core.js';
+import './legacy-breakpoint.js';
+
+declare global {
+    interface Window {
+        vl: any;
+        util: any;
+        breakpoint: any;
+    }
+}
+
+export const legacyCore = window.vl;
+export const legacyBreakpoint = window.breakpoint;

--- a/libs/common/utilities/src/util/skip-link.ts
+++ b/libs/common/utilities/src/util/skip-link.ts
@@ -1,0 +1,32 @@
+import { navigateToAnchor } from './anchor-navigation';
+
+export const SKIP_TO_CONTENT_LINK_TEXT = 'Ga meteen naar de inhoud';
+
+export const SKIP_TO_CONTENT_MISSING_ID_WARNING = [
+    'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
+    'Gebruik hiervoor de ID van de eerste heading van de content.',
+    '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)',
+] as const;
+
+/**
+ * Bouwt een `<a class="vl-skip-link">` waarmee toetsenbordgebruikers het header-blok kunnen overslaan
+ * (WCAG 2.4.1). De link is visueel verborgen tot hij focus krijgt (zie `vlAccessibilityStyles`) en
+ * verplaatst bij activatie de focus en de scroll naar het doel-element - pagina-breed gezocht, ook
+ * diep in shadow roots. Bestaat het doel niet, dan doet de link niets.
+ */
+export const createSkipToContentLink = (skipToContentId: string): HTMLAnchorElement => {
+    const href = `${skipToContentId.startsWith('#') ? '' : '#'}${skipToContentId}`;
+
+    const skipLink = document.createElement('a');
+    skipLink.setAttribute('href', href);
+    skipLink.classList.add('vl-skip-link');
+    skipLink.textContent = SKIP_TO_CONTENT_LINK_TEXT;
+
+    skipLink.addEventListener('click', (event: MouseEvent) => {
+        // navigateToAnchor onderdrukt de native sprong niet zelf; doe dat hier zodat focus + scroll de enige actie zijn.
+        event.preventDefault();
+        navigateToAnchor(href);
+    });
+
+    return skipLink;
+};

--- a/libs/common/utilities/src/util/sticky-scroll.ts
+++ b/libs/common/utilities/src/util/sticky-scroll.ts
@@ -1,0 +1,123 @@
+/**
+ * Maximum aantal sticky/fixed lagen dat bovenaan de viewport op elkaar gestapeld gemeten wordt
+ * (bv. de globale header met daaronder een sticky functional header).
+ */
+const MAX_STICKY_LAYERS = 4;
+
+/**
+ * Bovengrens voor de gemeten sticky hoogte, als fractie van de viewporthoogte. Beschermt tegen
+ * schermvullende overlays (modals, cookiebanners) die het doel anders volledig uit beeld zouden duwen.
+ */
+const MAX_STICKY_OFFSET_RATIO = 0.5;
+
+/**
+ * Zoekt de elementen op een punt in de viewport, ook diep in (open) shadow roots. `elementsFromPoint`
+ * op het document stopt namelijk bij de host van een shadow root, terwijl de sticky balk zelf vaak
+ * net binnen die shadow root zit.
+ */
+const elementsFromPointThroughShadowRoot = (x: number, y: number): Element[] => {
+    const elements: Element[] = [];
+
+    const visit = (root: Document | ShadowRoot) => {
+        // Niet elke browser implementeert elementsFromPoint op een shadow root; dan meten we gewoon
+        // verder met wat de light DOM oplevert.
+        if (typeof root.elementsFromPoint !== 'function') {
+            return;
+        }
+
+        root.elementsFromPoint(x, y).forEach((element) => {
+            // Vanuit een shadow root worden ook de elementen erbuiten teruggegeven (geretarget naar de
+            // host); die zijn hier al gezien, dus de check voorkomt meteen ook eindeloze recursie.
+            if (elements.includes(element)) {
+                return;
+            }
+            elements.push(element);
+            if (element.shadowRoot) {
+                visit(element.shadowRoot);
+            }
+        });
+    };
+
+    visit(document);
+
+    return elements;
+};
+
+/**
+ * De onderkant (in viewportcoordinaten) waar een element bovenaan blijft plakken, of 0 wanneer het
+ * element niet meeschuift.
+ */
+const getStuckBottom = (element: Element): number => {
+    const style = getComputedStyle(element);
+    if (style.position !== 'fixed' && style.position !== 'sticky') {
+        return 0;
+    }
+
+    const { top, height } = element.getBoundingClientRect();
+    if (height <= 0) {
+        return 0;
+    }
+
+    // Een sticky element klikt vast op zijn eigen `top`-offset: zolang er niet ver genoeg gescrold is
+    // staat het lager dan die positie, dus rekenen we met de vastgeklikte positie i.p.v. de huidige.
+    const stickyTop = style.position === 'sticky' ? parseFloat(style.top) : NaN;
+
+    return (Number.isNaN(stickyTop) ? top : stickyTop) + height;
+};
+
+/**
+ * Meet hoeveel pixels bovenaan de viewport afgedekt worden door sticky of fixed page chrome (de
+ * globale header, een sticky functional header, ...) ter hoogte van `target`.
+ *
+ * Er wordt gemeten in de kolom van het doel zelf, zodat een sticky zijkolom naast de inhoud (bv. een
+ * side-navigation) niet meegeteld wordt. Vanaf de bovenrand wordt laag per laag naar beneden gekeken
+ * zolang er chrome op elkaar gestapeld staat.
+ *
+ * @param target - het element dat straks in beeld gescrold wordt
+ * @return de hoogte in pixels van de chrome bovenaan de viewport (0 als er geen is)
+ */
+export const getStickyOffsetTop = (target: HTMLElement): number => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = document.documentElement.clientHeight;
+
+    const { left, width } = target.getBoundingClientRect();
+    const centerX = width > 0 ? left + width / 2 : viewportWidth / 2;
+    const x = Math.min(Math.max(centerX, 1), viewportWidth - 1);
+    const maxOffset = viewportHeight * MAX_STICKY_OFFSET_RATIO;
+
+    let offset = 0;
+    for (let layer = 0; layer < MAX_STICKY_LAYERS && offset < maxOffset; layer++) {
+        const nextOffset = Math.max(0, ...elementsFromPointThroughShadowRoot(x, offset + 1).map(getStuckBottom));
+        if (nextOffset <= offset) {
+            break;
+        }
+        offset = nextOffset;
+    }
+
+    return Math.min(offset, maxOffset);
+};
+
+/**
+ * Scrolt een element in beeld en houdt daarbij rekening met sticky of fixed page chrome bovenaan de
+ * viewport: een gewone `scrollIntoView()` legt het doel tegen de bovenrand en dus achter die chrome.
+ *
+ * Er wordt eerst gescrold en pas daarna gemeten - zo staat de chrome in zijn definitieve (vastgeklikte)
+ * positie. Dekt ze het doel af, dan krijgt het doel een `scroll-margin-top` en wordt er opnieuw
+ * gescrold. Die `scroll-margin-top` blijft staan zodat ook latere (native) scrolls naar het element,
+ * bv. via de URL-hash, eronder uitkomen.
+ *
+ * @param target - het element dat in beeld gescrold wordt
+ */
+export const scrollIntoViewBelowSticky = (target: HTMLElement): void => {
+    target.scrollIntoView();
+
+    const offset = getStickyOffsetTop(target);
+    // Zit het doel al onder de chrome (bv. omdat de consumer zelf al een scroll-margin-top zette),
+    // dan is er niets te corrigeren.
+    if (offset <= 0 || target.getBoundingClientRect().top >= offset) {
+        return;
+    }
+
+    target.style.scrollMarginTop = `${offset}px`;
+    target.scrollIntoView();
+};

--- a/libs/components/components.web-types.json
+++ b/libs/components/components.web-types.json
@@ -1075,6 +1075,121 @@
                     }
                 },
                 {
+                    "name": "vl-header-next",
+                    "doc-url": "https://flux.omgeving.vlaanderen.be/release-v1/DOMG-WC-VERSION/storybook/?path=/docs/components-next-header--documentatie",
+                    "attributes": [
+                        {
+                            "name": "authenticated-user-url",
+                            "description": "De url die wordt opgeroepen om te zien of een gebruiker is ingelogd.",
+                            "default": "/sso/ingelogde_gebruiker"
+                        },
+                        {
+                            "name": "development",
+                            "description": "Geeft aan dat de ontwikkel-servers van Digitaal Vlaanderen gebruikt moeten worden.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "identifier",
+                            "description": "De identifier die gebruikt wordt om bij Digitaal Vlaanderen de header op te halen. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via het stappenplan van Digitaal Vlaanderen. <a href=\"https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Ga naar het stappenplan van Digitaal Vlaanderen (opent in een nieuw venster)\">Ga naar het stappenplan van Digitaal Vlaanderen.</a>",
+                            "default": ""
+                        },
+                        {
+                            "name": "login-url",
+                            "description": "De url die gebruikt wordt bij het aanmelden.<br>Bij het aanpassen van dit attribuut wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode van Digitaal Vlaanderen opnieuw aangeroepen.",
+                            "default": "/sso/aanmelden"
+                        },
+                        {
+                            "name": "logout-url",
+                            "description": "De url die wordt opgeroepen wanneer men zich wil afmelden.<br>Bij het aanpassen van dit attribuut wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode van Digitaal Vlaanderen opnieuw aangeroepen.",
+                            "default": "/sso/afgemeld"
+                        },
+                        {
+                            "name": "simple",
+                            "description": "Indien true wordt het configureren van de sessie overgeslagen.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "skeleton",
+                            "description": "Geeft aan of de header een skeleton moet tonen voordat het rendert.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "switch-capacity-url",
+                            "description": "De url die wordt opgeroepen wanneer men van organisatie wil wisselen.<br>Bij het aanpassen van dit attribuut wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode van Digitaal Vlaanderen opnieuw aangeroepen.",
+                            "default": "/sso/wissel_organisatie"
+                        },
+                        {
+                            "name": "skip-to-content-id",
+                            "description": "De id van het content-element waarnaar de skip-link de focus verplaatst (WCAG 2.4.1). Zonder waarde wordt er geen skip-link gerenderd. Gebruik de id van de eerste heading van de pagina-inhoud.",
+                            "default": ""
+                        },
+                        {
+                            "name": "profile-token-url",
+                            "description": "De url die opgeroepen wordt om het PAPI profile token op te halen. Het token wordt achterliggend doorgegeven aan `window.globalHeaderClient.accessMenu.setProfile()` als `idpProfileToken`. Standaard `/sso/papi_token` (endpoint van de Cumuli security lib); zet leeg om geen token op te halen. Het token wordt nooit in de DOM opgenomen (om die reden is er geen `idp-profile-token` attribuut).<br/>Zie de documentatie pagina voor de verwachte response.",
+                            "default": "/sso/papi_token"
+                        },
+                        {
+                            "name": "idp-data-url",
+                            "description": "De url die opgeroepen wordt om manueel IdpData op te halen (handig voor mock users via lokale Keycloak). De response wordt doorgegeven aan `window.globalHeaderClient.accessMenu.setProfile()` als `idpData`.",
+                            "default": ""
+                        }
+                    ],
+                    "js": {
+                        "properties": [
+                            {
+                                "name": "applicationLinks",
+                                "description": "De links die getoond worden in de header.<br/>Zie de documentatie pagina voor meer informatie.",
+                                "type": "ApplicationLink[]",
+                                "default": "[]"
+                            },
+                            {
+                                "name": "idpProfileToken",
+                                "description": "Het PAPI profile token, te zetten via JavaScript (geen attribuut omdat het token niet in de DOM mag belanden). Heeft voorrang op `profile-token-url`. Wordt enkel meegestuurd wanneer de gebruiker is aangemeld.",
+                                "type": "string",
+                                "default": "undefined"
+                            },
+                            {
+                                "name": "idpData",
+                                "description": "Manuele override voor de IdpData. Heeft voorrang op `idp-data-url`. Handig voor mock users via lokale Keycloak.<br/>Zie de documentatie pagina voor het type.",
+                                "type": "IDPData",
+                                "default": "undefined"
+                            }
+                        ],
+                        "events": [
+                            {
+                                "name": "ready",
+                                "description": "Afgevuurd nadat de widget toegevoegd is aan de DOM.",
+                                "type": "-"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "vl-footer-next",
+                    "doc-url": "https://flux.omgeving.vlaanderen.be/release-v1/DOMG-WC-VERSION/storybook/?path=/docs/components-next-footer--documentatie",
+                    "attributes": [
+                        {
+                            "name": "development",
+                            "description": "Geeft aan dat de ontwikkel-servers van Digitaal Vlaanderen gebruikt moeten worden.",
+                            "default": "false"
+                        },
+                        {
+                            "name": "identifier",
+                            "description": "De identifier die gebruikt wordt om bij Digitaal Vlaanderen de footer op te halen. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via het stappenplan van Digitaal Vlaanderen. <a href=\"https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Ga naar het stappenplan van Digitaal Vlaanderen (opent in een nieuw venster)\">Ga naar het stappenplan van Digitaal Vlaanderen.</a>",
+                            "default": ""
+                        }
+                    ],
+                    "js": {
+                        "events": [
+                            {
+                                "name": "ready",
+                                "description": "Afgevuurd nadat de widget toegevoegd is aan de DOM.",
+                                "type": "-"
+                            }
+                        ]
+                    }
+                },
+                {
                     "name": "vl-cascader",
                     "description": "Gebruik de `cascader` component om hiërarchische data weer te geven als een drilldown van lijsten.",
                     "doc-url": "https://flux.omgeving.vlaanderen.be/release-v1/DOMG-WC-VERSION/storybook/?path=/docs/components-next-cascader-cascader--documentatie",

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -19,7 +19,9 @@ export { VlContentHeaderComponent } from './content-header';
 export { VlDatepickerComponent } from './datepicker';
 export { VlDescriptionData, VlDescriptionDataItem } from './description-data';
 export { VlDocumentComponent } from './document';
+export { VlFooter } from './next/footer';
 export { VlFunctionalHeaderComponent } from './functional-header';
+export { VlHeader, type ApplicationLink } from './next/header';
 export {
     VlHttp400Message,
     VlHttp401Message,

--- a/libs/components/src/next/footer/index.ts
+++ b/libs/components/src/next/footer/index.ts
@@ -1,0 +1,1 @@
+export { VlFooter } from './vl-footer.component';

--- a/libs/components/src/next/footer/stories/vl-footer.stories-arg.ts
+++ b/libs/components/src/next/footer/stories/vl-footer.stories-arg.ts
@@ -1,0 +1,42 @@
+import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
+import { ArgTypes } from '@storybook/web-components';
+import { action } from '@storybook/addon-actions';
+
+export const footerArgs = {
+    development: false,
+    identifier: '',
+    onReady: action('ready'),
+};
+
+export const footerArgTypes: ArgTypes<typeof footerArgs> = {
+    development: {
+        name: 'development',
+        description: 'Geeft aan dat de ontwikkel-servers van Digitaal Vlaanderen gebruikt moeten worden.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(footerArgs.development) },
+        },
+    },
+    identifier: {
+        name: 'identifier',
+        description:
+            'De identifier die gebruikt wordt om bij Digitaal Vlaanderen de footer op te halen. Deze' +
+            ' identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of' +
+            ' via het stappenplan van Digitaal Vlaanderen.' +
+            ' <a href="https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer" target="_blank" rel="noopener noreferrer" aria-label="Ga naar het stappenplan van Digitaal Vlaanderen (opent in een nieuw venster)">Ga naar het stappenplan van Digitaal Vlaanderen.</a>',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: footerArgs.identifier },
+        },
+    },
+    onReady: {
+        name: 'ready',
+        description: 'Afgevuurd nadat de widget toegevoegd is aan de DOM.',
+        table: {
+            type: { summary: '-' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+};

--- a/libs/components/src/next/footer/stories/vl-footer.stories-doc.mdx
+++ b/libs/components/src/next/footer/stories/vl-footer.stories-doc.mdx
@@ -1,0 +1,104 @@
+import { ArgTypes, Canvas } from '@storybook/blocks';
+import * as VlFooterStories from './vl-footer.stories';
+
+# Digitaal Vlaanderen Footer
+
+<VluxMetaData id="components-next-footer"/>
+
+
+## Doel
+
+Injecteert de footer widget (v5) van Digitaal Vlaanderen.
+Default wordt de footer geïnjecteerd in het native `<body>` element.
+
+<vl-alert data-vl-type="info" data-vl-title="Digitaal Vlaanderen widget-versie">
+
+[vl-footer](/docs/sections-footer--documentatie) gebruikt widget v4, [vl-footer-next](/docs/components-next-footer--documentatie) gebruikt widget v5.
+
+</vl-alert>
+
+Voor het consistent gebruik van de footer doorheen alle applicaties van Departement Omgeving, raden we aan om volgende
+template aan te houden:
+
+
+>   **[app-name] is een officiële website van de Vlaamse overheid**
+>    uitgegeven door Departement Omgeving
+
+
+"Departement Omgeving" is hierbij een externe link naar https://omgeving.vlaanderen.be/.
+
+Deze gegevens worden beheerd door Digitaal Vlaanderen en kunnen ingesteld worden bij het verkrijgen van de unieke
+identifier. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via dit
+[stappenplan](https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer) van Digitaal Vlaanderen.
+
+
+## Voorbeeld
+
+```js
+import { VlFooter } from '@domg-wc/components/next/footer';
+```
+
+```html
+<vl-footer-next></vl-footer-next>
+```
+
+<Canvas of={VlFooterStories.FooterDefault}/>
+
+
+## Configuratie
+
+<ArgTypes of={VlFooterStories.FooterDefault}/>
+
+
+## Ready event
+
+De component vuurt het `ready` event af zodra de global footer widget in de DOM gemount is.
+
+Het event wordt afgevuurd **op het `<vl-footer-next>` element zelf**. Het bubbelt niet en gaat niet door shadow
+boundaries, dus registreer de listener op het element:
+
+```js
+document.querySelector('vl-footer-next').addEventListener('ready', () => {
+    // de widget staat in de DOM
+});
+```
+
+In een lit-template:
+
+```js
+html`<vl-footer-next identifier="..." @ready=${onReady}></vl-footer-next>`;
+```
+
+
+## Sticky footer bar
+
+In collapsible modus toont de widget een `position: fixed` bar onderaan de pagina. Zonder
+gereserveerde ruimte bedekt die bar de onderste content. De component reserveert daarom
+standaard `48px`: dat is de hoogte van de bar op een smal scherm, op een breed scherm is
+de bar `35px`.
+
+Afnemers kunnen die hoogte overschrijven of de reservering volledig uitzetten via de
+CSS-variabele `--vl-footer--bar-reserved-height`, gezet op `:root`, `body` of een ander
+element boven de footer container:
+
+```css
+/* Eigen hoogte reserveren */
+:root {
+    --vl-footer--bar-reserved-height: 60px;
+}
+
+/* Reservering uitzetten (bv. wanneer de pagina de ruimte zelf al voorziet) */
+:root {
+    --vl-footer--bar-reserved-height: 0px;
+}
+```
+
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Footer](https://www.vlaanderen.be/digitaal-vlaanderen/onze-oplossingen/mijn-burgerprofiel/koppelen-met-mijn-burgerprofiel-als-dienstenleverancier/technische-toolkit-voor-aansluitingen-door-dienstenleveranciers)
+
+[Global Footer - interfaces](https://test.widgets.burgerprofiel.dev-vlaanderen.be/docs/global-footer/modules.html)
+

--- a/libs/components/src/next/footer/stories/vl-footer.stories.ts
+++ b/libs/components/src/next/footer/stories/vl-footer.stories.ts
@@ -1,0 +1,39 @@
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { story } from '@domg-wc/common-storybook';
+import { Meta } from '@storybook/web-components';
+import { html } from 'lit';
+import { VlFooter } from '../vl-footer.component';
+import { footerArgs, footerArgTypes } from './vl-footer.stories-arg';
+import footerDoc from './vl-footer.stories-doc.mdx';
+
+registerWebComponents([VlFooter]);
+
+export default {
+    id: 'components-next-footer',
+    title: 'Components-next/footer',
+    tags: ['autodocs'],
+    args: footerArgs,
+    argTypes: footerArgTypes,
+    parameters: {
+        docs: { page: footerDoc, inlineStories: false },
+        layout: 'fullscreen',
+    },
+} as Meta<typeof footerArgs>;
+
+export const FooterDefault = story(
+    footerArgs,
+    ({ identifier, development, onReady }) => html`
+        <body>
+            <vl-footer-next
+                ?development=${development}
+                identifier=${identifier}
+                @ready=${(event: CustomEvent) => onReady(event)}
+            ></vl-footer-next>
+        </body>
+    `
+);
+FooterDefault.storyName = 'vl-footer-next - default';
+FooterDefault.args = {
+    development: true,
+    identifier: '0337f8dc-3266-4e7a-8f4a-95fd65189e5b',
+};

--- a/libs/components/src/next/footer/vl-footer.component.cy.ts
+++ b/libs/components/src/next/footer/vl-footer.component.cy.ts
@@ -1,0 +1,146 @@
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { html } from 'lit';
+import { VlFooter } from './vl-footer.component';
+
+registerWebComponents([VlFooter]);
+
+type MountDefaultProps = {
+    development: boolean;
+    identifier: string;
+    onReady: (evt: CustomEvent) => void;
+};
+
+const mountDefault = (props: MountDefaultProps) => {
+    cy.mount(html`
+        <body>
+            <vl-footer-next
+                ?development=${props.development}
+                identifier=${props.identifier}
+                @ready=${(evt: CustomEvent) => props.onReady(evt)}
+            ></vl-footer-next>
+        </body>
+    `);
+
+    // elke test moet wachten tot het widget-script uitgevoerd is
+    cy.wait('@widgetScript');
+
+    return cy.window().its('globalFooterClient').should('exist');
+};
+
+const props: MountDefaultProps = {
+    development: false,
+    identifier: '0337f8dc-3266-4e7a-8f4a-95fd65189e5b',
+    onReady: () => console.log('ready'),
+};
+
+// root-niveau hooks: mocha draait deze voor/na elke test van elke suite in dit bestand, net zoals ze
+// eerder als hooks van de omhullende describe deden
+beforeEach(() => {
+    // zonder deze intercept haalt elke test het echte widget-script op bij widgets.(tni-)vlaanderen.be: traag,
+    // buiten onze controle en dus regelmatig falend
+    cy.intercept('GET', /widgets.*vlaanderen\.be.*entry/, stubWidgetScript()).as('widgetScript');
+});
+
+afterEach(() => {
+    // awaitScript slaat het laden over als er al een script met dit id staat, dus zonder opkuis krijgt de volgende
+    // test geen widget meer. Via document i.p.v. cy.get: het script hoeft er niet te zijn als een test vroeg faalt.
+    document.querySelector('script#vl-footer-widget')?.remove();
+    // De component ruimt zijn container zelf op bij disconnect; deze regel vangt de gevallen op waarin dat niet
+    // gebeurde, zodat een volgende test nooit twee #footer__container-elementen ziet.
+    document.querySelector('#footer__container')?.remove();
+    // Weg met de client van deze test, anders is de wachtvoorwaarde in mountDefault meteen voldaan.
+    delete (window as unknown as Record<string, unknown>).globalFooterClient;
+});
+
+describe('cypress-component - compliance components - vl-footer-next - default', () => {
+    beforeEach(() => {
+        mountDefault(props);
+    });
+
+    it('should mount', () => {
+        cy.get('vl-footer-next');
+    });
+
+    it('should be accessible', () => {
+        cy.get('vl-footer-next');
+
+        cy.injectAxe();
+        cy.checkA11y('vl-footer-next');
+    });
+});
+
+describe('cypress-component - compliance components - vl-footer-next - properties default', () => {
+    it('should have default values properties', () => {
+        mountDefault(props);
+
+        cy.get('vl-footer-next').should('not.have.attr', 'development', props.development);
+        cy.get('vl-footer-next').should('have.attr', 'identifier', props.identifier);
+    });
+});
+
+describe('cypress-component - compliance components - vl-footer-next - properties reflect', () => {
+    it('should reflect the <development> attribute', () => {
+        mountDefault({ ...props, development: true });
+
+        cy.get('vl-footer-next').should('have.attr', 'development', '');
+    });
+
+    it('should reflect the <identifier> attribute', () => {
+        mountDefault({ ...props, identifier: 'TEST_IDENTIFIER' });
+
+        cy.get('vl-footer-next').should('have.attr', 'identifier', 'TEST_IDENTIFIER');
+    });
+});
+
+describe('cypress-component - compliance components - vl-footer-next - events', () => {
+    it('should emit ready event', () => {
+        // mountDefault hangt de listener via @ready op het element zelf;
+        // de component vuurt 'ready' af zodra de widget gemount is
+        mountDefault({ ...props, development: true, onReady: cy.stub().as('ready') });
+
+        cy.get('@ready').should('have.been.calledOnce');
+    });
+});
+
+describe('cypress-component - compliance components - vl-footer-next - sticky footer spacer', () => {
+    const RESERVED_HEIGHT_VAR = '--vl-footer--bar-reserved-height';
+
+    afterEach(() => {
+        document.documentElement.style.removeProperty(RESERVED_HEIGHT_VAR);
+    });
+
+    it('should reserve space for the fixed footer bar on the container', () => {
+        mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+        cy.get('#footer__container').should('have.css', 'min-height', '48px');
+    });
+
+    it('should let consumers override the reserved height via CSS variable', () => {
+        document.documentElement.style.setProperty(RESERVED_HEIGHT_VAR, '60px');
+        mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+        cy.get('#footer__container').should('have.css', 'min-height', '60px');
+    });
+
+    it('should let consumers disable the reservation via CSS variable', () => {
+        document.documentElement.style.setProperty(RESERVED_HEIGHT_VAR, '0px');
+        mountDefault({ ...props, development: true, identifier: 'TEST_IDENTIFIER' });
+
+        cy.get('#footer__container').should('have.css', 'min-height', '0px');
+    });
+});
+
+/**
+ * Vervangt het widget-script: het echte script zet window.globalFooterClient klaar en meldt via een window-event dat de
+ * widget gemount is. Meer heeft de component niet nodig.
+ */
+const stubWidgetScript = () => ({
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/javascript' },
+    body: `
+        window.globalFooterClient = {
+            mount: () => Promise.resolve(),
+        };
+        window.dispatchEvent(new Event('widget.global_footer.mounted'));
+    `,
+});

--- a/libs/components/src/next/footer/vl-footer.component.ts
+++ b/libs/components/src/next/footer/vl-footer.component.ts
@@ -1,0 +1,112 @@
+import {
+    awaitScript,
+    BaseLitElement,
+    legacyBreakpoint,
+    legacyCore,
+    registerWebComponents,
+    webComponent,
+} from '@domg-wc/common-utilities';
+import { GlobalFooterClient } from '@govflanders/vl-widget-global-footer-types';
+
+declare global {
+    interface Window {
+        globalFooterClient: GlobalFooterClient;
+    }
+}
+
+registerWebComponents([legacyCore, legacyBreakpoint]);
+
+@webComponent('vl-footer-next')
+export class VlFooter extends BaseLitElement {
+    private development = false;
+    private identifier = '';
+
+    static get properties() {
+        return {
+            development: {
+                type: Boolean,
+                attribute: 'development',
+                reflect: true,
+            },
+            identifier: {
+                type: String,
+                attribute: 'identifier',
+                reflect: true,
+            },
+        };
+    }
+
+    constructor() {
+        super();
+        this.allowCustomCSS = false;
+    }
+
+    get footerContainer() {
+        return document.querySelector('#footer__container');
+    }
+
+    private injectFooterContainer() {
+        const vlBody = document.querySelector('body');
+
+        if (this.footerContainer) return;
+
+        (vlBody || document.body).insertAdjacentHTML(
+            'beforeend',
+            '<footer id="footer__container" style="min-height: var(--vl-footer--bar-reserved-height, 48px)"><div id="footer"></div></footer>'
+        );
+    }
+
+    // class field met pijlfunctie, geen methode !
+    // -> window.addEventListener krijgt hier enkel een functiereferentie mee
+    // -> als gewone methode is 'this' bij het afvuren het window, en dan komt het ready-event op window
+    //    terecht in plaats van op de component - afnemers die op het element luisteren zien het dan nooit
+    private onReady = () => {
+        this.dispatchEvent(new CustomEvent('ready'));
+    };
+
+    private async loadWidget() {
+        try {
+            window.addEventListener('widget.global_footer.mounted', this.onReady);
+
+            await awaitScript(
+                'vl-footer-widget',
+                `https://widgets.${this.development ? 'tni-' : ''}vlaanderen.be/api/v2/widget/${this.identifier}/entry`
+            );
+
+            if (!window.globalFooterClient) {
+                console.error('De global footer client werd niet geladen.');
+                return;
+            }
+
+            const footerElement = this.footerContainer?.querySelector<HTMLDivElement>('#footer') || undefined;
+
+            await window.globalFooterClient.mount(footerElement);
+        } catch (error) {
+            console.error('De global footer werd niet geladen.', error);
+        }
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        this.injectFooterContainer();
+        this.loadWidget();
+    }
+
+    createRenderRoot() {
+        return this;
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+
+        window.removeEventListener('widget.global_footer.mounted', this.onReady);
+        this.footerContainer?.remove();
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-footer-next': VlFooter;
+    }
+}

--- a/libs/components/src/next/header/index.ts
+++ b/libs/components/src/next/header/index.ts
@@ -1,0 +1,1 @@
+export { VlHeader, type ApplicationLink } from './vl-header.component';

--- a/libs/components/src/next/header/stories/vl-header.stories-arg.ts
+++ b/libs/components/src/next/header/stories/vl-header.stories-arg.ts
@@ -1,0 +1,177 @@
+import { CATEGORIES, TYPES } from '@domg-wc/common-storybook';
+import { ArgTypes } from '@storybook/web-components';
+import { action } from '@storybook/addon-actions';
+import { headerDefaults } from '../vl-header.defaults';
+
+type HeaderArgs = typeof headerDefaults & { onReady: () => void };
+
+export const headerArgs: HeaderArgs = {
+    ...headerDefaults,
+    onReady: action('ready'),
+};
+
+export const headerArgTypes: ArgTypes<HeaderArgs> = {
+    authenticatedUserUrl: {
+        name: 'authenticated-user-url',
+        description: 'De url die wordt opgeroepen om te zien of een gebruiker is ingelogd.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.authenticatedUserUrl },
+        },
+    },
+    development: {
+        name: 'development',
+        description: 'Geeft aan dat de ontwikkel-servers van Digitaal Vlaanderen gebruikt moeten worden.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(headerArgs.development) },
+        },
+    },
+    identifier: {
+        name: 'identifier',
+        description:
+            'De identifier die gebruikt wordt om bij Digitaal Vlaanderen de header op te halen. Deze' +
+            ' identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of' +
+            ' via het stappenplan van Digitaal Vlaanderen.' +
+            ' <a href="https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer" target="_blank" rel="noopener noreferrer" aria-label="Ga naar het stappenplan van Digitaal Vlaanderen (opent in een nieuw venster)">Ga naar het stappenplan van Digitaal Vlaanderen.</a>',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.identifier },
+        },
+    },
+    loginUrl: {
+        name: 'login-url',
+        description:
+            'De url die gebruikt wordt bij het aanmelden.<br>Bij het aanpassen van dit attribuut wordt' +
+            ' achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode van Digitaal' +
+            ' Vlaanderen opnieuw aangeroepen.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.loginUrl },
+        },
+    },
+    logoutUrl: {
+        name: 'logout-url',
+        description:
+            'De url die wordt opgeroepen wanneer men zich wil afmelden.<br>Bij het aanpassen van dit' +
+            ' attribuut wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode' +
+            ' van Digitaal Vlaanderen opnieuw aangeroepen.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.logoutUrl },
+        },
+    },
+    simple: {
+        name: 'simple',
+        description: 'Indien true wordt het configureren van de sessie overgeslagen.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(headerArgs.simple) },
+        },
+    },
+    skeleton: {
+        name: 'skeleton',
+        description: 'Geeft aan of de header een skeleton moet tonen voordat het rendert.',
+        table: {
+            type: { summary: TYPES.BOOLEAN },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: String(headerArgs.skeleton) },
+        },
+    },
+    switchCapacityUrl: {
+        name: 'switch-capacity-url',
+        description:
+            'De url die wordt opgeroepen wanneer men van organisatie wil wisselen.<br>Bij het aanpassen' +
+            ' van dit attribuut wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()`' +
+            ' methode van Digitaal Vlaanderen opnieuw aangeroepen.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.switchCapacityUrl },
+        },
+    },
+    skipToContentId: {
+        name: 'skip-to-content-id',
+        description:
+            'De id van het content-element waarnaar de skip-link de focus verplaatst (WCAG 2.4.1). Zonder waarde' +
+            ' wordt er geen skip-link gerenderd. Gebruik de id van de eerste heading van de pagina-inhoud.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.skipToContentId },
+        },
+    },
+    applicationLinks: {
+        name: 'applicationLinks',
+        description: 'De links die getoond worden in de header.<br/>Zie de documentatie pagina voor meer informatie.',
+        table: {
+            type: { summary: 'ApplicationLink[]' },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: '[]' },
+        },
+    },
+    profileTokenUrl: {
+        name: 'profile-token-url',
+        description:
+            'De url die opgeroepen wordt om het PAPI profile token op te halen. Het token wordt' +
+            ' achterliggend doorgegeven aan `window.globalHeaderClient.accessMenu.setProfile()` als' +
+            ' `idpProfileToken`. Standaard `/sso/papi_token` (endpoint van de Cumuli security lib);' +
+            ' zet leeg om geen token op te halen. Het token wordt nooit' +
+            ' in de DOM opgenomen (om die reden is er geen `idp-profile-token` attribuut).<br/>' +
+            'Zie de documentatie pagina voor de verwachte response.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.profileTokenUrl },
+        },
+    },
+    idpDataUrl: {
+        name: 'idp-data-url',
+        description:
+            'De url die opgeroepen wordt om manueel IdpData op te halen (handig voor mock users via' +
+            ' lokale Keycloak). De response wordt doorgegeven aan' +
+            ' `window.globalHeaderClient.accessMenu.setProfile()` als `idpData`.',
+        table: {
+            type: { summary: TYPES.URL },
+            category: CATEGORIES.ATTRIBUTES,
+            defaultValue: { summary: headerArgs.idpDataUrl },
+        },
+    },
+    idpProfileToken: {
+        name: 'idpProfileToken',
+        description:
+            'Het PAPI profile token, te zetten via JavaScript (geen attribuut omdat het token niet' +
+            ' in de DOM mag belanden). Heeft voorrang op `profile-token-url`. Wordt enkel meegestuurd' +
+            ' wanneer de gebruiker is aangemeld.',
+        table: {
+            type: { summary: TYPES.STRING },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: 'undefined' },
+        },
+    },
+    idpData: {
+        name: 'idpData',
+        description:
+            'Manuele override voor de IdpData. Heeft voorrang op `idp-data-url`. Handig voor mock' +
+            ' users via lokale Keycloak.<br/>Zie de documentatie pagina voor het type.',
+        table: {
+            type: { summary: 'IDPData' },
+            category: CATEGORIES.PROPERTIES,
+            defaultValue: { summary: 'undefined' },
+        },
+    },
+    onReady: {
+        name: 'ready',
+        description: 'Afgevuurd nadat de widget toegevoegd is aan de DOM.',
+        table: {
+            type: { summary: '-' },
+            category: CATEGORIES.EVENTS,
+        },
+    },
+};

--- a/libs/components/src/next/header/stories/vl-header.stories-doc.mdx
+++ b/libs/components/src/next/header/stories/vl-header.stories-doc.mdx
@@ -1,0 +1,184 @@
+import { ArgTypes, Canvas } from '@storybook/blocks';
+import * as VlHeaderStories from './vl-header.stories';
+
+# Digitaal Vlaanderen Header
+
+<VluxMetaData id="components-next-header" />
+
+
+## Doel
+
+Injecteert de global header widget (v5) van Digitaal Vlaanderen.
+Default wordt de header geïnjecteerd in het native `<body>` element.
+
+<vl-alert data-vl-type="info" data-vl-title="Digitaal Vlaanderen widget-versie">
+
+[vl-header](/docs/sections-header--documentatie) gebruikt widget v4, [vl-header-next](/docs/components-next-header--documentatie) gebruikt widget v5.
+
+</vl-alert>
+
+Voor het consistent gebruik van de header doorheen alle applicaties van Departement Omgeving, raden we aan om volgende
+template aan te houden:
+
+
+>   **[Logo Vlaanderen]** | **[App-name]** | witruimte | **Aanmelden** | **Hulp nodig?**
+
+- **"Logo Vlaanderen"** is hierbij een link naar https://vlaanderen.be.
+- **"App-name"** blijft op alle pagina's de naam van de applicatie en krijgt als link de startpagina van de applicatie.
+- Onder **"Aanmelden"** kan je app-links definiëren (zie [Applicatieve links](#applicatieve-links)).
+- Onder **"Hulp nodig?"** komt de tekst: **"Neem contact op met Departement Omgeving"**, gevolgd door verschillende
+contact opties (telefoonnummer, adres, e-mailadres).
+
+Deze gegevens worden beheerd door Digitaal Vlaanderen en kunnen ingesteld worden bij het verkrijgen van de unieke
+identifier. Deze identifier kan aangevraagd worden bij Team Infra van Departement Omgeving of via dit
+[stappenplan](https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/mijn-burgerprofiel/global-header-en-footer#stappenplan-koppeling-met-de-global-header-en-footer) van Digitaal Vlaanderen.
+
+
+## Voorbeeld
+
+```js
+import { VlHeader } from '@domg-wc/components/next/header';
+```
+
+```html
+<vl-header-next></vl-header-next>
+```
+
+<Canvas of={VlHeaderStories.HeaderDefault} />
+
+
+## Configuratie
+
+<ArgTypes of={VlHeaderStories.HeaderDefault} />
+
+## Ready event
+
+De component vuurt het `ready` event af zodra de global header widget in de DOM gemount is. Vanaf dat moment is de
+widget-inhoud beschikbaar en levert `height` de effectieve hoogte van de header op.
+
+Het event wordt afgevuurd **op het `<vl-header-next>` element zelf**. Het bubbelt niet en gaat niet door shadow
+boundaries, dus registreer de listener op het element:
+
+```js
+document.querySelector('vl-header-next').addEventListener('ready', () => {
+    // de widget staat in de DOM
+});
+```
+
+In een lit-template:
+
+```js
+html`<vl-header-next identifier="..." @ready=${onReady}></vl-header-next>`;
+```
+
+
+## Sessies
+
+### Configuratie
+
+Bij het aanpassen van volgende attributen wordt achterliggend de `window.globalHeaderClient.accessMenu.setProfile()` methode van DV opnieuw aangeroepen:
+
+-   `login-url`
+-   `logout-url`
+-   `switch-capacity-url`
+
+Zie [global header interfaces | setProfile](https://test.widgets.burgerprofiel.dev-vlaanderen.be/docs/global-header/interfaces/AccessMenuMethods.html#setprofile) voor de technische informatie.
+
+Zie [Digitaal Vlaanderen - De endpoints overschrijven](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6336119448/Aanmelden+met+eenvoudig+of+gekoppeld+toegangsbeheer#De-endpoints-overschrijven) voor meer informatie (v4 documentatie).
+
+### PAPI profile token
+
+Sinds global header v5 kan een PAPI profile token meegegeven worden aan de header. Hiermee toont de header automatisch de gegevens van de gebruiker (naam, hoedanigheden, ...). Zie [Profile API Integration Guide](https://docs.digitaal.vlaanderen.be/global-header/documents/Profile_API_Integration_Guide.html) van Digitaal Vlaanderen voor de achtergrond.
+
+`vl-header-next` ondersteunt twee manieren om het token mee te geven:
+
+1. **`profile-token-url` attribuut** (declaratief) — de component fetcht het token op deze endpoint van jouw backend wanneer de sessie geconfigureerd wordt. Standaard staat dit op `/sso/papi_token`, de endpoint van de Cumuli security lib. Verwachte response is het token als plain text (`text/plain`).
+
+    ```html
+    <vl-header-next
+        identifier="..."
+        profile-token-url="/api/papi-token"
+    ></vl-header-next>
+    ```
+
+2. **`idpProfileToken` JavaScript-property** (imperatief) — set het token direct vanuit je SPA. Heeft voorrang op `profile-token-url`. Handig wanneer je het token al in je client-side state hebt.
+
+    ```js
+    document.querySelector('vl-header-next').idpProfileToken = papiToken;
+    ```
+
+Het token wordt enkel aan `setProfile()` doorgegeven wanneer de gebruiker is aangemeld (`active: true`), conform de [vereiste van Digitaal Vlaanderen](https://docs.digitaal.vlaanderen.be/global-header/documents/Profile_API_Integration_Guide.html#3-frontend-passing-the-profile-token) dat `idpProfileToken` en `active: true` in dezelfde call moeten zitten.
+
+> **Waarom geen `idp-profile-token` HTML-attribuut?**
+> Het token is een bearer credential met korte levensduur. Een HTML-attribuut zou het token zichtbaar maken in View Source, server-side rendered HTML, MutationObservers van 3rd-party scripts en screenshots van de elementen-tab. Daarom wordt het token enkel via een URL-fetch of JS-property aanvaard — beide houden het token uit de DOM.
+
+### IdpData
+
+Wanneer er geen PAPI token beschikbaar is, kan IdpData manueel meegegeven worden (bijvoorbeeld bij mock users via een lokale Keycloak). Twee manieren, met dezelfde precedentie als bij het token:
+
+1. **`idp-data-url` attribuut** — de component fetcht een JSON-response op deze endpoint.
+
+    ```html
+    <vl-header-next
+        identifier="..."
+        idp-data-url="/api/idp-data"
+    ></vl-header-next>
+    ```
+
+2. **`idpData` JavaScript-property** — set het IDPData-object direct.
+
+    ```js
+    document.querySelector('vl-header-next').idpData = {
+        user: { firstName: 'John', name: 'Doe' },
+        loginHint: 'user-login-hint',
+        identities: [/* ... */],
+    };
+    ```
+
+Zie [IDPData interface](https://test.widgets.burgerprofiel.dev-vlaanderen.be/docs/global-header/interfaces/IDPData.html) voor het volledige type.
+
+## Applicatieve Links
+
+Je kan applicatieve links toevoegen aan de header door gebruik te maken van de `applicationLinks` property.<br/>
+Deze property verwacht een array met objecten van het volgende type:
+
+```js
+type ApplicationMenuLink = {
+    label: string;
+    href: string;
+    icon?: string;
+    target?: string;
+};
+```
+
+De `ApplicationMenuLink` TypeScript Type kan je zo importeren: `import { ApplicationMenuLink } from '@govflanders/vl-widget-global-header-types';`
+
+Zie [global header interfaces | ApplicationMenuLink](https://test.widgets.burgerprofiel.dev-vlaanderen.be/docs/global-header/interfaces/ApplicationMenuLink.html) voor de technische informatie.
+
+Zie [Digitaal Vlaanderen - Header applicatieve links](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6508874105/Aanmeldmenu#Applicatieve-links) voor meer informatie (v4 documentatie).
+
+### Logout request
+
+Sinds global header v5 is het niet meer nodig om automatische logout requests te rejecten. Onderstaande informatie gaat over de v4 implementatie (voorlopig behouden in de documentatie als referentie).
+
+> Bij het gebruik maken van sessies kan het logout request afgehandeld worden.<br/>
+> Dit kan handig zijn als je wilt dat de gebruiker niet automatisch wordt uitgelogd bv. bij inactiviteit of als de sessie verlopen is.
+>
+> Door gebruik te maken van het `reject-logout` attribuut worden alle logout requests afgewezen, behalve een logout request door de gebruiker.
+>
+> Met de `logoutCallback` property kan je een callback functie meegeven die wordt aangeroepen bij een logout request.<br/>
+> De logout reason wordt meegegeven aan de callback, door een boolean promise terug te geven kan je de logout accepteren of afwijzen.<br/>
+> De mogelijke reasons zijn: `inactivity` en `expired`.<br/>
+> Een logout request door de gebruiker wordt nooit afgewezen.
+>
+>
+> Zie [De aanvragen voor applicatie logout afhandelen via JavaScript](https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/6336119448/Aanmelden+met+eenvoudig+of+gekoppeld+toegangsbeheer#De-aanvragen-voor-applicatie-logout-afhandelen-via-JavaScript) voor meer informatie (v4 documentatie).
+
+
+## Referenties
+
+### Digitaal Vlaanderen
+
+[Documentatie Digitaal Vlaanderen - Header](https://www.vlaanderen.be/digitaal-vlaanderen/onze-oplossingen/mijn-burgerprofiel/koppelen-met-mijn-burgerprofiel-als-dienstenleverancier/technische-toolkit-voor-aansluitingen-door-dienstenleveranciers)
+
+[Global Header - interfaces](https://test.widgets.burgerprofiel.dev-vlaanderen.be/docs/global-header/modules.html)

--- a/libs/components/src/next/header/stories/vl-header.stories.ts
+++ b/libs/components/src/next/header/stories/vl-header.stories.ts
@@ -1,0 +1,90 @@
+import { story } from '@domg-wc/common-storybook';
+import { Meta } from '@storybook/web-components';
+import { html } from 'lit';
+import { headerArgs, headerArgTypes } from './vl-header.stories-arg';
+import headerDoc from './vl-header.stories-doc.mdx';
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { VlHeader } from '../vl-header.component';
+
+registerWebComponents([VlHeader]);
+
+export default {
+    id: 'components-next-header',
+    title: 'Components-next/header',
+    tags: ['autodocs'],
+    args: headerArgs,
+    argTypes: headerArgTypes,
+    parameters: {
+        docs: {
+            page: headerDoc,
+            inlineStories: false,
+        },
+        layout: 'fullscreen',
+    },
+} as Meta<typeof headerArgs>;
+
+export const HeaderDefault = story(
+    headerArgs,
+    ({
+        authenticatedUserUrl,
+        development,
+        identifier,
+        loginUrl,
+        logoutUrl,
+        skeleton,
+        simple,
+        switchCapacityUrl,
+        skipToContentId,
+        applicationLinks,
+        profileTokenUrl,
+        idpDataUrl,
+        idpProfileToken,
+        idpData,
+        onReady,
+    }) => html`
+        <body>
+            <vl-header-next
+                authenticated-user-url=${authenticatedUserUrl}
+                ?development=${development}
+                identifier=${identifier}
+                login-url=${loginUrl}
+                logout-url=${logoutUrl}
+                ?simple=${simple}
+                ?skeleton=${skeleton}
+                switch-capacity-url=${switchCapacityUrl}
+                skip-to-content-id=${skipToContentId}
+                profile-token-url=${profileTokenUrl}
+                idp-data-url=${idpDataUrl}
+                .applicationLinks=${applicationLinks}
+                .idpProfileToken=${idpProfileToken}
+                .idpData=${idpData}
+                @ready=${onReady}
+            ></vl-header-next>
+        </body>
+    `
+);
+
+HeaderDefault.storyName = 'vl-header-next - default';
+HeaderDefault.args = {
+    development: true,
+    identifier: '59188ff6-662b-45b9-b23a-964ad48c2bfb',
+    simple: true,
+};
+
+export const HeaderWithApplicationLinks = HeaderDefault.bind({});
+HeaderWithApplicationLinks.storyName = 'vl-header-next - application links';
+HeaderWithApplicationLinks.args = {
+    development: true,
+    identifier: '59188ff6-662b-45b9-b23a-964ad48c2bfb',
+    simple: true,
+    applicationLinks: [
+        {
+            label: 'Link 1',
+            href: 'https://example.com/link1',
+        },
+        {
+            label: 'Link 2',
+            href: 'https://example.com/link2',
+        },
+    ],
+};

--- a/libs/components/src/next/header/vl-header.component.cy.ts
+++ b/libs/components/src/next/header/vl-header.component.cy.ts
@@ -1,0 +1,529 @@
+import { registerWebComponents } from '@domg-wc/common-utilities';
+import { html, TemplateResult } from 'lit';
+import { ApplicationLink, VlHeader } from './index';
+
+registerWebComponents([VlHeader]);
+
+const identifier = '59188ff6-662b-45b9-b23a-964ad48c2bfb';
+
+// root-niveau hooks: mocha draait deze voor/na elke test van elke suite in dit bestand, net zoals ze
+// eerder als hooks van de omhullende describe deden
+beforeEach(() => {
+    cy.intercept('GET', /widgets.*vlaanderen\.be.*entry/, stubWidgetScriptMinimal()).as('widgetScript');
+});
+
+afterEach(() => {
+    // awaitScript slaat het laden over als er al een script met dit id staat, dus zonder opkuis krijgt de volgende
+    // test geen widget meer. Via document i.p.v. cy.get: het script hoeft er niet te zijn als een test vroeg faalt.
+    document.querySelector('script#vl-header-widget')?.remove();
+    // De component ruimt zijn container zelf op bij disconnect; deze regel vangt de gevallen op waarin dat niet
+    // gebeurde, zodat een volgende test nooit twee #header__container-elementen ziet.
+    document.querySelector('#header__container')?.remove();
+    // Weg met de client en de opgevangen setProfile-calls van deze test: anders is de wachtvoorwaarde in
+    // mountHeader meteen voldaan met de widget van de vorige test en lezen we diens configuratie uit.
+    delete (window as unknown as Record<string, unknown>).globalHeaderClient;
+    delete (window as unknown as Record<string, unknown>).__setProfileCalls;
+});
+
+/**
+ * Alle tests van dit bestand delen eenzelfde window. Een test die eindigt terwijl zijn widget-script nog onderweg
+ * is, laat dat script in de volgende test uitvoeren: dat vuurt daar een tweede 'widget.global_header.mounted' af
+ * en overschrijft window.globalHeaderClient (inclusief de opgevangen setProfile-calls). Vandaar dat elke mount
+ * hier wacht tot het script van deze test effectief uitgevoerd is - wachten op de response alleen volstaat niet.
+ */
+const mountHeader = (template: TemplateResult) => {
+    cy.mount(template);
+    cy.wait('@widgetScript');
+
+    return cy.window().its('globalHeaderClient').should('exist');
+};
+
+describe('cypress-component - compliance components - vl-header-next - default', () => {
+    beforeEach(() => {
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}"></vl-header-next>
+            </body>
+        `);
+    });
+
+    it('should mount', () => {
+        cy.get('vl-header-next');
+        cy.get('#header__container');
+    });
+
+    it('should be accessible', () => {
+        cy.injectAxe();
+
+        cy.get('vl-header-next');
+        cy.checkA11y('vl-header-next');
+        cy.checkA11y('#header__container');
+    });
+
+    it('should render with fixed height', () => {
+        cy.get('#header__container').should('have.css', 'min-height', '43px');
+    });
+
+    it('should wrap the global header in a <header> element so screenreaders pick it up as banner landmark', () => {
+        cy.get('#header__container').should('have.prop', 'tagName', 'HEADER');
+        cy.get('header[id="header__container"]').should('have.length', 1);
+    });
+});
+
+describe('cypress-component - compliance components - vl-header-next - ready event', () => {
+    it('should dispatch ready event when ready', () => {
+        const onReady = cy.stub().as('ready');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}" @ready=${onReady}></vl-header-next>
+            </body>
+        `);
+
+        cy.get('@ready').should('have.been.calledOnce');
+    });
+});
+
+describe('cypress-component - compliance components - vl-header-next - applicationLinks', () => {
+    const mockApplicationLinks: ApplicationLink[] = [
+        {
+            label: 'Link 1',
+            href: '#link1',
+        },
+        {
+            label: 'Link 2',
+            href: '#link2',
+        },
+    ];
+
+    it('should render the application links', () => {
+        cy.viewport(1280, 800);
+
+        cy.intercept('GET', /widgets.*vlaanderen\.be.*entry/, stubWidgetScriptWithApplicationLinks()).as(
+            'widgetScript',
+        );
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    .applicationLinks=${mockApplicationLinks}
+                ></vl-header-next>
+            </body>
+        `);
+
+        cy.get('#header__container > div').shadow().find('button.access-menu-toggle__button').click();
+        cy.get('#header__container > div')
+            .shadow()
+            .find(`a[href="${mockApplicationLinks[0].href}"]`)
+            .contains(mockApplicationLinks[0].label);
+        cy.get('#header__container > div')
+            .shadow()
+            .find(`a[href="${mockApplicationLinks[1].href}"]`)
+            .contains(mockApplicationLinks[1].label);
+    });
+});
+
+describe('cypress-component - compliance components - vl-header-next - skeleton', () => {
+    it('should render the skeleton container', () => {
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}" skeleton></vl-header-next>
+            </body>
+        `);
+
+        cy.get('#header__skeleton').should('have.css', 'height', '43px');
+    });
+});
+
+describe('cypress-component - compliance components - vl-header-next - PAPI profile token + idpData', () => {
+    beforeEach(() => {
+        cy.intercept('GET', /widgets.*vlaanderen\.be.*entry/, stubWidgetScriptCapturingSetProfile()).as('widgetScript');
+        cy.intercept('GET', '/sso/ingelogde_gebruiker', { statusCode: 200, body: '' }).as('authActive');
+        cy.intercept('GET', '/sso/papi_token', { statusCode: 401, body: '' }).as('defaultTokenUnset');
+    });
+
+    const lastSetProfileCall = (): Cypress.Chainable<Record<string, unknown>> =>
+        cy
+            .window()
+            .its('__setProfileCalls', { timeout: 15000 })
+            .should('have.length.greaterThan', 0)
+            .then((calls: Record<string, unknown>[]) => calls[calls.length - 1]);
+
+    it('should pass idpProfileToken via JS property when set', () => {
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    .idpProfileToken=${'token-via-property'}
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ active: true, idpProfileToken: 'token-via-property' });
+        });
+    });
+
+    it('should fetch and pass idpProfileToken via profile-token-url', () => {
+        cy.intercept('GET', '/api/papi-token', {
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            body: 'token-from-url',
+        }).as('tokenFetch');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    profile-token-url="/api/papi-token"
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+        cy.wait('@tokenFetch');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ active: true, idpProfileToken: 'token-from-url' });
+        });
+    });
+
+    it('should let JS property win over profile-token-url', () => {
+        cy.intercept('GET', '/api/papi-token', {
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            body: 'token-from-url',
+        }).as('tokenFetch');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    profile-token-url="/api/papi-token"
+                    .idpProfileToken=${'token-via-property'}
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ idpProfileToken: 'token-via-property' });
+        });
+    });
+
+    it('should not include idpProfileToken when user is not authenticated', () => {
+        cy.intercept('GET', '/sso/ingelogde_gebruiker', { statusCode: 401, body: '' }).as('authInactive');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    .idpProfileToken=${'token-via-property'}
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authInactive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.have.property('active', false);
+            expect(config).to.not.have.property('idpProfileToken');
+        });
+    });
+
+    it('should pass idpData via JS property when set', () => {
+        const mockIdpData = {
+            user: { firstName: 'John', name: 'Doe' },
+        };
+
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}" .idpData=${mockIdpData}></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.have.nested.property('idpData.user.firstName', 'John');
+        });
+    });
+
+    it('should fetch and pass idpData via idp-data-url', () => {
+        cy.intercept('GET', '/api/idp-data', {
+            statusCode: 200,
+            body: { user: { firstName: 'Jane', name: 'Smith' } },
+        }).as('idpDataFetch');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}" idp-data-url="/api/idp-data"></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+        cy.wait('@idpDataFetch');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.have.nested.property('idpData.user.firstName', 'Jane');
+        });
+    });
+
+    it('should not include idpData when a papi token is present', () => {
+        const mockIdpData = {
+            user: { firstName: 'John', name: 'Doe' },
+        };
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    .idpProfileToken=${'token-via-property'}
+                    .idpData=${mockIdpData}
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ active: true, idpProfileToken: 'token-via-property' });
+            expect(config).to.not.have.property('idpData');
+        });
+    });
+
+    it('should not fetch or include idpData when the user is not authenticated', () => {
+        cy.intercept('GET', '/sso/ingelogde_gebruiker', { statusCode: 401, body: '' }).as('authInactive');
+        cy.intercept('GET', '/api/idp-data', {
+            statusCode: 200,
+            body: { user: { firstName: 'Jane', name: 'Smith' } },
+        }).as('idpDataFetch');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next development identifier="${identifier}" idp-data-url="/api/idp-data"></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authInactive');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.have.property('active', false);
+            expect(config).to.not.have.property('idpData');
+        });
+        cy.get('@idpDataFetch.all').should('have.length', 0);
+    });
+
+    it('should configure the session only once on initial load', () => {
+        cy.intercept('GET', '/api/papi-token', {
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            body: 'token-from-url',
+        }).as('tokenFetch');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    profile-token-url="/api/papi-token"
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+        cy.wait('@tokenFetch');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ active: true, idpProfileToken: 'token-from-url' });
+        });
+        cy.get('@authActive.all').should('have.length', 1);
+        cy.get('@tokenFetch.all').should('have.length', 1);
+    });
+
+    it('should discard a stale overlapping configureSession call and keep the newest value', () => {
+        cy.intercept('GET', '/api/slow-token', {
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            body: 'stale-token',
+            delay: 500,
+        }).as('slowToken');
+
+        mountHeader(html`
+            <body>
+                <vl-header-next
+                    development
+                    identifier="${identifier}"
+                    profile-token-url="/api/slow-token"
+                ></vl-header-next>
+            </body>
+        `);
+        cy.wait('@authActive');
+
+        cy.get('vl-header-next').then(($el) => {
+            ($el[0] as VlHeader).idpProfileToken = 'fresh-token';
+        });
+
+        cy.wait('@slowToken');
+
+        lastSetProfileCall().should((config) => {
+            expect(config).to.include({ idpProfileToken: 'fresh-token' });
+        });
+    });
+
+    describe('skip-to-content-id', () => {
+        it('should not create a skip-link when skip-to-content-id is not set', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next development identifier="${identifier}"></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container').find('a.vl-skip-link').should('not.exist');
+        });
+
+        it('should warn the user when skip-to-content-id is not set', () => {
+            cy.spy(console, 'warn').as('warn');
+
+            cy.mount(html`
+                <body>
+                    <vl-header-next development identifier="${identifier}"></vl-header-next>
+                </body>
+            `);
+
+            cy.get('@warn').should(
+                'have.been.calledWith',
+                'vl-header-next -',
+                'Denk eraan om een skip-to-content-id mee te geven zodat er een skip-link kan gerenderd worden.',
+                'Gebruik hiervoor de ID van de eerste heading van de content.',
+                '(WCAG 2.4.1: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)'
+            );
+        });
+
+        it('should create the skip-link as the first focusable element in the header', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container')
+                .children()
+                .first()
+                .should('match', 'a[href="#main-content"].vl-skip-link')
+                .and('contain.text', 'Ga meteen naar de inhoud');
+        });
+
+        it('should show the skip-link on focus', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                </body>
+            `);
+
+            cy.get('#header__container')
+                .find('a.vl-skip-link')
+                .then(([skipLink]) => {
+                    expect(skipLink.getBoundingClientRect().width).to.equal(1);
+                    expect(skipLink.getBoundingClientRect().height).to.equal(1);
+                    skipLink.focus();
+                    expect(skipLink.getBoundingClientRect().width).to.be.greaterThan(1);
+                    expect(skipLink.getBoundingClientRect().height).to.be.greaterThan(1);
+                });
+        });
+
+        it('should move focus to the target element when the skip-link is activated', () => {
+            cy.mount(html`
+                <body>
+                    <vl-header-next
+                        development
+                        identifier="${identifier}"
+                        skip-to-content-id="main-content"
+                    ></vl-header-next>
+                    <main id="main-content">Inhoud</main>
+                </body>
+            `);
+
+            cy.get('#header__container').find('a.vl-skip-link').click({ force: true });
+
+            cy.get('#main-content').should('have.attr', 'tabindex', '-1').and('have.focus');
+        });
+    });
+});
+
+const stubWidgetScriptMinimal = () => ({
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/javascript' },
+    body: `
+        window.globalHeaderClient = {
+            mount: () => Promise.resolve(),
+            accessMenu: {
+                setProfile: () => {},
+                setApplicationMenuLinks: () => Promise.resolve(),
+            },
+        };
+        window.dispatchEvent(new Event('widget.global_header.mounted'));
+    `,
+});
+
+const stubWidgetScriptCapturingSetProfile = () => ({
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/javascript' },
+    body: `
+        window.__setProfileCalls = [];
+        window.globalHeaderClient = {
+            mount: () => Promise.resolve(),
+            accessMenu: {
+                setProfile: (config) => { window.__setProfileCalls.push(config); return Promise.resolve(true); },
+                setApplicationMenuLinks: () => Promise.resolve(),
+            },
+        };
+        window.dispatchEvent(new Event('widget.global_header.mounted'));
+    `,
+});
+
+const stubWidgetScriptWithApplicationLinks = () => ({
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/javascript' },
+    body: `
+        window.globalHeaderClient = (() => {
+            let appLinks = [];
+            let shadowRoot = null;
+
+            return {
+                mount: function(headerElement) {
+                    shadowRoot = headerElement.attachShadow({ mode: 'open' });
+                    const btn = document.createElement('button');
+                    btn.className = 'access-menu-toggle__button';
+                    btn.onclick = function() {
+                        appLinks.forEach(function(link) {
+                            const a = document.createElement('a');
+                            a.href = link.href;
+                            a.textContent = link.label;
+                            shadowRoot.appendChild(a);
+                        });
+                    };
+                    shadowRoot.appendChild(btn);
+                    return Promise.resolve();
+                },
+                accessMenu: {
+                    setProfile: () => {},
+                    setApplicationMenuLinks: function(links) {
+                        appLinks = links;
+                        return Promise.resolve();
+                    },
+                },
+            };
+        })();
+        window.dispatchEvent(new Event('widget.global_header.mounted'));
+    `,
+});

--- a/libs/components/src/next/header/vl-header.component.flux-css.ts
+++ b/libs/components/src/next/header/vl-header.component.flux-css.ts
@@ -1,0 +1,21 @@
+import { css } from 'lit';
+
+export const headerContainerStyles = css`
+    #header__container {
+        min-height: 43px;
+    }
+`;
+
+export const headerSkeletonStyles = css`
+    #header__skeleton {
+        content: '';
+        height: 43px;
+        width: 100%;
+        display: block;
+        background: #fff;
+    }
+
+    #header__container ~ #header__skeleton {
+        display: none;
+    }
+`;

--- a/libs/components/src/next/header/vl-header.component.ts
+++ b/libs/components/src/next/header/vl-header.component.ts
@@ -1,0 +1,291 @@
+import {
+    awaitScript,
+    BaseLitElement,
+    createSkipToContentLink,
+    legacyBreakpoint,
+    legacyCore,
+    registerWebComponents,
+    SKIP_TO_CONTENT_MISSING_ID_WARNING,
+    webComponent,
+} from '@domg-wc/common-utilities';
+import { vlAccessibilityStyles } from '@domg-wc/common-utilities';
+import {
+    ApplicationMenuLink,
+    GlobalHeaderClient,
+    IDPData,
+    ProfileConfig,
+} from '@govflanders/vl-widget-global-header-types';
+import { PropertyDeclarations } from 'lit';
+import { headerContainerStyles, headerSkeletonStyles } from './vl-header.component.flux-css';
+import { headerDefaults } from './vl-header.defaults';
+export type ApplicationLink = ApplicationMenuLink;
+
+declare global {
+    interface Window {
+        globalHeaderClient: GlobalHeaderClient;
+    }
+}
+
+registerWebComponents([legacyCore, legacyBreakpoint]);
+
+@webComponent('vl-header-next')
+export class VlHeader extends BaseLitElement {
+    // Properties
+    applicationLinks = headerDefaults.applicationLinks;
+    idpProfileToken: string | undefined = headerDefaults.idpProfileToken;
+    idpData: IDPData | undefined = headerDefaults.idpData;
+    // Attributes
+    private authenticatedUserUrl = headerDefaults.authenticatedUserUrl;
+    private development = headerDefaults.development;
+    private identifier = headerDefaults.identifier;
+    private loginUrl = headerDefaults.loginUrl;
+    private logoutUrl = headerDefaults.logoutUrl;
+    private switchCapacityUrl = headerDefaults.switchCapacityUrl;
+    private simple = headerDefaults.simple;
+    private skeleton = headerDefaults.skeleton;
+    private skipToContentId = headerDefaults.skipToContentId;
+    private profileTokenUrl = headerDefaults.profileTokenUrl;
+    private idpDataUrl = headerDefaults.idpDataUrl;
+    private initialSessionConfigured = false;
+    private configureSessionGeneration = 0;
+
+    constructor() {
+        super();
+
+        this.allowCustomCSS = false;
+    }
+
+    static get properties(): PropertyDeclarations {
+        return {
+            authenticatedUserUrl: { type: String, attribute: 'authenticated-user-url' },
+            development: { type: Boolean, attribute: 'development' },
+            identifier: { type: String, attribute: 'identifier' },
+            loginUrl: { type: String, attribute: 'login-url' },
+            logoutUrl: { type: String, attribute: 'logout-url' },
+            simple: { type: Boolean, attribute: 'simple' },
+            skeleton: { type: Boolean, attribute: 'skeleton' },
+            skipToContentId: { type: String, attribute: 'skip-to-content-id' },
+            switchCapacityUrl: { type: String, attribute: 'switch-capacity-url' },
+            applicationLinks: { type: Array },
+            profileTokenUrl: { type: String, attribute: 'profile-token-url' },
+            idpDataUrl: { type: String, attribute: 'idp-data-url' },
+            idpProfileToken: { attribute: false },
+            idpData: { attribute: false },
+        };
+    }
+
+    private get headerContainer(): HTMLElement | null {
+        return document.querySelector<HTMLElement>('#header__container');
+    }
+
+    private get headerContainerSkeleton(): HTMLDivElement | null {
+        return document.querySelector<HTMLDivElement>('#header__skeleton');
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        this.injectHeaderContainer();
+        this.injectSkipToContentLink();
+
+        if (this.skeleton) {
+            this.injectHeaderContainerSkeleton();
+        }
+
+        this.loadWidget();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+
+        this.headerContainer?.remove();
+
+        if (this.skeleton) {
+            this.headerContainerSkeleton?.remove();
+        }
+
+        window.removeEventListener('widget.global_header.mounted', this.onReady);
+    }
+
+    protected willUpdate(changedProperties: Map<string, unknown>) {
+        if (!this.initialSessionConfigured) {
+            return;
+        }
+
+        const sessionProperties = [
+            'loginUrl',
+            'logoutUrl',
+            'switchCapacityUrl',
+            'profileTokenUrl',
+            'idpDataUrl',
+            'idpProfileToken',
+            'idpData',
+        ];
+
+        if (sessionProperties.some((property) => changedProperties.has(property))) {
+            this.configureSession();
+        }
+    }
+
+    protected createRenderRoot(): HTMLElement | DocumentFragment {
+        return this;
+    }
+
+    private injectHeaderContainer() {
+        if (this.headerContainer) return;
+
+        (document.querySelector('body') || document.body).insertAdjacentHTML(
+            'afterbegin',
+            '<header id="header__container"><div id="header"></div></header>',
+        );
+        document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerContainerStyles.styleSheet!];
+    }
+
+    private injectHeaderContainerSkeleton() {
+        this.headerContainer?.insertAdjacentHTML('afterend', '<div id="header__skeleton"></div>');
+        document.adoptedStyleSheets = [...document.adoptedStyleSheets, headerSkeletonStyles.styleSheet!];
+    }
+
+    private injectSkipToContentLink() {
+        if (!this.skipToContentId) {
+            console.warn('vl-header-next -', ...SKIP_TO_CONTENT_MISSING_ID_WARNING);
+            return;
+        }
+
+        if (this.headerContainer?.querySelector('.vl-skip-link')) {
+            return;
+        }
+
+        const styleSheet = vlAccessibilityStyles.styleSheet!;
+        if (!document.adoptedStyleSheets.includes(styleSheet)) {
+            document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+        }
+
+        this.headerContainer?.prepend(createSkipToContentLink(this.skipToContentId));
+    }
+
+    private async isUserAuthenticated(): Promise<boolean> {
+        const response = await fetch(this.authenticatedUserUrl);
+
+        return response.status === 200;
+    }
+
+    // class field met pijlfunctie, geen methode !
+    // -> window.addEventListener krijgt hier enkel een functiereferentie mee
+    // -> als gewone methode is 'this' bij het afvuren het window, en dan komt het ready-event op window
+    //    terecht in plaats van op de component - afnemers die op het element luisteren zien het dan nooit
+    private onReady = () => {
+        this.dispatchEvent(new CustomEvent('ready'));
+    };
+
+    private async loadWidget() {
+        try {
+            window.addEventListener('widget.global_header.mounted', this.onReady);
+
+            await awaitScript(
+                'vl-header-widget',
+                `https://widgets.${this.development ? 'tni-' : ''}vlaanderen.be/api/v2/widget/${this.identifier}/entry`,
+            );
+
+            if (!this.isConnected) return;
+
+            if (!window.globalHeaderClient) {
+                console.error('De global header client werd niet geladen.');
+                return;
+            }
+
+            const headerElement = this.headerContainer?.querySelector<HTMLDivElement>('#header') || undefined;
+
+            await window.globalHeaderClient.mount(headerElement);
+
+            if (!this.isConnected) return;
+
+            if (this.applicationLinks.length > 0) {
+                await window.globalHeaderClient.accessMenu.setApplicationMenuLinks(this.applicationLinks);
+
+                if (!this.isConnected) {
+                    return;
+                }
+            }
+
+            if (this.simple) {
+                return;
+            }
+
+            this.configureSession();
+            this.initialSessionConfigured = true;
+        } catch (error) {
+            console.error('De global header werd niet geladen.', error);
+        }
+    }
+
+    private async resolveProfileToken(): Promise<string | undefined> {
+        if (this.idpProfileToken) return this.idpProfileToken;
+        if (!this.profileTokenUrl) return undefined;
+
+        try {
+            const response = await fetch(this.profileTokenUrl);
+            if (!response.ok) return undefined;
+
+            return (await response.text()).trim() || undefined;
+        } catch (error) {
+            console.error('Kon het PAPI profile token niet ophalen.', error);
+            return undefined;
+        }
+    }
+
+    private async resolveIdpData(): Promise<IDPData | undefined> {
+        if (this.idpData) return this.idpData;
+        if (!this.idpDataUrl) return undefined;
+
+        try {
+            const response = await fetch(this.idpDataUrl);
+            if (!response.ok) return undefined;
+            return (await response.json()) as IDPData;
+        } catch (error) {
+            console.error('Kon de IDP data niet ophalen.', error);
+            return undefined;
+        }
+    }
+
+    private async configureSession(): Promise<void> {
+        const generation = ++this.configureSessionGeneration;
+        const isStale = () => generation !== this.configureSessionGeneration || !this.isConnected;
+
+        const active = await this.isUserAuthenticated();
+        if (isStale()) return;
+
+        const config: Partial<ProfileConfig> = {
+            active,
+            loginUrl: this.loginUrl,
+            logoutUrl: this.logoutUrl,
+            switchCapacityUrl: this.switchCapacityUrl,
+        };
+
+        if (active) {
+            const token = await this.resolveProfileToken();
+            if (isStale()) return;
+
+            if (token) {
+                config.idpProfileToken = token;
+            } else {
+                const idpData = await this.resolveIdpData();
+                if (isStale()) return;
+                if (idpData) config.idpData = idpData;
+            }
+        }
+
+        if (isStale()) return;
+        window.globalHeaderClient?.accessMenu?.setProfile(config);
+    }
+
+    public get height(): number {
+        return this.headerContainer?.getBoundingClientRect().height || 0;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'vl-header-next': VlHeader;
+    }
+}

--- a/libs/components/src/next/header/vl-header.defaults.ts
+++ b/libs/components/src/next/header/vl-header.defaults.ts
@@ -1,0 +1,18 @@
+import { ApplicationMenuLink, IDPData } from '@govflanders/vl-widget-global-header-types';
+
+export const headerDefaults = {
+    authenticatedUserUrl: '/sso/ingelogde_gebruiker' as string,
+    development: false as boolean,
+    identifier: '' as string,
+    loginUrl: '/sso/aanmelden' as string,
+    logoutUrl: '/sso/afgemeld' as string,
+    switchCapacityUrl: '/sso/wissel_organisatie' as string,
+    simple: false as boolean,
+    skeleton: false as boolean,
+    skipToContentId: '' as string,
+    applicationLinks: [] as ApplicationMenuLink[],
+    profileTokenUrl: '/sso/papi_token' as string,
+    idpDataUrl: '' as string,
+    idpProfileToken: undefined as string | undefined,
+    idpData: undefined as IDPData | undefined,
+} as const;

--- a/libs/sections/src/footer/stories/vl-footer.stories-doc.mdx
+++ b/libs/sections/src/footer/stories/vl-footer.stories-doc.mdx
@@ -10,6 +10,15 @@ Default wordt de footer geïnjecteerd in de body, bij het gebruik van het `vl-bo
 in de `vl-body`.
 
 
+## Widget-versie
+
+<vl-alert data-vl-type="info" data-vl-title="Digitaal Vlaanderen widget-versie">
+
+[vl-footer](/docs/sections-footer--documentatie) gebruikt widget v4, [vl-footer-next](/docs/components-next-footer--documentatie) gebruikt widget v5.
+
+</vl-alert>
+
+
 ## Voorbeeld
 
 ```js

--- a/libs/sections/src/header/stories/vl-header.stories-doc.mdx
+++ b/libs/sections/src/header/stories/vl-header.stories-doc.mdx
@@ -10,6 +10,15 @@ Default wordt de header geïnjecteerd in de body, bij het gebruik van het vl-bod
 de vl-body.
 
 
+## Widget-versie
+
+<vl-alert data-vl-type="info" data-vl-title="Digitaal Vlaanderen widget-versie">
+
+[vl-header](/docs/sections-header--documentatie) gebruikt widget v4, [vl-header-next](/docs/components-next-header--documentatie) gebruikt widget v5.
+
+</vl-alert>
+
+
 ## Voorbeeld
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
                 "@govflanders/vl-ui-infotext": "21.0.2",
                 "@govflanders/vl-ui-progress-bar": "21.0.2",
                 "@govflanders/vl-ui-util": "21.0.2",
+                "@govflanders/vl-widget-global-footer-types": "1.0.28",
+                "@govflanders/vl-widget-global-header-types": "2.0.39",
                 "@lit/react": "1.0.3",
                 "@open-wc/form-control": "1.0.0",
                 "@open-wc/form-helpers": "1.0.0",
@@ -2004,7 +2006,6 @@
             "version": "7.23.8",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.23.8.tgz",
             "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -2979,6 +2980,34 @@
                 "multi-clamp": "^2.0.2",
                 "textfit": "^2.3.1",
                 "vue": "^2.5.16"
+            }
+        },
+        "node_modules/@govflanders/vl-widget-global-footer-types": {
+            "version": "1.0.28",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@govflanders/vl-widget-global-footer-types/-/vl-widget-global-footer-types-1.0.28.tgz",
+            "integrity": "sha512-8TJXaCllvzo+aX2OfBU4rjCXpR+Q7ZmahxbA3+3/c3voRfpFOL0re4WAuLC2oAn7GRDlGYIdqI92VYM573QLmw==",
+            "license": "MIT",
+            "dependencies": {
+                "@govflanders/vl-widget-shared": "^1.0.14"
+            }
+        },
+        "node_modules/@govflanders/vl-widget-global-header-types": {
+            "version": "2.0.39",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@govflanders/vl-widget-global-header-types/-/vl-widget-global-header-types-2.0.39.tgz",
+            "integrity": "sha512-wWYfnJ5YYFLhJUh3P334X7fmfTxNwhSLZRq0UfMShdmHablWmbZ1v6oKBTUgZVE1b9g5gf22EZeRgKiCFIFeXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@govflanders/vl-widget-shared": "1.0.17"
+            }
+        },
+        "node_modules/@govflanders/vl-widget-shared": {
+            "version": "1.0.17",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@govflanders/vl-widget-shared/-/vl-widget-shared-1.0.17.tgz",
+            "integrity": "sha512-y1VdJS3rsGK8AJdMoSc7R2JZLBPJZUA60L8dWEm9XAVKi5bEdAJrkTYxE1ekxA2u++kF18ozYOuDoXFucCt33g==",
+            "license": "MIT",
+            "peerDependencies": {
+                "i18next": "^23.6.0",
+                "pinia": "~2.1.7"
             }
         },
         "node_modules/@hapi/hoek": {
@@ -12271,6 +12300,13 @@
                 "@vue/shared": "3.5.4"
             }
         },
+        "node_modules/@vue/devtools-api": {
+            "version": "6.6.4",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@vue/shared": {
             "version": "3.5.4",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/@vue/shared/-/shared-3.5.4.tgz",
@@ -19770,6 +19806,30 @@
             "dev": true,
             "engines": {
                 "node": ">=10.18"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "23.16.8",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/i18next/-/i18next-23.16.8.tgz",
+            "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://locize.com"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://locize.com/i18next.html"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.23.2"
             }
         },
         "node_modules/icon-font-generator": {
@@ -27337,6 +27397,33 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/pinia": {
+            "version": "2.1.7",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/pinia/-/pinia-2.1.7.tgz",
+            "integrity": "sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/devtools-api": "^6.5.0",
+                "vue-demi": ">=0.14.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.4.0",
+                "typescript": ">=4.4.4",
+                "vue": "^2.6.14 || ^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/pino": {
             "version": "7.11.0",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/pino/-/pino-7.11.0.tgz",
@@ -32586,7 +32673,7 @@
             "version": "5.4.2",
             "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/typescript/-/typescript-5.4.2.tgz",
             "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -33378,6 +33465,33 @@
             "dependencies": {
                 "@vue/compiler-sfc": "2.7.16",
                 "csstype": "^3.1.0"
+            }
+        },
+        "node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://repo.omgeving.vlaanderen.be/artifactory/api/npm/acd-npm/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
             }
         },
         "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,8 @@
         "@govflanders/vl-ui-infotext": "21.0.2",
         "@govflanders/vl-ui-progress-bar": "21.0.2",
         "@govflanders/vl-ui-util": "21.0.2",
+        "@govflanders/vl-widget-global-footer-types": "1.0.28",
+        "@govflanders/vl-widget-global-header-types": "2.0.39",
         "@lit/react": "1.0.3",
         "@open-wc/form-control": "1.0.0",
         "@open-wc/form-helpers": "1.0.0",

--- a/resources/generate-web-types/wt-config-build/components.wt-config.ts
+++ b/resources/generate-web-types/wt-config-build/components.wt-config.ts
@@ -2,6 +2,8 @@ import { buttonArgTypes } from '@domg-wc/components/next/button/stories/vl-butto
 import { cascaderItemArgTypes } from '@domg-wc/components/next/cascader/stories/vl-cascader-item.stories-arg';
 import { cascaderArgTypes } from '@domg-wc/components/next/cascader/stories/vl-cascader.stories-arg';
 import { doormatArgTypes } from '@domg-wc/components/next/doormat/stories/vl-doormat.stories-arg';
+import { footerArgTypes } from '@domg-wc/components/next/footer/stories/vl-footer.stories-arg';
+import { headerArgTypes } from '@domg-wc/components/next/header/stories/vl-header.stories-arg';
 import { iconArgTypes } from '@domg-wc/components/next/icon/stories/vl-icon.stories-arg';
 import { infotextArgTypes } from '@domg-wc/components/next/infotext/stories/vl-infotext.stories-arg';
 import { linkArgTypes } from '@domg-wc/components/next/link/stories/vl-link.stories-arg';
@@ -168,6 +170,18 @@ export const buildWTConfigComponents: WTConfigArray = [
         buttonArgTypes,
         '../../libs/components/src/next/button/stories/vl-button.stories-doc.mdx',
         '/docs/components-next-button--documentatie'
+    ),
+    buildWTConfig(
+        'vl-header-next',
+        headerArgTypes,
+        '../../libs/components/src/next/header/stories/vl-header.stories-doc.mdx',
+        '/docs/components-next-header--documentatie'
+    ),
+    buildWTConfig(
+        'vl-footer-next',
+        footerArgTypes,
+        '../../libs/components/src/next/footer/stories/vl-footer.stories-doc.mdx',
+        '/docs/components-next-footer--documentatie'
     ),
     buildWTConfig(
         'vl-cascader',

--- a/resources/generate-web-types/wt-validate-completeness/web-types-completeness.spec.ts
+++ b/resources/generate-web-types/wt-validate-completeness/web-types-completeness.spec.ts
@@ -30,8 +30,8 @@ describe('valideer de volledigheid van de gegenereerde web-types', () => {
         expect(elementWTWithoutWC).toStrictEqual([]);
     });
     it('components - valideer de volledigheid van de web-types', () => {
-        expect(componentWCNameCount).toEqual(112);
-        expect(componentWTNameCount).toEqual(97);
+        expect(componentWCNameCount).toEqual(114);
+        expect(componentWTNameCount).toEqual(99);
         expect(componentWCWithoutWT).toStrictEqual([]);
         expect(componentWTWithoutWC).toStrictEqual([]);
     });


### PR DESCRIPTION
https://jira.omgeving.vlaanderen.be/jira/browse/FLUX-772

De volledige header-next en footer-next uit develop-v2, aangepast aan de v1-structuur (src/next, imports via @domg-wc/common-utilities, storybook-conventies van v1), met de gedeelde bouwstenen in common-utilities (legacyCore, legacyBreakpoint, skip-link, accessibility skip-link styles), de global header/footer widget-types dependencies en registratie in de web-types generatie.

Op elke component-doc (next en legacy, header en footer) een info-alert met de Digitaal Vlaanderen widget-versie (v4 voor vl-header/vl-footer, v5 voor de next-varianten) en klikbare links tussen beide varianten.

---

graag te bekijken:

Docs (widget-versie): info-alert op elke component-doc die feitelijk meldt dat vl-header/vl-footer widget v4 gebruikt en de next-varianten v5, met klikbare links tussen beide. Bewust enkel het feit, niet "wat het niet is". De kapotte next-badge is weg (2 vlux-meta-data entries verwijderd). Dit deel mag je gerust apart challengen.

Het centrale planning-doc 2_aanpak_v2_v3 is bewust niet aangeraakt: de stale "de -next suffix verdwijnt" tekst daar is een aparte teambeslissing.